### PR TITLE
feat: implement org removal when an org resource is deleted

### DIFF
--- a/zitadel/v2/org/funcs.go
+++ b/zitadel/v2/org/funcs.go
@@ -14,7 +14,25 @@ import (
 )
 
 func delete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	tflog.Info(ctx, "org delete not yet implemented")
+	tflog.Info(ctx, "started delete")
+
+	clientinfo, ok := m.(*helper.ClientInfo)
+	if !ok {
+		return diag.Errorf("failed to get client")
+	}
+
+	client, err := helper.GetAdminClient(clientinfo)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	_, err = client.RemoveOrg(ctx, &admin.RemoveOrgRequest{
+		OrgId: d.Id(),
+	})
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId("")
 	return nil
 }
 


### PR DESCRIPTION
This implements organization removal when a `zitadel_org` resource is removed.