### PR TITLE
chore: Fix issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,6 +1,5 @@
 name: 🐛 Bug Report
-description: "Create a bug report to help us improve ZITADEL Terrafform Provider."
-title: ""
+description: "Create a bug report to help us improve ZITADEL Terraform Provider."
 labels: ["bug"]
 body:
 - type: markdown
@@ -21,8 +20,9 @@ body:
   id: version
   attributes:
     label: Version
+    description: Which version of the Terraform Provider are you using.
+  validations:
     required: true
-    description: Which version of the Terrafor Provider are you using.
 - type: input
   id: zitadelversion
   attributes:
@@ -59,7 +59,7 @@ body:
   id: config
   attributes:
     label: Relevant Configuration
-    description: Add any relevant configurations that could help as. Make sure to redact any sensitive information. 
+    description: Add any relevant configurations that could help as. Make sure to redact any sensitive information.
 - type: textarea
   id: additional
   attributes:

--- a/.github/ISSUE_TEMPLATE/docs.yaml
+++ b/.github/ISSUE_TEMPLATE/docs.yaml
@@ -1,6 +1,5 @@
 name: 📄 Documentation
 description: Create an issue for missing or wrong documentation.
-title: ""
 labels: ["docs"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/improvement.yaml
+++ b/.github/ISSUE_TEMPLATE/improvement.yaml
@@ -1,6 +1,5 @@
 name: 🛠️ Improvement
-description: 
-title: ""
+description: "Create a report to help us improve ZITADEL Terraform Provider."
 labels: ["improvement"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/proposal.yaml
+++ b/.github/ISSUE_TEMPLATE/proposal.yaml
@@ -1,6 +1,5 @@
 name: 💡 Proposal / Feature request
-description: 
-title: ""
+description: "Create a proposal or feature request for ZITADEL Terraform Provider."
 labels: ["enhancement"]
 body:
   - type: markdown


### PR DESCRIPTION
Some issue templates failed schema validation, making it impossible to create new issues using templates.

![image](https://github.com/zitadel/terraform-provider-zitadel/assets/10341994/b86110fb-674a-4639-9152-52b9906cb1a9)
