### PR TITLE
refactor: format examples

### DIFF
--- a/docs/data-sources/action.md
+++ b/docs/data-sources/action.md
@@ -12,12 +12,12 @@ Datasource representing an action belonging to an organization.
 ## Example Usage
 
 ```terraform
-data zitadel_action action {
+data "zitadel_action" "action" {
   org_id    = data.zitadel_org.org.id
   action_id = "177073621691269123"
 }
 
-output action {
+output "action" {
   value = data.zitadel_action.action
 }
 ```

--- a/docs/data-sources/application_api.md
+++ b/docs/data-sources/application_api.md
@@ -12,13 +12,13 @@ Datasource representing an API application belonging to a project, with all conf
 ## Example Usage
 
 ```terraform
-data zitadel_application_api api_application {
+data "zitadel_application_api" "api_application" {
   org_id     = data.zitadel_org.org.id
   project_id = data.zitadel_project.project.id
   app_id     = "177073625566806019"
 }
 
-output api_application {
+output "api_application" {
   value = data.zitadel_application_api.api_application
 }
 ```

--- a/docs/data-sources/application_oidc.md
+++ b/docs/data-sources/application_oidc.md
@@ -12,13 +12,13 @@ Datasource representing an OIDC application belonging to a project, with all con
 ## Example Usage
 
 ```terraform
-data zitadel_application_oidc oidc_application {
+data "zitadel_application_oidc" "oidc_application" {
   org_id     = data.zitadel_org.org.id
   project_id = data.zitadel_project.project.id
   app_id     = "177073626925760515"
 }
 
-output oidc_application {
+output "oidc_application" {
   value = data.zitadel_application_oidc.oidc_application
 }
 ```

--- a/docs/data-sources/default_oidc_settings.md
+++ b/docs/data-sources/default_oidc_settings.md
@@ -12,9 +12,9 @@ Datasource representing the default oidc settings.
 ## Example Usage
 
 ```terraform
-data zitadel_default_oidc_settings oidc_settings {}
+data "zitadel_default_oidc_settings" "oidc_settings" {}
 
-output oidc_settings {
+output "oidc_settings" {
   value = data.zitadel_default_oidc_settings.oidc_settings
 }
 ```

--- a/docs/data-sources/human_user.md
+++ b/docs/data-sources/human_user.md
@@ -12,12 +12,12 @@ Datasource representing a human user situated under an organization, which then 
 ## Example Usage
 
 ```terraform
-data zitadel_human_user human_user {
+data "zitadel_human_user" "human_user" {
   org_id  = data.zitadel_org.org.id
   user_id = "177073614158299139"
 }
 
-output human_user {
+output "human_user" {
   value = data.zitadel_human_user.human_user
 }
 ```

--- a/docs/data-sources/machine_user.md
+++ b/docs/data-sources/machine_user.md
@@ -12,12 +12,12 @@ Datasource representing a serviceaccount situated under an organization, which t
 ## Example Usage
 
 ```terraform
-data zitadel_machine_user machine_user {
+data "zitadel_machine_user" "machine_user" {
   org_id  = data.zitadel_org.org.id
   user_id = "177073617463410691"
 }
 
-output machine_user {
+output "machine_user" {
   value = data.zitadel_machine_user.machine_user
 }
 ```

--- a/docs/data-sources/org.md
+++ b/docs/data-sources/org.md
@@ -12,11 +12,11 @@ Datasource representing an organization in ZITADEL, which is the highest level a
 ## Example Usage
 
 ```terraform
-data zitadel_org org {
+data "zitadel_org" "org" {
   org_id = "177073608051458051"
 }
 
-output org {
+output "org" {
   value = data.zitadel_org.org
 }
 ```

--- a/docs/data-sources/org_jwt_idp.md
+++ b/docs/data-sources/org_jwt_idp.md
@@ -12,12 +12,12 @@ Datasource representing a generic JWT IdP on the organization.
 ## Example Usage
 
 ```terraform
-data zitadel_org_jwt_idp org_jwt_idp {
+data "zitadel_org_jwt_idp" "org_jwt_idp" {
   org_id = data.zitadel_org.org.id
   idp_id = "177073612581240835"
 }
 
-output org_jwt_idp {
+output "org_jwt_idp" {
   value = data.zitadel_org_jwt_idp.org_jwt_idp
 }
 ```

--- a/docs/data-sources/org_oidc_idp.md
+++ b/docs/data-sources/org_oidc_idp.md
@@ -12,12 +12,12 @@ Datasource representing a generic OIDC IdP on the organization.
 ## Example Usage
 
 ```terraform
-data zitadel_org_oidc_idp org_oidc_idp {
+data "zitadel_org_oidc_idp" "org_oidc_idp" {
   org_id = data.zitadel_org.org.id
   idp_id = "177073612581240835"
 }
 
-output org_oidc_idp {
+output "org_oidc_idp" {
   value = data.zitadel_org_oidc_idp.org_oidc_idp
 }
 ```

--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -12,12 +12,12 @@ Datasource representing the project, which can then be granted to different orga
 ## Example Usage
 
 ```terraform
-data zitadel_project project {
+data "zitadel_project" "project" {
   org_id     = data.zitadel_org.org.id
   project_id = "177073620768522243"
 }
 
-output project {
+output "project" {
   value = data.zitadel_project.project
 }
 ```

--- a/docs/data-sources/project_role.md
+++ b/docs/data-sources/project_role.md
@@ -12,13 +12,13 @@ Datasource representing the project roles, which can be given as authorizations 
 ## Example Usage
 
 ```terraform
-data zitadel_project_role project_role {
+data "zitadel_project_role" "project_role" {
   org_id     = data.zitadel_org.org.id
   project_id = data.zitadel_project.project.id
   role_key   = "key"
 }
 
-output project_role {
+output "project_role" {
   value = data.zitadel_project_role.project_role
 }
 ```

--- a/docs/data-sources/trigger_actions.md
+++ b/docs/data-sources/trigger_actions.md
@@ -12,13 +12,13 @@ Resource representing triggers, when actions get started
 ## Example Usage
 
 ```terraform
-data zitadel_trigger_actions trigger_actions {
+data "zitadel_trigger_actions" "trigger_actions" {
   org_id       = data.zitadel_org.org.id
   flow_type    = "FLOW_TYPE_EXTERNAL_AUTHENTICATION"
   trigger_type = "TRIGGER_TYPE_POST_AUTHENTICATION"
 }
 
-output trigger_actions {
+output "trigger_actions" {
   value = data.zitadel_trigger_actions.trigger_actions
 }
 ```

--- a/docs/resources/action.md
+++ b/docs/resources/action.md
@@ -12,7 +12,7 @@ Resource representing an action belonging to an organization.
 ## Example Usage
 
 ```terraform
-resource zitadel_action action {
+resource "zitadel_action" "action" {
   org_id          = zitadel_org.org.id
   name            = "actionname"
   script          = "testscript"

--- a/docs/resources/application_api.md
+++ b/docs/resources/application_api.md
@@ -12,7 +12,7 @@ Resource representing an API application belonging to a project, with all config
 ## Example Usage
 
 ```terraform
