### PR TITLE
feat: add jwt_profile_json to authenticate

### DIFF
--- a/zitadel/provider.go
+++ b/zitadel/provider.go
@@ -78,6 +78,7 @@ type providerModel struct {
 	Insecure       types.Bool   `tfsdk:"insecure"`
 	Domain         types.String `tfsdk:"domain"`
 	Port           types.String `tfsdk:"port"`
+	Token          types.String `tfsdk:"token"`
 	JWTProfileFile types.String `tfsdk:"jwt_profile_file"`
 	JWTProfileJSON types.String `tfsdk:"jwt_profile_json"`
 }
@@ -97,6 +98,11 @@ func (p *providerPV6) GetSchema(_ context.Context) (tfsdk.Schema, fdiag.Diagnost
 				Type:        types.BoolType,
 				Optional:    true,
 				Description: "Use insecure connection",
+			},
+			helper.TokenVar: {
+				Type:        types.StringType,
+				Optional:    true,
+				Description: "Path to the file containing credentials to connect to ZITADEL",
 			},
 			helper.JWTProfileFile: {
 				Type:        types.StringType,
@@ -128,6 +134,7 @@ func (p *providerPV6) Configure(ctx context.Context, req provider.ConfigureReque
 	info, err := helper.GetClientInfo(
 		config.Insecure.ValueBool(),
 		config.Domain.ValueString(),
+		config.Token.ValueString(),
 		config.JWTProfileFile.ValueString(),
 		config.JWTProfileJSON.ValueString(),
 		config.Port.ValueString(),
@@ -188,6 +195,11 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: "Use insecure connection",
+			},
+			helper.TokenVar: {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Path to the file containing credentials to connect to ZITADEL",
 			},
 			helper.JWTProfileFile: {
 				Type:        schema.TypeString,
@@ -250,6 +262,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	clientinfo, err := helper.GetClientInfo(
 		d.Get(helper.InsecureVar).(bool),
 		d.Get(helper.DomainVar).(string),
+		d.Get(helper.TokenVar).(string),
 		d.Get(helper.JWTProfileFile).(string),
 		d.Get(helper.JWTProfileJSON).(string),
 		d.Get(helper.PortVar).(string),

--- a/zitadel/provider.go
+++ b/zitadel/provider.go
@@ -75,10 +75,12 @@ func NewProviderPV6() provider.Provider {
 }
 
 type providerModel struct {
-	Insecure types.Bool   `tfsdk:"insecure"`
-	Domain   types.String `tfsdk:"domain"`
-	Token    types.String `tfsdk:"token"`
-	Port     types.String `tfsdk:"port"`
+	Insecure       types.Bool   `tfsdk:"insecure"`
+	Domain         types.String `tfsdk:"domain"`
+	Token          types.String `tfsdk:"token"`
+	Port           types.String `tfsdk:"port"`
+	JWTProfileFile types.String `tfsdk:"jwt_profile_file"`
+	JWTProfileJSON types.String `tfsdk:"jwt_profile_json"`
 }
 
 func (p *providerPV6) Metadata(_ context.Context, _ provider.MetadataRequest, resp *provider.MetadataResponse) {
@@ -97,10 +99,20 @@ func (p *providerPV6) GetSchema(_ context.Context) (tfsdk.Schema, fdiag.Diagnost
 				Optional:    true,
 				Description: "Use insecure connection",
 			},
+			helper.JWTProfileFile: {
+				Type:        types.StringType,
+				Optional:    true,
+				Description: "Path to the file containing credentials to connect to ZITADEL",
+			},
+			helper.JWTProfileJSON: {
+				Type:        types.StringType,
+				Optional:    true,
+				Description: "JSON value of credentials to connect to ZITADEL",
+			},
 			helper.TokenVar: {
 				Type:        types.StringType,
-				Required:    true,
-				Description: "Path to the file containing credentials to connect to ZITADEL",
+				Optional:    true,
+				Description: "Path to the file containing credentials to connect to ZITADEL (deprecated)",
 			},
 			helper.PortVar: {
 				Type:        types.StringType,
@@ -122,6 +134,8 @@ func (p *providerPV6) Configure(ctx context.Context, req provider.ConfigureReque
 	info, err := helper.GetClientInfo(
 		config.Insecure.ValueBool(),
 		config.Domain.ValueString(),
+		config.JWTProfileFile.ValueString(),
+		config.JWTProfileJSON.ValueString(),
 		config.Token.ValueString(),
 		config.Port.ValueString(),
 	)
@@ -184,8 +198,18 @@ func Provider() *schema.Provider {
 			},
 			helper.TokenVar: {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
+				Description: "Path to the file containing credentials to connect to ZITADEL (deprecated)",
+			},
+			helper.JWTProfileFile: {
+				Type:        schema.TypeString,
+				Optional:    true,
 				Description: "Path to the file containing credentials to connect to ZITADEL",
+			},
+			helper.JWTProfileJSON: {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "JSON value of credentials to connect to ZITADEL",
 			},
 			helper.PortVar: {
 				Type:        schema.TypeString,
@@ -238,6 +262,8 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	clientinfo, err := helper.GetClientInfo(
 		d.Get(helper.InsecureVar).(bool),
 		d.Get(helper.DomainVar).(string),
+		d.Get(helper.JWTProfileFile).(string),
+		d.Get(helper.JWTProfileJSON).(string),
 		d.Get(helper.TokenVar).(string),
 		d.Get(helper.PortVar).(string),
 	)

--- a/zitadel/provider.go
+++ b/zitadel/provider.go
@@ -77,7 +77,6 @@ func NewProviderPV6() provider.Provider {
 type providerModel struct {
 	Insecure       types.Bool   `tfsdk:"insecure"`
 	Domain         types.String `tfsdk:"domain"`
-	Token          types.String `tfsdk:"token"`
 	Port           types.String `tfsdk:"port"`
 	JWTProfileFile types.String `tfsdk:"jwt_profile_file"`
 	JWTProfileJSON types.String `tfsdk:"jwt_profile_json"`
@@ -102,17 +101,12 @@ func (p *providerPV6) GetSchema(_ context.Context) (tfsdk.Schema, fdiag.Diagnost
 			helper.JWTProfileFile: {
 				Type:        types.StringType,
 				Optional:    true,
-				Description: "Path to the file containing credentials to connect to ZITADEL",
+				Description: "Path to the file containing credentials to connect to ZITADEL. Either 'jwt_profile_file' or 'jwt_profile_json' is required",
 			},
 			helper.JWTProfileJSON: {
 				Type:        types.StringType,
 				Optional:    true,
-				Description: "JSON value of credentials to connect to ZITADEL",
-			},
-			helper.TokenVar: {
-				Type:        types.StringType,
-				Optional:    true,
-				Description: "Path to the file containing credentials to connect to ZITADEL (deprecated)",
+				Description: "JSON value of credentials to connect to ZITADEL. Either 'jwt_profile_file' or 'jwt_profile_json' is required",
 			},
 			helper.PortVar: {
 				Type:        types.StringType,
@@ -136,7 +130,6 @@ func (p *providerPV6) Configure(ctx context.Context, req provider.ConfigureReque
 		config.Domain.ValueString(),
 		config.JWTProfileFile.ValueString(),
 		config.JWTProfileJSON.ValueString(),
-		config.Token.ValueString(),
 		config.Port.ValueString(),
 	)
 	if err != nil {
@@ -196,20 +189,15 @@ func Provider() *schema.Provider {
 				Optional:    true,
 				Description: "Use insecure connection",
 			},
-			helper.TokenVar: {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Path to the file containing credentials to connect to ZITADEL (deprecated)",
-			},
 			helper.JWTProfileFile: {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Path to the file containing credentials to connect to ZITADEL",
+				Description: "Path to the file containing credentials to connect to ZITADEL. Either 'jwt_profile_file' or 'jwt_profile_json' is required",
 			},
 			helper.JWTProfileJSON: {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "JSON value of credentials to connect to ZITADEL",
+				Description: "JSON value of credentials to connect to ZITADEL. Either 'jwt_profile_file' or 'jwt_profile_json' is required",
 			},
 			helper.PortVar: {
 				Type:        schema.TypeString,
@@ -264,7 +252,6 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		d.Get(helper.DomainVar).(string),
 		d.Get(helper.JWTProfileFile).(string),
 		d.Get(helper.JWTProfileJSON).(string),
-		d.Get(helper.TokenVar).(string),
 		d.Get(helper.PortVar).(string),
 	)
 	if err != nil {

--- a/zitadel/v2/helper/client.go
+++ b/zitadel/v2/helper/client.go
@@ -13,10 +13,12 @@ import (
 )
 
 const (
-	DomainVar   = "domain"
-	InsecureVar = "insecure"
-	TokenVar    = "token"
-	PortVar     = "port"
+	DomainVar      = "domain"
+	InsecureVar    = "insecure"
+	TokenVar       = "token"
+	PortVar        = "port"
+	JWTProfileFile = "jwt_profile_file"
+	JWTProfileJSON = "jwt_profile_json"
 )
 
 type ClientInfo struct {
@@ -26,8 +28,15 @@ type ClientInfo struct {
 	Options []zitadel.Option
 }
 
-func GetClientInfo(insecure bool, domain string, token string, port string) (*ClientInfo, error) {
-	options := []zitadel.Option{zitadel.WithJWTProfileTokenSource(middleware.JWTProfileFromPath(token))}
+func GetClientInfo(insecure bool, domain string, jwtProfileFile string, jwtProfileJSON string, token string, port string) (*ClientInfo, error) {
+	options := []zitadel.Option{}
+	if jwtProfileFile != "" {
+		options = append(options, zitadel.WithJWTProfileTokenSource(middleware.JWTProfileFromPath(jwtProfileFile)))
+	} else if jwtProfileJSON != "" {
+		options = append(options, zitadel.WithJWTProfileTokenSource(middleware.JWTProfileFromFileData([]byte(jwtProfileJSON))))
+	} else {
+		options = append(options, zitadel.WithJWTProfileTokenSource(middleware.JWTProfileFromPath(token)))
+	}
 
 	issuer := ""
 	if port != "" {

--- a/zitadel/v2/helper/client.go
+++ b/zitadel/v2/helper/client.go
@@ -25,17 +25,18 @@ type ClientInfo struct {
 	Domain  string
 	Issuer  string
 	KeyPath string
+	Data    []byte
 	Options []zitadel.Option
 }
 
-func GetClientInfo(insecure bool, domain string, jwtProfileFile string, jwtProfileJSON string, token string, port string) (*ClientInfo, error) {
+func GetClientInfo(insecure bool, domain string, jwtProfileFile string, jwtProfileJSON string, port string) (*ClientInfo, error) {
 	options := []zitadel.Option{}
 	if jwtProfileFile != "" {
 		options = append(options, zitadel.WithJWTProfileTokenSource(middleware.JWTProfileFromPath(jwtProfileFile)))
 	} else if jwtProfileJSON != "" {
 		options = append(options, zitadel.WithJWTProfileTokenSource(middleware.JWTProfileFromFileData([]byte(jwtProfileJSON))))
 	} else {
-		options = append(options, zitadel.WithJWTProfileTokenSource(middleware.JWTProfileFromPath(token)))
+		return nil, fmt.Errorf("either 'jwt_profile_file' or 'jwt_profile_json' is required")
 	}
 
 	issuer := ""
@@ -61,7 +62,8 @@ func GetClientInfo(insecure bool, domain string, jwtProfileFile string, jwtProfi
 	return &ClientInfo{
 		domain,
 		issuer,
-		token,
+		jwtProfileFile,
+		[]byte(jwtProfileJSON),
 		options,
 	}, nil
 }

--- a/zitadel/v2/helper/client.go
+++ b/zitadel/v2/helper/client.go
@@ -29,10 +29,15 @@ type ClientInfo struct {
 	Options []zitadel.Option
 }
 
-func GetClientInfo(insecure bool, domain string, jwtProfileFile string, jwtProfileJSON string, port string) (*ClientInfo, error) {
+func GetClientInfo(insecure bool, domain string, token string, jwtProfileFile string, jwtProfileJSON string, port string) (*ClientInfo, error) {
 	options := []zitadel.Option{}
-	if jwtProfileFile != "" {
+	keyPath := ""
+	if token != "" {
+		options = append(options, zitadel.WithJWTProfileTokenSource(middleware.JWTProfileFromPath(token)))
+		keyPath = token
+	} else if jwtProfileFile != "" {
 		options = append(options, zitadel.WithJWTProfileTokenSource(middleware.JWTProfileFromPath(jwtProfileFile)))
+		keyPath = token
 	} else if jwtProfileJSON != "" {
 		options = append(options, zitadel.WithJWTProfileTokenSource(middleware.JWTProfileFromFileData([]byte(jwtProfileJSON))))
 	} else {
@@ -62,7 +67,7 @@ func GetClientInfo(insecure bool, domain string, jwtProfileFile string, jwtProfi
 	return &ClientInfo{
 		domain,
 		issuer,
-		jwtProfileFile,
+		keyPath,
 		[]byte(jwtProfileJSON),
 		options,
 	}, nil

--- a/zitadel/v2/helper/form.go
+++ b/zitadel/v2/helper/form.go
@@ -83,7 +83,7 @@ func formFilePost(clientInfo *ClientInfo, endpoint, path string, additionalHeade
 			return diag.Errorf("failed to create client: %v", err)
 		}
 	} else if len(clientInfo.Data) > 0 {
-		client, err = NewClientWithInterceptorFromKeyFile(clientInfo.Issuer, clientInfo.KeyPath, []string{oidc.ScopeOpenID, zitadel.ScopeZitadelAPI()})
+		client, err = NewClientWithInterceptorFromKeyFileData(clientInfo.Issuer, clientInfo.Data, []string{oidc.ScopeOpenID, zitadel.ScopeZitadelAPI()})
 		if err != nil {
 			return diag.Errorf("failed to create client: %v", err)
 		}

--- a/zitadel/v2/helper/form.go
+++ b/zitadel/v2/helper/form.go
@@ -68,6 +68,7 @@ func OrgFormFilePost(clientInfo *ClientInfo, endpoint, path, orgID string) diag.
 }
 
 func formFilePost(clientInfo *ClientInfo, endpoint, path string, additionalHeaders map[string]string) diag.Diagnostics {
+	var client *http.Client
 	r, err := createMultipartRequest(clientInfo.Issuer, endpoint, path)
 	if err != nil {
 		return diag.Errorf("failed to create asset request: %v", err)
@@ -76,9 +77,18 @@ func formFilePost(clientInfo *ClientInfo, endpoint, path string, additionalHeade
 		r.Header.Add(k, v)
 	}
 
-	client, err := NewClientWithInterceptor(clientInfo.Issuer, clientInfo.KeyPath, []string{oidc.ScopeOpenID, zitadel.ScopeZitadelAPI()})
-	if err != nil {
-		return diag.Errorf("failed to create client: %v", err)
+	if clientInfo.KeyPath != "" {
+		client, err = NewClientWithInterceptorFromKeyFile(clientInfo.Issuer, clientInfo.KeyPath, []string{oidc.ScopeOpenID, zitadel.ScopeZitadelAPI()})
+		if err != nil {
+			return diag.Errorf("failed to create client: %v", err)
+		}
+	} else if len(clientInfo.Data) > 0 {
+		client, err = NewClientWithInterceptorFromKeyFile(clientInfo.Issuer, clientInfo.KeyPath, []string{oidc.ScopeOpenID, zitadel.ScopeZitadelAPI()})
+		if err != nil {
+			return diag.Errorf("failed to create client: %v", err)
+		}
+	} else {
+		return diag.Errorf("either 'jwt_profile_file' or 'jwt_profile_json' is required")
 	}
 
 	resp, err := client.Do(r)
@@ -93,8 +103,19 @@ type Interceptor struct {
 	core        http.RoundTripper
 }
 
-func NewClientWithInterceptor(issuer, keyPath string, scopes []string) (*http.Client, error) {
+func NewClientWithInterceptorFromKeyFile(issuer, keyPath string, scopes []string) (*http.Client, error) {
 	ts, err := profile.NewJWTProfileTokenSourceFromKeyFile(issuer, keyPath, scopes)
+	if err != nil {
+		return nil, err
+	}
+
+	return &http.Client{
+		Transport: Interceptor{core: http.DefaultTransport, tokenSource: ts},
+	}, nil
+}
+
+func NewClientWithInterceptorFromKeyFileData(issuer string, data []byte, scopes []string) (*http.Client, error) {
+	ts, err := profile.NewJWTProfileTokenSourceFromKeyFileData(issuer, data, scopes)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Close #27

I just added two parameters `jwt_profile_file` and `jwt_profile_json` in the provider parameter.
Let me know if there is uncomfortable coding or missing part.

## Note

`token` and `jwt_profile_file` are exactly the same thing but I the old one to keep compatibility.
If the `alpha` doesn't have to support backward compatibility, let's remove it.