### PR TITLE
feat: update privacy_policy and default_privacy_policy resources to add support for support email

### DIFF
--- a/docs/resources/default_privacy_policy.md
+++ b/docs/resources/default_privacy_policy.md
@@ -26,6 +26,7 @@ resource zitadel_default_privacy_policy privacy_policy {
 
 - `help_link` (String)
 - `privacy_link` (String)
+- `support_email` (String)
 - `tos_link` (String)
 
 ### Read-Only

--- a/docs/resources/privacy_policy.md
+++ b/docs/resources/privacy_policy.md
@@ -28,6 +28,7 @@ resource zitadel_privacy_policy privacy_policy {
 - `help_link` (String)
 - `org_id` (String) Id for the organization
 - `privacy_link` (String)
+- `support_email` (String)
 - `tos_link` (String)
 
 ### Read-Only

--- a/examples/provider/resources/default_privacy_policy.tf
+++ b/examples/provider/resources/default_privacy_policy.tf
@@ -1,5 +1,6 @@
 resource zitadel_default_privacy_policy privacy_policy {
-  tos_link     = "https://google.com"
-  privacy_link = "https://google.com"
-  help_link    = "https://google.com"
+  tos_link      = "https://google.com"
+  privacy_link  = "https://google.com"
+  help_link     = "https://google.com"
+  support_email = "support@email.com"
 }

--- a/examples/provider/resources/privacy_policy.tf
+++ b/examples/provider/resources/privacy_policy.tf
@@ -1,6 +1,7 @@
 resource zitadel_privacy_policy privacy_policy {
-  org_id       = zitadel_org.org.id
-  tos_link     = "https://google.com"
-  privacy_link = "https://google.com"
-  help_link    = "https://google.com"
+  org_id        = zitadel_org.org.id
+  tos_link      = "https://google.com"
+  privacy_link  = "https://google.com"
+  help_link     = "https://google.com"
+  support_email = "support@email.com"
 }

--- a/zitadel/v2/default_privacy_policy/const.go
+++ b/zitadel/v2/default_privacy_policy/const.go
@@ -1,7 +1,8 @@
 package default_privacy_policy
 
 const (
-	tosLinkVar     = "tos_link"
-	privacyLinkVar = "privacy_link"
-	helpLinkVar    = "help_link"
+	tosLinkVar      = "tos_link"
+	privacyLinkVar  = "privacy_link"
+	helpLinkVar     = "help_link"
+	supportEmailVar = "support_email"
 )

--- a/zitadel/v2/default_privacy_policy/funcs.go
+++ b/zitadel/v2/default_privacy_policy/funcs.go
@@ -30,11 +30,12 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 	}
 
 	id := ""
-	if d.HasChanges(tosLinkVar, privacyLinkVar, helpLinkVar) {
+	if d.HasChanges(tosLinkVar, privacyLinkVar, helpLinkVar, supportEmailVar) {
 		resp, err := client.UpdatePrivacyPolicy(ctx, &admin.UpdatePrivacyPolicyRequest{
-			TosLink:     d.Get(tosLinkVar).(string),
-			PrivacyLink: d.Get(privacyLinkVar).(string),
-			HelpLink:    d.Get(helpLinkVar).(string),
+			TosLink:      d.Get(tosLinkVar).(string),
+			PrivacyLink:  d.Get(privacyLinkVar).(string),
+			HelpLink:     d.Get(helpLinkVar).(string),
+			SupportEmail: d.Get(supportEmailVar).(string),
 		})
 		if helper.IgnorePreconditionError(err) != nil {
 			return diag.Errorf("failed to update default privacy policy: %v", err)
@@ -78,9 +79,10 @@ func read(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagn
 
 	policy := resp.Policy
 	set := map[string]interface{}{
-		tosLinkVar:     policy.GetTosLink(),
-		privacyLinkVar: policy.GetPrivacyLink(),
-		helpLinkVar:    policy.GetHelpLink(),
+		tosLinkVar:      policy.GetTosLink(),
+		privacyLinkVar:  policy.GetPrivacyLink(),
+		helpLinkVar:     policy.GetHelpLink(),
+		supportEmailVar: policy.GetSupportEmail(),
 	}
 
 	for k, v := range set {

--- a/zitadel/v2/default_privacy_policy/resource.go
+++ b/zitadel/v2/default_privacy_policy/resource.go
@@ -23,6 +23,11 @@ func GetResource() *schema.Resource {
 				Required:    true,
 				Description: "",
 			},
+			supportEmailVar: {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "",
+			},
 		},
 		CreateContext: update,
 		DeleteContext: delete,

--- a/zitadel/v2/privacy_policy/const.go
+++ b/zitadel/v2/privacy_policy/const.go
@@ -1,8 +1,9 @@
 package privacy_policy
 
 const (
-	orgIDVar       = "org_id"
-	tosLinkVar     = "tos_link"
-	privacyLinkVar = "privacy_link"
-	helpLinkVar    = "help_link"
+	orgIDVar        = "org_id"
+	tosLinkVar      = "tos_link"
+	privacyLinkVar  = "privacy_link"
+	helpLinkVar     = "help_link"
+	supportEmailVar = "support_email"
 )

--- a/zitadel/v2/privacy_policy/funcs.go
+++ b/zitadel/v2/privacy_policy/funcs.go
@@ -47,9 +47,10 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 	}
 
 	_, err = client.UpdateCustomPrivacyPolicy(ctx, &management.UpdateCustomPrivacyPolicyRequest{
-		TosLink:     d.Get(tosLinkVar).(string),
-		PrivacyLink: d.Get(privacyLinkVar).(string),
-		HelpLink:    d.Get(helpLinkVar).(string),
+		TosLink:      d.Get(tosLinkVar).(string),
+		PrivacyLink:  d.Get(privacyLinkVar).(string),
+		HelpLink:     d.Get(helpLinkVar).(string),
+		SupportEmail: d.Get(supportEmailVar).(string),
 	})
 	if err != nil {
 		return diag.Errorf("failed to update privacy policy: %v", err)
@@ -72,9 +73,10 @@ func create(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 	}
 
 	_, err = client.AddCustomPrivacyPolicy(ctx, &management.AddCustomPrivacyPolicyRequest{
-		TosLink:     d.Get(tosLinkVar).(string),
-		PrivacyLink: d.Get(privacyLinkVar).(string),
-		HelpLink:    d.Get(helpLinkVar).(string),
+		TosLink:      d.Get(tosLinkVar).(string),
+		PrivacyLink:  d.Get(privacyLinkVar).(string),
+		HelpLink:     d.Get(helpLinkVar).(string),
+		SupportEmail: d.Get(supportEmailVar).(string),
 	})
 	if err != nil {
 		return diag.Errorf("failed to create privacy policy: %v", err)
@@ -112,10 +114,11 @@ func read(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagn
 		return nil
 	}
 	set := map[string]interface{}{
-		orgIDVar:       policy.GetDetails().GetResourceOwner(),
-		tosLinkVar:     policy.GetTosLink(),
-		privacyLinkVar: policy.GetPrivacyLink(),
-		helpLinkVar:    policy.GetHelpLink(),
+		orgIDVar:        policy.GetDetails().GetResourceOwner(),
+		tosLinkVar:      policy.GetTosLink(),
+		privacyLinkVar:  policy.GetPrivacyLink(),
+		helpLinkVar:     policy.GetHelpLink(),
+		supportEmailVar: policy.GetSupportEmail(),
 	}
 
 	for k, v := range set {

--- a/zitadel/v2/privacy_policy/resource.go
+++ b/zitadel/v2/privacy_policy/resource.go
@@ -29,6 +29,11 @@ func GetResource() *schema.Resource {
 				Required:    true,
 				Description: "",
 			},
+			supportEmailVar: {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "",
+			},
 		},
 		CreateContext: create,
 		DeleteContext: delete,


### PR DESCRIPTION
This adds support for setting the Support Email on the `privacy_policy` and `default_privacy_policy` resources.