### PR TITLE
fix: validate AD tenant type

### DIFF
--- a/zitadel/v2/idp_azure_ad/resource_test.go
+++ b/zitadel/v2/idp_azure_ad/resource_test.go
@@ -2,10 +2,10 @@ package idp_azure_ad_test
 
 import (
 	"fmt"
-	"github.com/zitadel/terraform-provider-zitadel/zitadel/v2/idp_utils"
 	"testing"
 
 	"github.com/zitadel/terraform-provider-zitadel/zitadel/v2/helper/test_utils"
+	"github.com/zitadel/terraform-provider-zitadel/zitadel/v2/idp_utils"
 	"github.com/zitadel/terraform-provider-zitadel/zitadel/v2/idp_utils/idp_test_utils"
 )
 
@@ -23,7 +23,6 @@ resource "%s" "%s" {
   client_secret       = "%s"
   scopes              = ["two", "scopes"]
   tenant_type         = "AZURE_AD_TENANT_TYPE_COMMON"
-  tenant_id           = "atenantid"
   email_verified      = true
   is_linking_allowed  = false
   is_creation_allowed = true

--- a/zitadel/v2/org_idp_azure_ad/funcs.go
+++ b/zitadel/v2/org_idp_azure_ad/funcs.go
@@ -23,13 +23,17 @@ func create(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	tenant, err := idp_azure_ad.ConstructTenant(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	resp, err := client.AddAzureADProvider(ctx, &management.AddAzureADProviderRequest{
 		Name:            idp_utils.StringValue(d, idp_utils.NameVar),
 		ClientId:        idp_utils.StringValue(d, idp_utils.ClientIDVar),
 		ClientSecret:    idp_utils.StringValue(d, idp_utils.ClientSecretVar),
 		Scopes:          idp_utils.ScopesValue(d),
 		ProviderOptions: idp_utils.ProviderOptionsValue(d),
-		Tenant:          idp_azure_ad.ConstructTenant(d),
+		Tenant:          tenant,
 		EmailVerified:   idp_utils.BoolValue(d, idp_azure_ad.EmailVerifiedVar),
 	})
 	if err != nil {
@@ -48,6 +52,10 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	tenant, err := idp_azure_ad.ConstructTenant(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	_, err = client.UpdateAzureADProvider(ctx, &management.UpdateAzureADProviderRequest{
 		Id:              d.Id(),
 		Name:            idp_utils.StringValue(d, idp_utils.NameVar),
@@ -55,7 +63,7 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 		ClientSecret:    idp_utils.StringValue(d, idp_utils.ClientSecretVar),
 		Scopes:          idp_utils.ScopesValue(d),
 		ProviderOptions: idp_utils.ProviderOptionsValue(d),
-		Tenant:          idp_azure_ad.ConstructTenant(d),
+		Tenant:          tenant,
 		EmailVerified:   idp_utils.BoolValue(d, idp_azure_ad.EmailVerifiedVar),
 	})
 	if err != nil {

--- a/zitadel/v2/org_idp_azure_ad/resource_test.go
+++ b/zitadel/v2/org_idp_azure_ad/resource_test.go
@@ -5,9 +5,8 @@ import (
 	"testing"
 
 	"github.com/zitadel/terraform-provider-zitadel/zitadel/v2/helper/test_utils"
-	"github.com/zitadel/terraform-provider-zitadel/zitadel/v2/org_idp_utils/org_idp_test_utils"
-
 	"github.com/zitadel/terraform-provider-zitadel/zitadel/v2/idp_utils"
+	"github.com/zitadel/terraform-provider-zitadel/zitadel/v2/org_idp_utils/org_idp_test_utils"
 )
 
 func TestAccZITADELOrgIdPAzureAD(t *testing.T) {
@@ -25,7 +24,6 @@ resource "%s" "%s" {
   client_secret       = "%s"
   scopes              = ["two", "scopes"]
   tenant_type         = "AZURE_AD_TENANT_TYPE_COMMON"
-  tenant_id           = "atenantid"
   email_verified      = true
   is_linking_allowed  = false
   is_creation_allowed = true


### PR DESCRIPTION
A tenant can either be configured by ID or by type.
To avoid confusion and non-empty plans, we validate that the properties are mutually exclusive.