### PR TITLE
feat: Add default login texts

### DIFF
--- a/zitadel/provider.go
+++ b/zitadel/provider.go
@@ -22,6 +22,7 @@ import (
 	"github.com/zitadel/terraform-provider-zitadel/zitadel/v2/default_label_policy"
 	"github.com/zitadel/terraform-provider-zitadel/zitadel/v2/default_lockout_policy"
 	"github.com/zitadel/terraform-provider-zitadel/zitadel/v2/default_login_policy"
+	"github.com/zitadel/terraform-provider-zitadel/zitadel/v2/default_login_texts"
 	"github.com/zitadel/terraform-provider-zitadel/zitadel/v2/default_notification_policy"
 	"github.com/zitadel/terraform-provider-zitadel/zitadel/v2/default_password_complexity_policy"
 	"github.com/zitadel/terraform-provider-zitadel/zitadel/v2/default_password_reset_message_text"
@@ -165,6 +166,7 @@ func (p *providerPV6) Resources(_ context.Context) []func() resource.Resource {
 		passwordless_registration_message_text.New,
 		default_domain_claimed_message_text.New,
 		default_init_message_text.New,
+		default_login_texts.New,
 		default_password_reset_message_text.New,
 		default_passwordless_registration_message_text.New,
 		default_verify_email_message_text.New,

--- a/zitadel/v2/default_login_texts/resource.go
+++ b/zitadel/v2/default_login_texts/resource.go
@@ -1,0 +1,235 @@
+package default_login_texts
+
+import (
+	"context"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/zitadel/zitadel-go/v2/pkg/client/zitadel/admin"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	textpb "github.com/zitadel/zitadel-go/v2/pkg/client/zitadel/text"
+
+	"github.com/zitadel/terraform-provider-zitadel/gen/github.com/zitadel/zitadel/pkg/grpc/text"
+	"github.com/zitadel/terraform-provider-zitadel/zitadel/v2/helper"
+)
+
+const (
+	languageVar = "language"
+)
+
+var (
+	_ resource.Resource = &defaultLoginTextsResource{}
+)
+
+func New() resource.Resource {
+	return &defaultLoginTextsResource{}
+}
+
+type defaultLoginTextsResource struct {
+	clientInfo *helper.ClientInfo
+}
+
+func (r *defaultLoginTextsResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_default_login_texts"
+}
+
+func (r *defaultLoginTextsResource) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+	s, d := text.GenSchemaLoginCustomText(ctx)
+	delete(s.Attributes, "org_id")
+	return s, d
+}
+
+func (r *defaultLoginTextsResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	r.clientInfo = req.ProviderData.(*helper.ClientInfo)
+}
+
+func (r *defaultLoginTextsResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	language := getPlanAttrs(ctx, req.Plan, resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var plan types.Object
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	obj := textpb.LoginCustomText{}
+	resp.Diagnostics.Append(text.CopyLoginCustomTextFromTerraform(ctx, plan, &obj)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	jsonpb := &runtime.JSONPb{
+		UnmarshalOptions: protojson.UnmarshalOptions{
+			DiscardUnknown: true,
+		},
+	}
+	data, err := jsonpb.Marshal(obj)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to marshal login texts", err.Error())
+		return
+	}
+	zReq := &admin.SetCustomLoginTextsRequest{}
+	if err := jsonpb.Unmarshal(data, zReq); err != nil {
+		resp.Diagnostics.AddError("failed to unmarshal login texts", err.Error())
+		return
+	}
+	zReq.Language = language
+
+	client, err := helper.GetAdminClient(r.clientInfo)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to get client", err.Error())
+		return
+	}
+
+	_, err = client.SetCustomLoginText(ctx, zReq)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to create login texts", err.Error())
+		return
+	}
+
+	setID(plan, language)
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *defaultLoginTextsResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state types.Object
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	language := getID(ctx, state)
+
+	client, err := helper.GetAdminClient(r.clientInfo)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to get client", err.Error())
+		return
+	}
+
+	zResp, err := client.GetCustomLoginTexts(ctx, &admin.GetCustomLoginTextsRequest{Language: language})
+	if err != nil {
+		return
+	}
+	if zResp.CustomText.IsDefault {
+		return
+	}
+
+	resp.Diagnostics.Append(text.CopyLoginCustomTextToTerraform(ctx, *zResp.CustomText, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	setID(state, language)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *defaultLoginTextsResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	language := getPlanAttrs(ctx, req.Plan, resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var plan types.Object
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	obj := textpb.LoginCustomText{}
+	resp.Diagnostics.Append(text.CopyLoginCustomTextFromTerraform(ctx, plan, &obj)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	jsonpb := &runtime.JSONPb{
+		UnmarshalOptions: protojson.UnmarshalOptions{
+			DiscardUnknown: true,
+		},
+	}
+	data, err := jsonpb.Marshal(obj)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to marshal login texts", err.Error())
+		return
+	}
+	zReq := &admin.SetCustomLoginTextsRequest{}
+	if err := jsonpb.Unmarshal(data, zReq); err != nil {
+		resp.Diagnostics.AddError("failed to unmarshal login texts", err.Error())
+		return
+	}
+	zReq.Language = language
+
+	client, err := helper.GetAdminClient(r.clientInfo)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to get client", err.Error())
+		return
+	}
+
+	_, err = client.SetCustomLoginText(ctx, zReq)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to update login texts", err.Error())
+		return
+	}
+
+	setID(plan, language)
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *defaultLoginTextsResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	language := getStateAttrs(ctx, req.State, resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client, err := helper.GetAdminClient(r.clientInfo)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to get client", err.Error())
+		return
+	}
+
+	_, err = client.ResetCustomLoginTextToDefault(ctx, &admin.ResetCustomLoginTextsToDefaultRequest{Language: language})
+	if err != nil {
+		resp.Diagnostics.AddError("failed to delete login texts", err.Error())
+		return
+	}
+}
+
+func setID(obj types.Object, language string) {
+	attrs := obj.Attributes()
+	attrs["id"] = types.StringValue(language)
+	attrs[languageVar] = types.StringValue(language)
+}
+
+func getID(ctx context.Context, obj types.Object) string {
+	return helper.GetStringFromAttr(ctx, obj.Attributes(), "id")
+}
+
+func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) string {
+	var language string
+	diag.Append(plan.GetAttribute(ctx, path.Root(languageVar), &language)...)
+	if diag.HasError() {
+		return ""
+	}
+	return language
+}
+
+func getStateAttrs(ctx context.Context, state tfsdk.State, diag diag.Diagnostics) string {
+	var language string
+	diag.Append(state.GetAttribute(ctx, path.Root(languageVar), &language)...)
+	if diag.HasError() {
+		return ""
+	}
+	return language
+}


### PR DESCRIPTION
Close #70 

- Add `zitadel_default_login_texts` resource like as https://registry.terraform.io/providers/zitadel/zitadel/latest/docs/resources/login_texts
    - Write codes based on existing functions below
        - https://github.com/zitadel/terraform-provider-zitadel/tree/alpha/zitadel/v2/login_texts
        - https://github.com/zitadel/terraform-provider-zitadel/tree/alpha/zitadel/v2/default_password_reset_message_text

## Note

- I'm not sure how to generate docs regarding this type of resource. It looks different from other functions like https://github.com/zitadel/terraform-provider-zitadel/tree/alpha/zitadel/v2/human_user