-resource zitadel_application_api application_api {
+resource "zitadel_application_api" "application_api" {
   org_id           = zitadel_org.org.id
   project_id       = zitadel_project.project.id
   name             = "applicationapi"

--- a/docs/resources/application_key.md
+++ b/docs/resources/application_key.md
@@ -12,7 +12,7 @@ Resource representing a app key
 ## Example Usage
 
 ```terraform
-resource zitadel_application_key app_key {
+resource "zitadel_application_key" "app_key" {
   org_id          = zitadel_org.org.id
   project_id      = zitadel_project.project.id
   app_id          = zitadel_application_api.application_api.id

--- a/docs/resources/application_oidc.md
+++ b/docs/resources/application_oidc.md
@@ -12,7 +12,7 @@ Resource representing an OIDC application belonging to a project, with all confi
 ## Example Usage
 
 ```terraform
-resource zitadel_application_oidc application_oidc {
+resource "zitadel_application_oidc" "application_oidc" {
   project_id = zitadel_project.project.id
   org_id     = zitadel_org.org.id
 

--- a/docs/resources/default_domain_claimed_message_text.md
+++ b/docs/resources/default_domain_claimed_message_text.md
@@ -12,7 +12,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource zitadel_default_domain_claimed_message_text domain_claimed_en {
+resource "zitadel_default_domain_claimed_message_text" "domain_claimed_en" {
   language = "en"
 
   title       = "title example"

--- a/docs/resources/default_domain_policy.md
+++ b/docs/resources/default_domain_policy.md
@@ -12,7 +12,7 @@ Resource representing the default domain policy.
 ## Example Usage
 
 ```terraform
-resource zitadel_default_domain_policy domain_policy {
+resource "zitadel_default_domain_policy" "domain_policy" {
   user_login_must_be_domain                   = false
   validate_org_domains                        = false
   smtp_sender_address_matches_instance_domain = false

--- a/docs/resources/default_init_message_text.md
+++ b/docs/resources/default_init_message_text.md
@@ -12,7 +12,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource zitadel_default_init_message_text init_en {
+resource "zitadel_default_init_message_text" "init_en" {
   language = "en"
 
   title       = "title example"

--- a/docs/resources/default_label_policy.md
+++ b/docs/resources/default_label_policy.md
@@ -12,7 +12,7 @@ Resource representing the default label policy.
 ## Example Usage
 
 ```terraform
-resource zitadel_default_label_policy label_policy {
+resource "zitadel_default_label_policy" "label_policy" {
   primary_color          = "#5469d4"
   hide_login_name_suffix = true
   warn_color             = "#cd3d56"

--- a/docs/resources/default_lockout_policy.md
+++ b/docs/resources/default_lockout_policy.md
@@ -12,7 +12,7 @@ Resource representing the default lockout policy.
 ## Example Usage
 
 ```terraform
-resource zitadel_default_lockout_policy lockout_policy {
+resource "zitadel_default_lockout_policy" "lockout_policy" {
   max_password_attempts = "5"
 }
 ```

--- a/docs/resources/default_login_policy.md
+++ b/docs/resources/default_login_policy.md
@@ -12,7 +12,7 @@ Resource representing the default login policy.
 ## Example Usage
 
 ```terraform
-resource zitadel_default_login_policy login_policy {
+resource "zitadel_default_login_policy" "login_policy" {
   user_login                    = true
   allow_register                = true
   allow_external_idp            = true

--- a/docs/resources/default_login_texts.md
+++ b/docs/resources/default_login_texts.md
@@ -12,7 +12,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource zitadel_default_login_texts login_texts_en {
+resource "zitadel_default_login_texts" "login_texts_en" {
   language = "en"
 
   email_verification_done_text = {

--- a/docs/resources/default_notification_policy.md
+++ b/docs/resources/default_notification_policy.md
@@ -12,7 +12,7 @@ Resource representing the default notification policy.
 ## Example Usage
 
 ```terraform
-resource zitadel_default_notification_policy notification_policy {
+resource "zitadel_default_notification_policy" "notification_policy" {
   password_change = false
 }
 ```

--- a/docs/resources/default_oidc_settings.md
+++ b/docs/resources/default_oidc_settings.md
@@ -12,10 +12,10 @@ Resource representing the default oidc settings.
 ## Example Usage
 
 ```terraform
-resource zitadel_default_oidc_settings oidc_settings {
-  access_token_lifetime = "12h0m0s"
-  id_token_lifetime = "12h0m0s"
-  refresh_token_expiration = "720h0m0s"
+resource "zitadel_default_oidc_settings" "oidc_settings" {
+  access_token_lifetime         = "12h0m0s"
+  id_token_lifetime             = "12h0m0s"
+  refresh_token_expiration      = "720h0m0s"
   refresh_token_idle_expiration = "2160h0m0s"
 }
 ```

--- a/docs/resources/default_password_change_message_text.md
+++ b/docs/resources/default_password_change_message_text.md
@@ -12,7 +12,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource zitadel_default_password_change_message_text password_change_en {
+resource "zitadel_default_password_change_message_text" "password_change_en" {
   language = "en"
 
   title       = "title example"

--- a/docs/resources/default_password_complexity_policy.md
+++ b/docs/resources/default_password_complexity_policy.md
@@ -12,7 +12,7 @@ Resource representing the default password complexity policy.
 ## Example Usage
 
 ```terraform
-resource zitadel_default_password_complexity_policy password_complexity_policy {
+resource "zitadel_default_password_complexity_policy" "password_complexity_policy" {
   min_length    = "8"
   has_uppercase = true
   has_lowercase = true

--- a/docs/resources/default_password_reset_message_text.md
+++ b/docs/resources/default_password_reset_message_text.md
@@ -12,7 +12,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource zitadel_default_password_reset_message_text password_reset_en {
+resource "zitadel_default_password_reset_message_text" "password_reset_en" {
   language = "en"
 
   title       = "title example"

--- a/docs/resources/default_passwordless_registration_message_text.md
+++ b/docs/resources/default_passwordless_registration_message_text.md
@@ -12,7 +12,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource zitadel_default_passwordless_registration_message_text passwordless_registration_en {
+resource "zitadel_default_passwordless_registration_message_text" "passwordless_registration_en" {
   language = "en"
 
   title       = "title example"

--- a/docs/resources/default_privacy_policy.md
+++ b/docs/resources/default_privacy_policy.md
@@ -12,10 +12,11 @@ Resource representing the default privacy policy.
 ## Example Usage
 
 ```terraform
-resource zitadel_default_privacy_policy privacy_policy {
-  tos_link     = "https://google.com"
-  privacy_link = "https://google.com"
-  help_link    = "https://google.com"
+resource "zitadel_default_privacy_policy" "privacy_policy" {
+  tos_link      = "https://google.com"
+  privacy_link  = "https://google.com"
+  help_link     = "https://google.com"
+  support_email = "support@email.com"
 }
 ```
 

--- a/docs/resources/default_verify_email_message_text.md
+++ b/docs/resources/default_verify_email_message_text.md
@@ -12,7 +12,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource zitadel_default_verify_email_message_text verify_email_en {
+resource "zitadel_default_verify_email_message_text" "verify_email_en" {
   language = "en"
 
   title       = "title example"

--- a/docs/resources/default_verify_phone_message_text.md
+++ b/docs/resources/default_verify_phone_message_text.md
@@ -12,7 +12,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource zitadel_default_verify_phone_message_text verify_phone_en {
+resource "zitadel_default_verify_phone_message_text" "verify_phone_en" {
   language = "en"
 
   title       = "title example"

--- a/docs/resources/domain.md
+++ b/docs/resources/domain.md
@@ -12,9 +12,9 @@ Resource representing a domain of the organization.
 ## Example Usage
 
 ```terraform
-resource zitadel_domain domain {
-  org_id    = zitadel_org.org.id
-  name      = "zitadel.default.127.0.0.1.sslip.io"
+resource "zitadel_domain" "domain" {
+  org_id     = zitadel_org.org.id
+  name       = "zitadel.default.127.0.0.1.sslip.io"
   is_primary = true
 }
 ```

--- a/docs/resources/domain_claimed_message_text.md
+++ b/docs/resources/domain_claimed_message_text.md
@@ -12,7 +12,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource zitadel_domain_claimed_message_text domain_claimed_en {
+resource "zitadel_domain_claimed_message_text" "domain_claimed_en" {
   org_id   = zitadel_org.org.id
   language = "en"
 

--- a/docs/resources/domain_policy.md
+++ b/docs/resources/domain_policy.md
@@ -12,7 +12,7 @@ Resource representing the custom domain policy of an organization.
 ## Example Usage
 
 ```terraform
-resource zitadel_domain_policy domain_policy {
+resource "zitadel_domain_policy" "domain_policy" {
   org_id                                      = zitadel_org.org.id
   user_login_must_be_domain                   = false
   validate_org_domains                        = false

--- a/docs/resources/human_user.md
+++ b/docs/resources/human_user.md
@@ -14,7 +14,7 @@ Resource representing a human user situated under an organization, which then ca
 ## Example Usage
 
 ```terraform
-resource zitadel_human_user human_user {
+resource "zitadel_human_user" "human_user" {
   org_id             = zitadel_org.org.id
   user_name          = "humanfull@localhost.com"
   first_name         = "firstname"

--- a/docs/resources/init_message_text.md
+++ b/docs/resources/init_message_text.md
@@ -12,7 +12,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource zitadel_init_message_text init_en {
+resource "zitadel_init_message_text" "init_en" {
   org_id   = zitadel_org.org.id
   language = "en"
 

--- a/docs/resources/instance_member.md
+++ b/docs/resources/instance_member.md
@@ -12,7 +12,7 @@ Resource representing the membership of a user on an instance, defined with the 
 ## Example Usage
 
 ```terraform
-resource zitadel_instance_member instance_member {
+resource "zitadel_instance_member" "instance_member" {
   user_id = zitadel_human_user.human_user.id
   roles   = ["IAM_OWNER"]
 }

--- a/docs/resources/label_policy.md
+++ b/docs/resources/label_policy.md
@@ -12,7 +12,7 @@ Resource representing the custom label policy of an organization.
 ## Example Usage
 
 ```terraform
-resource zitadel_label_policy label_policy {
+resource "zitadel_label_policy" "label_policy" {
   org_id                 = zitadel_org.org.id
   primary_color          = "#5469d4"
   hide_login_name_suffix = true

--- a/docs/resources/lockout_policy.md
+++ b/docs/resources/lockout_policy.md
@@ -12,7 +12,7 @@ Resource representing the custom lockout policy of an organization.
 ## Example Usage
 
 ```terraform
-resource zitadel_lockout_policy lockout_policy {
+resource "zitadel_lockout_policy" "lockout_policy" {
   org_id                = zitadel_org.org.id
   max_password_attempts = "5"
 }

--- a/docs/resources/login_policy.md
+++ b/docs/resources/login_policy.md
@@ -12,7 +12,7 @@ Resource representing the custom login policy of an organization.
 ## Example Usage
 
 ```terraform
-resource zitadel_login_policy login_policy {
+resource "zitadel_login_policy" "login_policy" {
   org_id                        = zitadel_org.org.id
   user_login                    = true
   allow_register                = true

--- a/docs/resources/login_texts.md
+++ b/docs/resources/login_texts.md
@@ -12,7 +12,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource zitadel_login_texts login_texts_en {
+resource "zitadel_login_texts" "login_texts_en" {
   org_id   = zitadel_org.org.id
   language = "en"
 

--- a/docs/resources/machine_key.md
+++ b/docs/resources/machine_key.md
@@ -12,7 +12,7 @@ Resource representing a machine key
 ## Example Usage
 
 ```terraform
-resource zitadel_machine_key machine_key {
+resource "zitadel_machine_key" "machine_key" {
   org_id          = zitadel_org.org.id
   user_id         = zitadel_machine_user.machine_user.id
   key_type        = "KEY_TYPE_JSON"

--- a/docs/resources/machine_user.md
+++ b/docs/resources/machine_user.md
@@ -12,7 +12,7 @@ Resource representing a serviceaccount situated under an organization, which the
 ## Example Usage
 
 ```terraform
-resource zitadel_machine_user machine_user {
+resource "zitadel_machine_user" "machine_user" {
   org_id      = zitadel_org.org.id
   user_name   = "machine@localhost.com"
   name        = "name"

--- a/docs/resources/notification_policy.md
+++ b/docs/resources/notification_policy.md
@@ -12,7 +12,7 @@ Resource representing the custom notification policy of an organization.
 ## Example Usage
 
 ```terraform
-resource zitadel_notification_policy notification_policy {
+resource "zitadel_notification_policy" "notification_policy" {
   org_id          = zitadel_org.org.id
   password_change = false
 }

--- a/docs/resources/org.md
+++ b/docs/resources/org.md
@@ -12,7 +12,7 @@ Resource representing an organization in ZITADEL, which is the highest level aft
 ## Example Usage
 
 ```terraform
-resource zitadel_org org {
+resource "zitadel_org" "org" {
   name = "terraform-test"
 }
 ```

--- a/docs/resources/org_idp_jwt.md
+++ b/docs/resources/org_idp_jwt.md
@@ -12,7 +12,7 @@ Resource representing a generic JWT IdP of the organization.
 ## Example Usage
 
 ```terraform
-resource zitadel_org_idp_jwt jwt_idp {
+resource "zitadel_org_idp_jwt" "jwt_idp" {
   org_id        = zitadel_org.org.id
   name          = "jwtidp"
   styling_type  = "STYLING_TYPE_UNSPECIFIED"

--- a/docs/resources/org_idp_oidc.md
+++ b/docs/resources/org_idp_oidc.md
@@ -12,7 +12,7 @@ Resource representing a generic OIDC IdP on the organization.
 ## Example Usage
 
 ```terraform
-resource zitadel_org_idp_oidc oidc_idp {
+resource "zitadel_org_idp_oidc" "oidc_idp" {
   org_id               = zitadel_org.org.id
   name                 = "oidcidp"
   styling_type         = "STYLING_TYPE_UNSPECIFIED"

--- a/docs/resources/org_member.md
+++ b/docs/resources/org_member.md
@@ -12,7 +12,7 @@ Resource representing the membership of a user on an organization, defined with 
 ## Example Usage
 
 ```terraform
-resource zitadel_org_member org_member {
+resource "zitadel_org_member" "org_member" {
   org_id  = zitadel_org.org.id
   user_id = zitadel_human_user.human_user.id
   roles   = ["ORG_OWNER"]

--- a/docs/resources/password_change_message_text.md
+++ b/docs/resources/password_change_message_text.md
@@ -12,7 +12,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource zitadel_password_change_message_text password_change_en {
+resource "zitadel_password_change_message_text" "password_change_en" {
   org_id   = zitadel_org.org.id
   language = "en"
 

--- a/docs/resources/password_complexity_policy.md
+++ b/docs/resources/password_complexity_policy.md
@@ -12,7 +12,7 @@ Resource representing the custom password complexity policy of an organization.
 ## Example Usage
 
 ```terraform
-resource zitadel_password_complexity_policy password_complexity_policy {
+resource "zitadel_password_complexity_policy" "password_complexity_policy" {
   org_id        = zitadel_org.org.id
   min_length    = "8"
   has_uppercase = true

--- a/docs/resources/password_reset_message_text.md
+++ b/docs/resources/password_reset_message_text.md
@@ -12,7 +12,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource zitadel_password_reset_message_text password_reset_en {
+resource "zitadel_password_reset_message_text" "password_reset_en" {
   org_id   = zitadel_org.org.id
   language = "en"
 

--- a/docs/resources/passwordless_registration_message_text.md
+++ b/docs/resources/passwordless_registration_message_text.md
@@ -12,7 +12,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource zitadel_passwordless_registration_message_text passwordless_registration_en {
+resource "zitadel_passwordless_registration_message_text" "passwordless_registration_en" {
   org_id   = zitadel_org.org.id
   language = "en"
 

--- a/docs/resources/personal_access_token.md
+++ b/docs/resources/personal_access_token.md
@@ -12,7 +12,7 @@ Resource representing a personal access token of a user
 ## Example Usage
 
 ```terraform
-resource zitadel_personal_access_token pat {
+resource "zitadel_personal_access_token" "pat" {
   org_id          = zitadel_org.org.id
   user_id         = zitadel_machine_user.machine_user.id
   expiration_date = "2519-04-01T08:45:00Z"

--- a/docs/resources/privacy_policy.md
+++ b/docs/resources/privacy_policy.md
@@ -12,11 +12,12 @@ Resource representing the custom privacy policy of an organization.
 ## Example Usage
 
 ```terraform
-resource zitadel_privacy_policy privacy_policy {
-  org_id       = zitadel_org.org.id
-  tos_link     = "https://google.com"
-  privacy_link = "https://google.com"
-  help_link    = "https://google.com"
+resource "zitadel_privacy_policy" "privacy_policy" {
+  org_id        = zitadel_org.org.id
+  tos_link      = "https://google.com"
+  privacy_link  = "https://google.com"
+  help_link     = "https://google.com"
+  support_email = "support@email.com"
 }
 ```
 

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -12,7 +12,7 @@ Resource representing the project, which can then be granted to different organi
 ## Example Usage
 
 ```terraform
-resource zitadel_project project {
+resource "zitadel_project" "project" {
   name                     = "projectname"
   org_id                   = zitadel_org.org.id
   project_role_assertion   = true

--- a/docs/resources/project_grant.md
+++ b/docs/resources/project_grant.md
@@ -12,7 +12,7 @@ Resource representing the grant of a project to a different organization, also c
 ## Example Usage
 
 ```terraform
-resource zitadel_project_grant project_grant {
+resource "zitadel_project_grant" "project_grant" {
   org_id         = zitadel_org.org.id
   project_id     = zitadel_project.project.id
   granted_org_id = zitadel_org.grantedorg.id

--- a/docs/resources/project_grant_member.md
+++ b/docs/resources/project_grant_member.md
@@ -12,7 +12,7 @@ Resource representing the membership of a user on an granted project, defined wi
 ## Example Usage
 
 ```terraform
-resource zitadel_project_grant_member project_grant_member {
+resource "zitadel_project_grant_member" "project_grant_member" {
   org_id     = zitadel_org.org.id
   project_id = zitadel_project.project.id
   grant_id   = zitadel_project_grant.project_grant.id

--- a/docs/resources/project_member.md
+++ b/docs/resources/project_member.md
@@ -12,7 +12,7 @@ Resource representing the membership of a user on an project, defined with the g
 ## Example Usage
 
 ```terraform
-resource zitadel_project_member project_member {
+resource "zitadel_project_member" "project_member" {
   org_id     = zitadel_org.org.id
   project_id = zitadel_project.project.id
   user_id    = zitadel_human_user.human_user.id

--- a/docs/resources/project_role.md
+++ b/docs/resources/project_role.md
@@ -12,7 +12,7 @@ Resource representing the project roles, which can be given as authorizations to
 ## Example Usage
 
 ```terraform
-resource zitadel_project_role project_role {
+resource "zitadel_project_role" "project_role" {
   org_id       = zitadel_org.org.id
   project_id   = zitadel_project.project.id
   role_key     = "key"

--- a/docs/resources/sms_provider_twilio.md
+++ b/docs/resources/sms_provider_twilio.md
@@ -12,7 +12,7 @@ Resource representing the SMS provider Twilio configuration of an instance.
 ## Example Usage
 
 ```terraform
-resource zitadel_sms_provider_twilio twilio {
+resource "zitadel_sms_provider_twilio" "twilio" {
   sid           = "sid"
   sender_number = "019920892"
   token         = "token"

--- a/docs/resources/smtp_config.md
+++ b/docs/resources/smtp_config.md
@@ -12,7 +12,7 @@ Resource representing the SMTP configuration of an instance.
 ## Example Usage
 
 ```terraform
-resource zitadel_smtp_config smtp {
+resource "zitadel_smtp_config" "smtp" {
   sender_address = "address"
   sender_name    = "no-reply"
   tls            = true

--- a/docs/resources/trigger_actions.md
+++ b/docs/resources/trigger_actions.md
@@ -12,7 +12,7 @@ Resource representing triggers, when actions get started
 ## Example Usage
 
 ```terraform
-resource zitadel_trigger_actions trigger_actions {
+resource "zitadel_trigger_actions" "trigger_actions" {
   org_id       = zitadel_org.org.id
   flow_type    = "FLOW_TYPE_EXTERNAL_AUTHENTICATION"
   trigger_type = "TRIGGER_TYPE_POST_AUTHENTICATION"

--- a/docs/resources/user_grant.md
+++ b/docs/resources/user_grant.md
@@ -12,7 +12,7 @@ Resource representing the authorization given to a user directly, including the 
 ## Example Usage
 
 ```terraform
-resource zitadel_user_grant user_grant {
+resource "zitadel_user_grant" "user_grant" {
   project_id = zitadel_project.project.id
   org_id     = zitadel_org.org.id
   role_keys  = ["key"]

--- a/docs/resources/verify_email_message_text.md
+++ b/docs/resources/verify_email_message_text.md
@@ -12,7 +12,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource zitadel_verify_email_message_text verify_email_en {
+resource "zitadel_verify_email_message_text" "verify_email_en" {
   org_id   = zitadel_org.org.id
   language = "en"
 

--- a/docs/resources/verify_phone_message_text.md
+++ b/docs/resources/verify_phone_message_text.md
@@ -12,7 +12,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource zitadel_verify_phone_message_text verify_phone_en {
+resource "zitadel_verify_phone_message_text" "verify_phone_en" {
   org_id   = zitadel_org.org.id
   language = "en"
 

--- a/examples/provider/data-sources/action.tf
+++ b/examples/provider/data-sources/action.tf
@@ -1,8 +1,8 @@
-data zitadel_action action {
+data "zitadel_action" "action" {
   org_id    = data.zitadel_org.org.id
   action_id = "177073621691269123"
 }
 
-output action {
+output "action" {
   value = data.zitadel_action.action
 }

--- a/examples/provider/data-sources/application_api.tf
+++ b/examples/provider/data-sources/application_api.tf
@@ -1,9 +1,9 @@
-data zitadel_application_api api_application {
+data "zitadel_application_api" "api_application" {
   org_id     = data.zitadel_org.org.id
   project_id = data.zitadel_project.project.id
   app_id     = "177073625566806019"
 }
 
-output api_application {
+output "api_application" {
   value = data.zitadel_application_api.api_application
 }

--- a/examples/provider/data-sources/application_oidc.tf
+++ b/examples/provider/data-sources/application_oidc.tf
@@ -1,9 +1,9 @@
-data zitadel_application_oidc oidc_application {
+data "zitadel_application_oidc" "oidc_application" {
   org_id     = data.zitadel_org.org.id
   project_id = data.zitadel_project.project.id
   app_id     = "177073626925760515"
 }
 
-output oidc_application {
+output "oidc_application" {
   value = data.zitadel_application_oidc.oidc_application
 }

--- a/examples/provider/data-sources/default_oidc_settings.tf
+++ b/examples/provider/data-sources/default_oidc_settings.tf
@@ -1,5 +1,5 @@
-data zitadel_default_oidc_settings oidc_settings {}
+data "zitadel_default_oidc_settings" "oidc_settings" {}
 
-output oidc_settings {
+output "oidc_settings" {
   value = data.zitadel_default_oidc_settings.oidc_settings
 }

--- a/examples/provider/data-sources/human_user.tf
+++ b/examples/provider/data-sources/human_user.tf
@@ -1,8 +1,8 @@
-data zitadel_human_user human_user {
+data "zitadel_human_user" "human_user" {
   org_id  = data.zitadel_org.org.id
   user_id = "177073614158299139"
 }
 
-output human_user {
+output "human_user" {
   value = data.zitadel_human_user.human_user
 }

--- a/examples/provider/data-sources/machine_user.tf
+++ b/examples/provider/data-sources/machine_user.tf
@@ -1,8 +1,8 @@
-data zitadel_machine_user machine_user {
+data "zitadel_machine_user" "machine_user" {
   org_id  = data.zitadel_org.org.id
   user_id = "177073617463410691"
 }
 
-output machine_user {
+output "machine_user" {
   value = data.zitadel_machine_user.machine_user
 }

--- a/examples/provider/data-sources/org.tf
+++ b/examples/provider/data-sources/org.tf
@@ -1,7 +1,7 @@
-data zitadel_org org {
+data "zitadel_org" "org" {
   org_id = "177073608051458051"
 }
 
-output org {
+output "org" {
   value = data.zitadel_org.org
 }

--- a/examples/provider/data-sources/org_jwt_idp.tf
+++ b/examples/provider/data-sources/org_jwt_idp.tf
@@ -1,8 +1,8 @@
-data zitadel_org_jwt_idp org_jwt_idp {
+data "zitadel_org_jwt_idp" "org_jwt_idp" {
   org_id = data.zitadel_org.org.id
   idp_id = "177073612581240835"
 }
 
-output org_jwt_idp {
+output "org_jwt_idp" {
   value = data.zitadel_org_jwt_idp.org_jwt_idp
 }

--- a/examples/provider/data-sources/org_oidc_idp.tf
+++ b/examples/provider/data-sources/org_oidc_idp.tf
@@ -1,8 +1,8 @@
-data zitadel_org_oidc_idp org_oidc_idp {
+data "zitadel_org_oidc_idp" "org_oidc_idp" {
   org_id = data.zitadel_org.org.id
   idp_id = "177073612581240835"
 }
 
-output org_oidc_idp {
+output "org_oidc_idp" {
   value = data.zitadel_org_oidc_idp.org_oidc_idp
 }

--- a/examples/provider/data-sources/project.tf
+++ b/examples/provider/data-sources/project.tf
@@ -1,8 +1,8 @@
-data zitadel_project project {
+data "zitadel_project" "project" {
   org_id     = data.zitadel_org.org.id
   project_id = "177073620768522243"
 }
 
-output project {
+output "project" {
   value = data.zitadel_project.project
 }

--- a/examples/provider/data-sources/project_role.tf
+++ b/examples/provider/data-sources/project_role.tf
@@ -1,9 +1,9 @@
-data zitadel_project_role project_role {
+data "zitadel_project_role" "project_role" {
   org_id     = data.zitadel_org.org.id
   project_id = data.zitadel_project.project.id
   role_key   = "key"
 }
 
-output project_role {
+output "project_role" {
   value = data.zitadel_project_role.project_role
 }

--- a/examples/provider/data-sources/trigger_actions.tf
+++ b/examples/provider/data-sources/trigger_actions.tf
@@ -1,9 +1,9 @@
-data zitadel_trigger_actions trigger_actions {
+data "zitadel_trigger_actions" "trigger_actions" {
   org_id       = data.zitadel_org.org.id
   flow_type    = "FLOW_TYPE_EXTERNAL_AUTHENTICATION"
   trigger_type = "TRIGGER_TYPE_POST_AUTHENTICATION"
 }
 
-output trigger_actions {
+output "trigger_actions" {
   value = data.zitadel_trigger_actions.trigger_actions
 }

--- a/examples/provider/resources/action.tf
+++ b/examples/provider/resources/action.tf
@@ -1,4 +1,4 @@
-resource zitadel_action action {
+resource "zitadel_action" "action" {
   org_id          = zitadel_org.org.id
   name            = "actionname"
   script          = "testscript"

--- a/examples/provider/resources/app_key.tf
+++ b/examples/provider/resources/app_key.tf
@@ -1,4 +1,4 @@
-resource zitadel_application_key app_key {
+resource "zitadel_application_key" "app_key" {
   org_id          = zitadel_org.org.id
   project_id      = zitadel_project.project.id
   app_id          = zitadel_application_api.application_api.id

--- a/examples/provider/resources/application_api.tf
+++ b/examples/provider/resources/application_api.tf
@@ -1,4 +1,4 @@
-resource zitadel_application_api application_api {
+resource "zitadel_application_api" "application_api" {
   org_id           = zitadel_org.org.id
   project_id       = zitadel_project.project.id
   name             = "applicationapi"

--- a/examples/provider/resources/application_oidc.tf
+++ b/examples/provider/resources/application_oidc.tf
@@ -1,4 +1,4 @@
-resource zitadel_application_oidc application_oidc {
+resource "zitadel_application_oidc" "application_oidc" {
   project_id = zitadel_project.project.id
   org_id     = zitadel_org.org.id
 

--- a/examples/provider/resources/default_domain_claimed_message_text.tf
+++ b/examples/provider/resources/default_domain_claimed_message_text.tf
@@ -1,4 +1,4 @@
-resource zitadel_default_domain_claimed_message_text domain_claimed_en {
+resource "zitadel_default_domain_claimed_message_text" "domain_claimed_en" {
   language = "en"
 
   title       = "title example"

--- a/examples/provider/resources/default_domain_policy.tf
+++ b/examples/provider/resources/default_domain_policy.tf
@@ -1,4 +1,4 @@
-resource zitadel_default_domain_policy domain_policy {
+resource "zitadel_default_domain_policy" "domain_policy" {
   user_login_must_be_domain                   = false
   validate_org_domains                        = false
   smtp_sender_address_matches_instance_domain = false

--- a/examples/provider/resources/default_init_message_text.tf
+++ b/examples/provider/resources/default_init_message_text.tf
@@ -1,4 +1,4 @@
-resource zitadel_default_init_message_text init_en {
+resource "zitadel_default_init_message_text" "init_en" {
   language = "en"
 
   title       = "title example"

--- a/examples/provider/resources/default_label_policy.tf
+++ b/examples/provider/resources/default_label_policy.tf
@@ -1,4 +1,4 @@
-resource zitadel_default_label_policy label_policy {
+resource "zitadel_default_label_policy" "label_policy" {
   primary_color          = "#5469d4"
   hide_login_name_suffix = true
   warn_color             = "#cd3d56"

--- a/examples/provider/resources/default_lockout_policy.tf
+++ b/examples/provider/resources/default_lockout_policy.tf
@@ -1,3 +1,3 @@
-resource zitadel_default_lockout_policy lockout_policy {
+resource "zitadel_default_lockout_policy" "lockout_policy" {
   max_password_attempts = "5"
 }

--- a/examples/provider/resources/default_login_policy.tf
+++ b/examples/provider/resources/default_login_policy.tf
@@ -1,4 +1,4 @@
-resource zitadel_default_login_policy login_policy {
+resource "zitadel_default_login_policy" "login_policy" {
   user_login                    = true
   allow_register                = true
   allow_external_idp            = true

--- a/examples/provider/resources/default_login_texts.tf
+++ b/examples/provider/resources/default_login_texts.tf
@@ -1,4 +1,4 @@
-resource zitadel_default_login_texts login_texts_en {
+resource "zitadel_default_login_texts" "login_texts_en" {
   language = "en"
 
   email_verification_done_text = {

--- a/examples/provider/resources/default_notification_policy.tf
+++ b/examples/provider/resources/default_notification_policy.tf
@@ -1,3 +1,3 @@
-resource zitadel_default_notification_policy notification_policy {
+resource "zitadel_default_notification_policy" "notification_policy" {
   password_change = false
 }

--- a/examples/provider/resources/default_oidc_settings.tf
+++ b/examples/provider/resources/default_oidc_settings.tf
@@ -1,6 +1,6 @@
-resource zitadel_default_oidc_settings oidc_settings {
-  access_token_lifetime = "12h0m0s"
-  id_token_lifetime = "12h0m0s"
-  refresh_token_expiration = "720h0m0s"
+resource "zitadel_default_oidc_settings" "oidc_settings" {
+  access_token_lifetime         = "12h0m0s"
+  id_token_lifetime             = "12h0m0s"
+  refresh_token_expiration      = "720h0m0s"
   refresh_token_idle_expiration = "2160h0m0s"
 }

--- a/examples/provider/resources/default_password_change_message_text.tf
+++ b/examples/provider/resources/default_password_change_message_text.tf
@@ -1,4 +1,4 @@
-resource zitadel_default_password_change_message_text password_change_en {
+resource "zitadel_default_password_change_message_text" "password_change_en" {
   language = "en"
 
   title       = "title example"

--- a/examples/provider/resources/default_password_complexity_policy.tf
+++ b/examples/provider/resources/default_password_complexity_policy.tf
@@ -1,4 +1,4 @@
-resource zitadel_default_password_complexity_policy password_complexity_policy {
+resource "zitadel_default_password_complexity_policy" "password_complexity_policy" {
   min_length    = "8"
   has_uppercase = true
   has_lowercase = true

--- a/examples/provider/resources/default_password_reset_message_text.tf
+++ b/examples/provider/resources/default_password_reset_message_text.tf
@@ -1,4 +1,4 @@
-resource zitadel_default_password_reset_message_text password_reset_en {
+resource "zitadel_default_password_reset_message_text" "password_reset_en" {
   language = "en"
 
   title       = "title example"

--- a/examples/provider/resources/default_passwordless_registration_message_text.tf
+++ b/examples/provider/resources/default_passwordless_registration_message_text.tf
@@ -1,4 +1,4 @@
-resource zitadel_default_passwordless_registration_message_text passwordless_registration_en {
+resource "zitadel_default_passwordless_registration_message_text" "passwordless_registration_en" {
   language = "en"
 
   title       = "title example"

--- a/examples/provider/resources/default_privacy_policy.tf
+++ b/examples/provider/resources/default_privacy_policy.tf
@@ -1,4 +1,4 @@
-resource zitadel_default_privacy_policy privacy_policy {
+resource "zitadel_default_privacy_policy" "privacy_policy" {
   tos_link      = "https://google.com"
   privacy_link  = "https://google.com"
   help_link     = "https://google.com"

--- a/examples/provider/resources/default_verify_email_message_text.tf
+++ b/examples/provider/resources/default_verify_email_message_text.tf
@@ -1,4 +1,4 @@
-resource zitadel_default_verify_email_message_text verify_email_en {
+resource "zitadel_default_verify_email_message_text" "verify_email_en" {
   language = "en"
 
   title       = "title example"

--- a/examples/provider/resources/default_verify_phone_message_text.tf
+++ b/examples/provider/resources/default_verify_phone_message_text.tf
@@ -1,4 +1,4 @@
-resource zitadel_default_verify_phone_message_text verify_phone_en {
+resource "zitadel_default_verify_phone_message_text" "verify_phone_en" {
   language = "en"
 
   title       = "title example"

--- a/examples/provider/resources/domain.tf
+++ b/examples/provider/resources/domain.tf
@@ -1,5 +1,5 @@
-resource zitadel_domain domain {
-  org_id    = zitadel_org.org.id
-  name      = "zitadel.default.127.0.0.1.sslip.io"
+resource "zitadel_domain" "domain" {
+  org_id     = zitadel_org.org.id
+  name       = "zitadel.default.127.0.0.1.sslip.io"
   is_primary = true
 }

--- a/examples/provider/resources/domain_claimed_message_text.tf
+++ b/examples/provider/resources/domain_claimed_message_text.tf
@@ -1,4 +1,4 @@
-resource zitadel_domain_claimed_message_text domain_claimed_en {
+resource "zitadel_domain_claimed_message_text" "domain_claimed_en" {
   org_id   = zitadel_org.org.id
   language = "en"
 

--- a/examples/provider/resources/domain_policy.tf
+++ b/examples/provider/resources/domain_policy.tf
@@ -1,4 +1,4 @@
-resource zitadel_domain_policy domain_policy {
+resource "zitadel_domain_policy" "domain_policy" {
   org_id                                      = zitadel_org.org.id
   user_login_must_be_domain                   = false
   validate_org_domains                        = false

--- a/examples/provider/resources/granted_human_user.tf
+++ b/examples/provider/resources/granted_human_user.tf
@@ -1,4 +1,4 @@
-resource zitadel_human_user granted_human_user {
+resource "zitadel_human_user" "granted_human_user" {
   org_id             = zitadel_org.grantedorg.id
   user_name          = "human@localhost"
   first_name         = "firstname"

--- a/examples/provider/resources/granted_org.tf
+++ b/examples/provider/resources/granted_org.tf
@@ -1,3 +1,3 @@
-resource zitadel_org grantedorg {
+resource "zitadel_org" "grantedorg" {
   name = "terraform-test-granted"
 }

--- a/examples/provider/resources/human_user.tf
+++ b/examples/provider/resources/human_user.tf
@@ -1,4 +1,4 @@
-resource zitadel_human_user human_user {
+resource "zitadel_human_user" "human_user" {
   org_id             = zitadel_org.org.id
   user_name          = "humanfull@localhost.com"
   first_name         = "firstname"

--- a/examples/provider/resources/init_message_text.tf
+++ b/examples/provider/resources/init_message_text.tf
@@ -1,4 +1,4 @@
-resource zitadel_init_message_text init_en {
+resource "zitadel_init_message_text" "init_en" {
   org_id   = zitadel_org.org.id
   language = "en"
 

--- a/examples/provider/resources/instance_member.tf
+++ b/examples/provider/resources/instance_member.tf
@@ -1,4 +1,4 @@
-resource zitadel_instance_member instance_member {
+resource "zitadel_instance_member" "instance_member" {
   user_id = zitadel_human_user.human_user.id
   roles   = ["IAM_OWNER"]
 }

--- a/examples/provider/resources/label_policy.tf
+++ b/examples/provider/resources/label_policy.tf
@@ -1,4 +1,4 @@
-resource zitadel_label_policy label_policy {
+resource "zitadel_label_policy" "label_policy" {
   org_id                 = zitadel_org.org.id
   primary_color          = "#5469d4"
   hide_login_name_suffix = true

--- a/examples/provider/resources/lockout_policy.tf
+++ b/examples/provider/resources/lockout_policy.tf
@@ -1,4 +1,4 @@
-resource zitadel_lockout_policy lockout_policy {
+resource "zitadel_lockout_policy" "lockout_policy" {
   org_id                = zitadel_org.org.id
   max_password_attempts = "5"
 }

--- a/examples/provider/resources/login_policy.tf
+++ b/examples/provider/resources/login_policy.tf
@@ -1,4 +1,4 @@
-resource zitadel_login_policy login_policy {
+resource "zitadel_login_policy" "login_policy" {
   org_id                        = zitadel_org.org.id
   user_login                    = true
   allow_register                = true

--- a/examples/provider/resources/login_texts.tf
+++ b/examples/provider/resources/login_texts.tf
@@ -1,4 +1,4 @@
-resource zitadel_login_texts login_texts_en {
+resource "zitadel_login_texts" "login_texts_en" {
   org_id   = zitadel_org.org.id
   language = "en"
 

--- a/examples/provider/resources/machine_key.tf
+++ b/examples/provider/resources/machine_key.tf
@@ -1,4 +1,4 @@
-resource zitadel_machine_key machine_key {
+resource "zitadel_machine_key" "machine_key" {
   org_id          = zitadel_org.org.id
   user_id         = zitadel_machine_user.machine_user.id
   key_type        = "KEY_TYPE_JSON"

--- a/examples/provider/resources/machine_user.tf
+++ b/examples/provider/resources/machine_user.tf
@@ -1,4 +1,4 @@
-resource zitadel_machine_user machine_user {
+resource "zitadel_machine_user" "machine_user" {
   org_id      = zitadel_org.org.id
   user_name   = "machine@localhost.com"
   name        = "name"

--- a/examples/provider/resources/notification_policy.tf
+++ b/examples/provider/resources/notification_policy.tf
@@ -1,4 +1,4 @@
-resource zitadel_notification_policy notification_policy {
+resource "zitadel_notification_policy" "notification_policy" {
   org_id          = zitadel_org.org.id
   password_change = false
 }

--- a/examples/provider/resources/org.tf
+++ b/examples/provider/resources/org.tf
@@ -1,3 +1,3 @@
-resource zitadel_org org {
+resource "zitadel_org" "org" {
   name = "terraform-test"
 }

--- a/examples/provider/resources/org_idp_jwt.tf
+++ b/examples/provider/resources/org_idp_jwt.tf
@@ -1,4 +1,4 @@
-resource zitadel_org_idp_jwt jwt_idp {
+resource "zitadel_org_idp_jwt" "jwt_idp" {
   org_id        = zitadel_org.org.id
   name          = "jwtidp"
   styling_type  = "STYLING_TYPE_UNSPECIFIED"

--- a/examples/provider/resources/org_idp_oidc.tf
+++ b/examples/provider/resources/org_idp_oidc.tf
@@ -1,4 +1,4 @@
-resource zitadel_org_idp_oidc oidc_idp {
+resource "zitadel_org_idp_oidc" "oidc_idp" {
   org_id               = zitadel_org.org.id
   name                 = "oidcidp"
   styling_type         = "STYLING_TYPE_UNSPECIFIED"

--- a/examples/provider/resources/org_member.tf
+++ b/examples/provider/resources/org_member.tf
@@ -1,4 +1,4 @@
-resource zitadel_org_member org_member {
+resource "zitadel_org_member" "org_member" {
   org_id  = zitadel_org.org.id
   user_id = zitadel_human_user.human_user.id
   roles   = ["ORG_OWNER"]

--- a/examples/provider/resources/password_change_message_text.tf
+++ b/examples/provider/resources/password_change_message_text.tf
@@ -1,4 +1,4 @@
-resource zitadel_password_change_message_text password_change_en {
+resource "zitadel_password_change_message_text" "password_change_en" {
   org_id   = zitadel_org.org.id
   language = "en"
 

--- a/examples/provider/resources/password_complexity_policy.tf
+++ b/examples/provider/resources/password_complexity_policy.tf
@@ -1,4 +1,4 @@
-resource zitadel_password_complexity_policy password_complexity_policy {
+resource "zitadel_password_complexity_policy" "password_complexity_policy" {
   org_id        = zitadel_org.org.id
   min_length    = "8"
   has_uppercase = true

--- a/examples/provider/resources/password_reset_message_text.tf
+++ b/examples/provider/resources/password_reset_message_text.tf
@@ -1,4 +1,4 @@
-resource zitadel_password_reset_message_text password_reset_en {
+resource "zitadel_password_reset_message_text" "password_reset_en" {
   org_id   = zitadel_org.org.id
   language = "en"
 

--- a/examples/provider/resources/passwordless_registration_message_text.tf
+++ b/examples/provider/resources/passwordless_registration_message_text.tf
@@ -1,4 +1,4 @@
-resource zitadel_passwordless_registration_message_text passwordless_registration_en {
+resource "zitadel_passwordless_registration_message_text" "passwordless_registration_en" {
   org_id   = zitadel_org.org.id
   language = "en"
 

--- a/examples/provider/resources/personal_access_token.tf
+++ b/examples/provider/resources/personal_access_token.tf
@@ -1,4 +1,4 @@
-resource zitadel_personal_access_token pat {
+resource "zitadel_personal_access_token" "pat" {
   org_id          = zitadel_org.org.id
   user_id         = zitadel_machine_user.machine_user.id
   expiration_date = "2519-04-01T08:45:00Z"

--- a/examples/provider/resources/privacy_policy.tf
+++ b/examples/provider/resources/privacy_policy.tf
@@ -1,4 +1,4 @@
-resource zitadel_privacy_policy privacy_policy {
+resource "zitadel_privacy_policy" "privacy_policy" {
   org_id        = zitadel_org.org.id
   tos_link      = "https://google.com"
   privacy_link  = "https://google.com"

--- a/examples/provider/resources/project.tf
+++ b/examples/provider/resources/project.tf
@@ -1,4 +1,4 @@
-resource zitadel_project project {
+resource "zitadel_project" "project" {
   name                     = "projectname"
   org_id                   = zitadel_org.org.id
   project_role_assertion   = true

--- a/examples/provider/resources/project_grant.tf
+++ b/examples/provider/resources/project_grant.tf
@@ -1,4 +1,4 @@
-resource zitadel_project_grant project_grant {
+resource "zitadel_project_grant" "project_grant" {
   org_id         = zitadel_org.org.id
   project_id     = zitadel_project.project.id
   granted_org_id = zitadel_org.grantedorg.id

--- a/examples/provider/resources/project_grant_member.tf
+++ b/examples/provider/resources/project_grant_member.tf
@@ -1,4 +1,4 @@
-resource zitadel_project_grant_member project_grant_member {
+resource "zitadel_project_grant_member" "project_grant_member" {
   org_id     = zitadel_org.org.id
   project_id = zitadel_project.project.id
   grant_id   = zitadel_project_grant.project_grant.id

--- a/examples/provider/resources/project_member.tf
+++ b/examples/provider/resources/project_member.tf
@@ -1,4 +1,4 @@
-resource zitadel_project_member project_member {
+resource "zitadel_project_member" "project_member" {
   org_id     = zitadel_org.org.id
   project_id = zitadel_project.project.id
   user_id    = zitadel_human_user.human_user.id

--- a/examples/provider/resources/project_role.tf
+++ b/examples/provider/resources/project_role.tf
@@ -1,4 +1,4 @@
-resource zitadel_project_role project_role {
+resource "zitadel_project_role" "project_role" {
   org_id       = zitadel_org.org.id
   project_id   = zitadel_project.project.id
   role_key     = "key"

--- a/examples/provider/resources/sms_provider_twilio.tf
+++ b/examples/provider/resources/sms_provider_twilio.tf
@@ -1,4 +1,4 @@
-resource zitadel_sms_provider_twilio twilio {
+resource "zitadel_sms_provider_twilio" "twilio" {
   sid           = "sid"
   sender_number = "019920892"
   token         = "token"

--- a/examples/provider/resources/smtp_config.tf
+++ b/examples/provider/resources/smtp_config.tf
@@ -1,4 +1,4 @@
-resource zitadel_smtp_config smtp {
+resource "zitadel_smtp_config" "smtp" {
   sender_address = "address"
   sender_name    = "no-reply"
   tls            = true

--- a/examples/provider/resources/trigger_actions.tf
+++ b/examples/provider/resources/trigger_actions.tf
@@ -1,4 +1,4 @@
-resource zitadel_trigger_actions trigger_actions {
+resource "zitadel_trigger_actions" "trigger_actions" {
   org_id       = zitadel_org.org.id
   flow_type    = "FLOW_TYPE_EXTERNAL_AUTHENTICATION"
   trigger_type = "TRIGGER_TYPE_POST_AUTHENTICATION"

--- a/examples/provider/resources/user_grant.tf
+++ b/examples/provider/resources/user_grant.tf
@@ -1,4 +1,4 @@
-resource zitadel_user_grant user_grant {
+resource "zitadel_user_grant" "user_grant" {
   project_id = zitadel_project.project.id
   org_id     = zitadel_org.org.id
   role_keys  = ["key"]

--- a/examples/provider/resources/verify_email_message_text.tf
+++ b/examples/provider/resources/verify_email_message_text.tf
@@ -1,4 +1,4 @@
-resource zitadel_verify_email_message_text verify_email_en {
+resource "zitadel_verify_email_message_text" "verify_email_en" {
   org_id   = zitadel_org.org.id
   language = "en"
 

--- a/examples/provider/resources/verify_phone_message_text.tf
+++ b/examples/provider/resources/verify_phone_message_text.tf
@@ -1,4 +1,4 @@
-resource zitadel_verify_phone_message_text verify_phone_en {
+resource "zitadel_verify_phone_message_text" "verify_phone_en" {
   org_id   = zitadel_org.org.id
   language = "en"
 

--- a/zitadel/v2/default_privacy_policy/resource_test.go
+++ b/zitadel/v2/default_privacy_policy/resource_test.go
@@ -27,6 +27,7 @@ func TestAccDefaultPrivacyPolicy(t *testing.T) {
 resource "%s" "%s" {
   tos_link     = "https://google.com"
   privacy_link = "https://google.com"
+  support_email = "support@email.com"
   help_link    = "%s"
 }`, resourceName, frame.UniqueResourcesID, configProperty)
 		},

--- a/zitadel/v2/privacy_policy/resource_test.go
+++ b/zitadel/v2/privacy_policy/resource_test.go
@@ -28,6 +28,7 @@ resource "%s" "%s" {
   org_id       = "%s"
   tos_link     = "https://google.com"
   privacy_link = "https://google.com"
+  support_email = "support@email.com"
   help_link    = "%s"
 }`, resourceName, frame.UniqueResourcesID, frame.OrgID, configProperty)
 		},


### PR DESCRIPTION
Replaces #83 

- ran `terraform fmt` on example resources and datasources
- regenerated docs