### PR TITLE
test: datasources name suggestions

### DIFF
--- a/acceptance/docker-compose.yaml
+++ b/acceptance/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
       - ./keys:/keys
       - ./zitadel.yaml:/zitadel.yaml
     healthcheck:
-      test: ['CMD', '/app/zitadel', 'ready']
+      test: ['CMD', '/app/zitadel', 'ready', "--config", "/zitadel.yaml"]
       interval: '2s'
       timeout: '30s'
       retries: 5

--- a/examples/provider/data-sources/application_api.tf
+++ b/examples/provider/data-sources/application_api.tf
@@ -1,5 +1,5 @@
 data "zitadel_application_api" "default" {
-  org_id     = "345678901234567890"
-  project_id = "234567890123456789"
+  org_id     = data.zitadel_org.default.id
+  project_id = data.zitadel_project.default.id
   app_id     = "123456789012345678"
 }

--- a/examples/provider/data-sources/application_apis.tf
+++ b/examples/provider/data-sources/application_apis.tf
@@ -1,6 +1,6 @@
 data "zitadel_application_apis" "default" {
-  org_id      = "123456789012345678"
-  project_id = "234567890123456789"
+  org_id      = data.zitadel_org.default.id
+  project_id  = data.zitadel_project.default.id
   name        = "example-name"
   name_method = "TEXT_QUERY_METHOD_CONTAINS_IGNORE_CASE"
 }

--- a/examples/provider/data-sources/application_oidc.tf
+++ b/examples/provider/data-sources/application_oidc.tf
@@ -1,5 +1,5 @@
 data "zitadel_application_oidc" "default" {
-  org_id     = "345678901234567890"
-  project_id = "234567890123456789"
+  org_id     = data.zitadel_org.default.id
+  project_id = data.zitadel_project.default.id
   app_id     = "123456789012345678"
 }

--- a/examples/provider/data-sources/application_oidcs.tf
+++ b/examples/provider/data-sources/application_oidcs.tf
@@ -1,6 +1,6 @@
 data "zitadel_application_oidcs" "default" {
-  org_id      = "123456789012345678"
-  project_id = "234567890123456789"
+  org_id      = data.zitadel_org.default.id
+  project_id  = data.zitadel_project.default.id
   name        = "example-name"
   name_method = "TEXT_QUERY_METHOD_CONTAINS_IGNORE_CASE"
 }

--- a/examples/provider/data-sources/machine_user.tf
+++ b/examples/provider/data-sources/machine_user.tf
@@ -1,4 +1,4 @@
 data "zitadel_machine_user" "default" {
-  org_id  = "234567890123456789"
+  org_id  = data.zitadel_org.default.id
   user_id = "123456789012345678"
 }

--- a/examples/provider/data-sources/machine_users.tf
+++ b/examples/provider/data-sources/machine_users.tf
@@ -1,5 +1,5 @@
 data "zitadel_machine_users" "default" {
-  org_id           = "123456789012345678"
+  org_id           = data.zitadel_org.default.id
   user_name        = "example-name"
   user_name_method = "TEXT_QUERY_METHOD_CONTAINS_IGNORE_CASE"
 }

--- a/examples/provider/data-sources/project.tf
+++ b/examples/provider/data-sources/project.tf
@@ -1,4 +1,4 @@
 data "zitadel_project" "default" {
-  org_id     = "234567890123456789"
+  org_id     = data.zitadel_org.default.id
   project_id = "123456789012345678"
 }

--- a/examples/provider/data-sources/projects.tf
+++ b/examples/provider/data-sources/projects.tf
@@ -1,5 +1,5 @@
 data "zitadel_projects" "default" {
-  org_id      = "123456789012345678"
+  org_id      = data.zitadel_org.default.id
   name        = "example-name"
   name_method = "TEXT_QUERY_METHOD_CONTAINS_IGNORE_CASE"
 }

--- a/zitadel/application_api/application_api_test_dep/dependency.go
+++ b/zitadel/application_api/application_api_test_dep/dependency.go
@@ -11,7 +11,7 @@ import (
 )
 
 func Create(t *testing.T, frame *test_utils.OrgTestFrame, projectID, name string) (string, string) {
-	return test_utils.CreateProjectDefaultDependency(t, "zitadel_application_api", frame.OrgID, application_api.ProjectIDVar, projectID, application_api.AppIDVar, func() (string, error) {
+	return test_utils.CreateDefaultDependency(t, "zitadel_application_api", application_api.AppIDVar, func() (string, error) {
 		apiApp, err := frame.AddAPIApp(frame, &management.AddAPIAppRequest{
 			ProjectId:      projectID,
 			Name:           name,

--- a/zitadel/application_api/datasource_test.go
+++ b/zitadel/application_api/datasource_test.go
@@ -11,20 +11,24 @@ import (
 
 	"github.com/zitadel/terraform-provider-zitadel/zitadel/application_api"
 	"github.com/zitadel/terraform-provider-zitadel/zitadel/application_api/application_api_test_dep"
-	"github.com/zitadel/terraform-provider-zitadel/zitadel/helper"
 	"github.com/zitadel/terraform-provider-zitadel/zitadel/helper/test_utils"
 	"github.com/zitadel/terraform-provider-zitadel/zitadel/project/project_test_dep"
 )
 
 func TestAccApplicationAPIDatasource_ID(t *testing.T) {
-	frame := test_utils.NewOrgTestFrame(t, "zitadel_application_api")
+	datasourceName := "zitadel_application_api"
+	frame := test_utils.NewOrgTestFrame(t, datasourceName)
+	config, attributes := test_utils.ReadExample(t, test_utils.Datasources, datasourceName)
+	exampleID := test_utils.AttributeValue(t, application_api.AppIDVar, attributes).AsString()
+	projectDep, projectID := project_test_dep.Create(t, frame, frame.UniqueResourcesID)
 	appName := "application_api_datasource_" + frame.UniqueResourcesID
-	_, projectID := project_test_dep.Create(t, frame, frame.UniqueResourcesID)
-	appDep, appID := application_api_test_dep.Create(t, frame, projectID, appName)
+	_, appID := application_api_test_dep.Create(t, frame, projectID, appName)
+	config = strings.Replace(config, exampleID, appID, 1)
 	test_utils.RunDatasourceTest(
 		t,
 		frame.BaseTestFrame,
-		appDep,
+		config,
+		[]string{frame.AsOrgDefaultDependency, projectDep},
 		nil,
 		map[string]string{
 			"org_id":     frame.OrgID,
@@ -40,21 +44,18 @@ func TestAccApplicationAPIsDatasources_ID_Name_Match(t *testing.T) {
 	frame := test_utils.NewOrgTestFrame(t, datasourceName)
 	config, attributes := test_utils.ReadExample(t, test_utils.Datasources, datasourceName)
 	exampleName := test_utils.AttributeValue(t, application_api.NameVar, attributes).AsString()
-	exampleProject := test_utils.AttributeValue(t, application_api.ProjectIDVar, attributes).AsString()
-	exampleOrg := test_utils.AttributeValue(t, helper.OrgIDVar, attributes).AsString()
 	appName := fmt.Sprintf("%s-%s", exampleName, frame.UniqueResourcesID)
 	// for-each is not supported in acceptance tests, so we cut the example down to the first block
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/536
 	config = strings.Join(strings.Split(config, "\n")[0:6], "\n")
 	config = strings.Replace(config, exampleName, appName, 1)
-	config = strings.Replace(config, exampleOrg, frame.OrgID, 1)
-	_, projectID := project_test_dep.Create(t, frame, frame.UniqueResourcesID)
-	config = strings.Replace(config, exampleProject, projectID, 1)
+	projectDep, projectID := project_test_dep.Create(t, frame, frame.UniqueResourcesID)
 	_, appID := application_api_test_dep.Create(t, frame, projectID, appName)
 	test_utils.RunDatasourceTest(
 		t,
 		frame.BaseTestFrame,
 		config,
+		[]string{frame.AsOrgDefaultDependency, projectDep},
 		checkRemoteDatasourceProperty(frame, projectID, appID)(appName),
 		map[string]string{
 			"app_ids.0": appID,
@@ -68,22 +69,19 @@ func TestAccApplicationAPIsDatasources_ID_Name_Mismatch(t *testing.T) {
 	frame := test_utils.NewOrgTestFrame(t, datasourceName)
 	config, attributes := test_utils.ReadExample(t, test_utils.Datasources, datasourceName)
 	exampleName := test_utils.AttributeValue(t, application_api.NameVar, attributes).AsString()
-	exampleProject := test_utils.AttributeValue(t, application_api.ProjectIDVar, attributes).AsString()
-	exampleOrg := test_utils.AttributeValue(t, helper.OrgIDVar, attributes).AsString()
 	appName := fmt.Sprintf("%s-%s", exampleName, frame.UniqueResourcesID)
 	// for-each is not supported in acceptance tests, so we cut the example down to the first block
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/536
 	config = strings.Join(strings.Split(config, "\n")[0:6], "\n")
 	config = strings.Replace(config, exampleName, "mismatch", 1)
-	config = strings.Replace(config, exampleOrg, frame.OrgID, 1)
-	_, projectID := project_test_dep.Create(t, frame, frame.UniqueResourcesID)
-	config = strings.Replace(config, exampleProject, projectID, 1)
-	_, userID := application_api_test_dep.Create(t, frame, projectID, appName)
+	projectDep, projectID := project_test_dep.Create(t, frame, frame.UniqueResourcesID)
+	_, appID := application_api_test_dep.Create(t, frame, projectID, appName)
 	test_utils.RunDatasourceTest(
 		t,
 		frame.BaseTestFrame,
 		config,
-		checkRemoteDatasourceProperty(frame, projectID, userID)(appName),
+		[]string{frame.AsOrgDefaultDependency, projectDep},
+		checkRemoteDatasourceProperty(frame, projectID, appID)(appName),
 		map[string]string{
 			"app_ids.#": "0",
 		},

--- a/zitadel/application_oidc/application_oidc_test_dep/dependency.go
+++ b/zitadel/application_oidc/application_oidc_test_dep/dependency.go
@@ -10,7 +10,7 @@ import (
 )
 
 func Create(t *testing.T, frame *test_utils.OrgTestFrame, projectID, name string) (string, string) {
-	return test_utils.CreateProjectDefaultDependency(t, "zitadel_application_oidc", frame.OrgID, application_oidc.ProjectIDVar, projectID, application_oidc.AppIDVar, func() (string, error) {
+	return test_utils.CreateDefaultDependency(t, "zitadel_application_oidc", application_oidc.AppIDVar, func() (string, error) {
 		oidcApp, err := frame.AddOIDCApp(frame, &management.AddOIDCAppRequest{
 			ProjectId: projectID,
 			Name:      name,

--- a/zitadel/application_oidc/datasource_test.go
+++ b/zitadel/application_oidc/datasource_test.go
@@ -11,20 +11,24 @@ import (
 
 	"github.com/zitadel/terraform-provider-zitadel/zitadel/application_oidc"
 	"github.com/zitadel/terraform-provider-zitadel/zitadel/application_oidc/application_oidc_test_dep"
-	"github.com/zitadel/terraform-provider-zitadel/zitadel/helper"
 	"github.com/zitadel/terraform-provider-zitadel/zitadel/helper/test_utils"
 	"github.com/zitadel/terraform-provider-zitadel/zitadel/project/project_test_dep"
 )
 
 func TestAccApplicationOIDCDatasource_ID(t *testing.T) {
-	frame := test_utils.NewOrgTestFrame(t, "zitadel_application_oidc")
+	datasourceName := "zitadel_application_oidc"
+	frame := test_utils.NewOrgTestFrame(t, datasourceName)
+	config, attributes := test_utils.ReadExample(t, test_utils.Datasources, datasourceName)
+	exampleID := test_utils.AttributeValue(t, application_oidc.AppIDVar, attributes).AsString()
+	projectDep, projectID := project_test_dep.Create(t, frame, frame.UniqueResourcesID)
 	appName := "application_oidc_datasource_" + frame.UniqueResourcesID
-	_, projectID := project_test_dep.Create(t, frame, frame.UniqueResourcesID)
-	appDep, appID := application_oidc_test_dep.Create(t, frame, projectID, appName)
+	_, appID := application_oidc_test_dep.Create(t, frame, projectID, appName)
+	config = strings.Replace(config, exampleID, appID, 1)
 	test_utils.RunDatasourceTest(
 		t,
 		frame.BaseTestFrame,
-		appDep,
+		config,
+		[]string{frame.AsOrgDefaultDependency, projectDep},
 		nil,
 		map[string]string{
 			"org_id":     frame.OrgID,
@@ -40,21 +44,18 @@ func TestAccApplicationOIDCsDatasources_ID_Name_Match(t *testing.T) {
 	frame := test_utils.NewOrgTestFrame(t, datasourceName)
 	config, attributes := test_utils.ReadExample(t, test_utils.Datasources, datasourceName)
 	exampleName := test_utils.AttributeValue(t, application_oidc.NameVar, attributes).AsString()
-	exampleProject := test_utils.AttributeValue(t, application_oidc.ProjectIDVar, attributes).AsString()
-	exampleOrg := test_utils.AttributeValue(t, helper.OrgIDVar, attributes).AsString()
 	appName := fmt.Sprintf("%s-%s", exampleName, frame.UniqueResourcesID)
 	// for-each is not supported in acceptance tests, so we cut the example down to the first block
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/536
 	config = strings.Join(strings.Split(config, "\n")[0:6], "\n")
 	config = strings.Replace(config, exampleName, appName, 1)
-	config = strings.Replace(config, exampleOrg, frame.OrgID, 1)
-	_, projectID := project_test_dep.Create(t, frame, frame.UniqueResourcesID)
-	config = strings.Replace(config, exampleProject, projectID, 1)
+	projectDep, projectID := project_test_dep.Create(t, frame, frame.UniqueResourcesID)
 	_, appID := application_oidc_test_dep.Create(t, frame, projectID, appName)
 	test_utils.RunDatasourceTest(
 		t,
 		frame.BaseTestFrame,
 		config,
+		[]string{frame.AsOrgDefaultDependency, projectDep},
 		checkRemoteDatasourceProperty(frame, projectID, appID)(appName),
 		map[string]string{
 			"app_ids.0": appID,
@@ -68,22 +69,19 @@ func TestAccApplicationOIDCsDatasources_ID_Name_Mismatch(t *testing.T) {
 	frame := test_utils.NewOrgTestFrame(t, datasourceName)
 	config, attributes := test_utils.ReadExample(t, test_utils.Datasources, datasourceName)
 	exampleName := test_utils.AttributeValue(t, application_oidc.NameVar, attributes).AsString()
-	exampleProject := test_utils.AttributeValue(t, application_oidc.ProjectIDVar, attributes).AsString()
-	exampleOrg := test_utils.AttributeValue(t, helper.OrgIDVar, attributes).AsString()
 	appName := fmt.Sprintf("%s-%s", exampleName, frame.UniqueResourcesID)
 	// for-each is not supported in acceptance tests, so we cut the example down to the first block
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/536
 	config = strings.Join(strings.Split(config, "\n")[0:6], "\n")
 	config = strings.Replace(config, exampleName, "mismatch", 1)
-	config = strings.Replace(config, exampleOrg, frame.OrgID, 1)
-	_, projectID := project_test_dep.Create(t, frame, frame.UniqueResourcesID)
-	config = strings.Replace(config, exampleProject, projectID, 1)
-	_, userID := application_oidc_test_dep.Create(t, frame, projectID, appName)
+	projectDep, projectID := project_test_dep.Create(t, frame, frame.UniqueResourcesID)
+	_, appID := application_oidc_test_dep.Create(t, frame, projectID, appName)
 	test_utils.RunDatasourceTest(
 		t,
 		frame.BaseTestFrame,
 		config,
-		checkRemoteDatasourceProperty(frame, projectID, userID)(appName),
+		[]string{frame.AsOrgDefaultDependency, projectDep},
+		checkRemoteDatasourceProperty(frame, projectID, appID)(appName),
 		map[string]string{
 			"app_ids.#": "0",
 		},

--- a/zitadel/helper/test_utils/datasourcetest.go
+++ b/zitadel/helper/test_utils/datasourcetest.go
@@ -2,6 +2,7 @@ package test_utils
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -11,6 +12,7 @@ func RunDatasourceTest(
 	t *testing.T,
 	frame BaseTestFrame,
 	config string,
+	dependencies []string,
 	awaitRemoteResource resource.TestCheckFunc,
 	expectProperties map[string]string,
 ) {
@@ -23,7 +25,7 @@ func RunDatasourceTest(
 	}
 	resource.ParallelTest(t, resource.TestCase{
 		Steps: []resource.TestStep{{
-			Config: fmt.Sprintf("%s\n%s", frame.ProviderSnippet, config),
+			Config: fmt.Sprintf("%s\n%s\n%s", frame.ProviderSnippet, strings.Join(dependencies, "\n"), config),
 			Check:  resource.ComposeAggregateTestCheckFunc(checks...),
 		}},
 		ProtoV6ProviderFactories: frame.v6ProviderFactories,

--- a/zitadel/helper/test_utils/dependency.go
+++ b/zitadel/helper/test_utils/dependency.go
@@ -3,8 +3,6 @@ package test_utils
 import (
 	"strings"
 	"testing"
-
-	"github.com/zitadel/terraform-provider-zitadel/zitadel/helper"
 )
 
 func CreateDefaultDependency(t *testing.T, datasourceType string, idField string, newDependencyID func() (string, error)) (string, string) {
@@ -14,29 +12,4 @@ func CreateDefaultDependency(t *testing.T, datasourceType string, idField string
 		t.Fatalf("failed to create dependency for %s: %v", datasourceType, err)
 	}
 	return strings.Replace(datasourceExample, AttributeValue(t, idField, datasourceExampleAttributes).AsString(), dependencyID, 1), dependencyID
-}
-
-func CreateOrgDefaultDependency(t *testing.T, datasourceType string, orgID string, idField string, newDependencyID func() (string, error)) (string, string) {
-	datasourceExample, datasourceExampleAttributes := ReadExample(t, Datasources, datasourceType)
-	dependencyID, err := newDependencyID()
-	if err != nil {
-		t.Fatalf("failed to create dependency for %s: %v", datasourceType, err)
-	}
-	// org exampleID does always have to be different then the idField value
-	dep := strings.Replace(datasourceExample, AttributeValue(t, idField, datasourceExampleAttributes).AsString(), dependencyID, 1)
-	// replace the exmaple OrgID with the given org
-	return strings.Replace(dep, AttributeValue(t, helper.OrgIDVar, datasourceExampleAttributes).AsString(), orgID, 1), dependencyID
-}
-
-func CreateProjectDefaultDependency(t *testing.T, datasourceType string, orgID string, projectField string, projectID string, idField string, newDependencyID func() (string, error)) (string, string) {
-	datasourceExample, datasourceExampleAttributes := ReadExample(t, Datasources, datasourceType)
-	dependencyID, err := newDependencyID()
-	if err != nil {
-		t.Fatalf("failed to create dependency for %s: %v", datasourceType, err)
-	}
-	// org exampleID does always have to be different then the idField value
-	dep := strings.Replace(datasourceExample, AttributeValue(t, idField, datasourceExampleAttributes).AsString(), dependencyID, 1)
-	dep = strings.Replace(dep, AttributeValue(t, projectField, datasourceExampleAttributes).AsString(), projectID, 1)
-	// replace the exmaple OrgID with the given org
-	return strings.Replace(dep, AttributeValue(t, helper.OrgIDVar, datasourceExampleAttributes).AsString(), orgID, 1), dependencyID
 }

--- a/zitadel/machine_user/machine_user_test_dep/dependency.go
+++ b/zitadel/machine_user/machine_user_test_dep/dependency.go
@@ -10,7 +10,7 @@ import (
 )
 
 func Create(t *testing.T, frame *test_utils.OrgTestFrame, username string) (string, string) {
-	return test_utils.CreateOrgDefaultDependency(t, "zitadel_machine_user", frame.OrgID, machine_user.UserIDVar, func() (string, error) {
+	return test_utils.CreateDefaultDependency(t, "zitadel_machine_user", machine_user.UserIDVar, func() (string, error) {
 		user, err := frame.AddMachineUser(frame, &management.AddMachineUserRequest{
 			UserName: username,
 			Name:     "Don't care",

--- a/zitadel/org/datasource_test.go
+++ b/zitadel/org/datasource_test.go
@@ -12,13 +12,18 @@ import (
 )
 
 func TestAccOrgDatasource_ID(t *testing.T) {
-	frame := test_utils.NewOrgTestFrame(t, "zitadel_org")
+	datasourceName := "zitadel_org"
+	frame := test_utils.NewOrgTestFrame(t, datasourceName)
+	config, attributes := test_utils.ReadExample(t, test_utils.Datasources, datasourceName)
+	exampleID := test_utils.AttributeValue(t, org.OrgIDVar, attributes).AsString()
 	orgName := "org_datasource_" + frame.UniqueResourcesID
 	otherFrame := frame.AnotherOrg(t, orgName)
+	config = strings.Replace(config, exampleID, otherFrame.OrgID, 1)
 	test_utils.RunDatasourceTest(
 		t,
 		otherFrame.BaseTestFrame,
-		otherFrame.AsOrgDefaultDependency,
+		config,
+		nil,
 		nil,
 		map[string]string{
 			"id":    otherFrame.OrgID,
@@ -45,6 +50,7 @@ func TestAccOrgsDatasources_ID_Name_Match(t *testing.T) {
 		t,
 		otherFrame.BaseTestFrame,
 		config,
+		nil,
 		checkRemoteProperty(otherFrame, idFromFrame(otherFrame))(orgName),
 		map[string]string{
 			"ids.0": otherFrame.OrgID,
@@ -63,6 +69,7 @@ func TestAccOrgsDatasources_ID_Name_Mismatch(t *testing.T) {
 		t,
 		otherFrame.BaseTestFrame,
 		config,
+		nil,
 		checkRemoteProperty(otherFrame, idFromFrame(otherFrame))(orgName),
 		map[string]string{"ids.#": "0"},
 	)

--- a/zitadel/project/datasource_test.go
+++ b/zitadel/project/datasource_test.go
@@ -9,20 +9,24 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/zitadel/zitadel-go/v2/pkg/client/zitadel/management"
 
-	"github.com/zitadel/terraform-provider-zitadel/zitadel/helper"
 	"github.com/zitadel/terraform-provider-zitadel/zitadel/helper/test_utils"
 	"github.com/zitadel/terraform-provider-zitadel/zitadel/project"
 	"github.com/zitadel/terraform-provider-zitadel/zitadel/project/project_test_dep"
 )
 
 func TestAccProjectDatasource_ID(t *testing.T) {
-	frame := test_utils.NewOrgTestFrame(t, "zitadel_project")
+	datasourceName := "zitadel_project"
+	frame := test_utils.NewOrgTestFrame(t, datasourceName)
+	config, attributes := test_utils.ReadExample(t, test_utils.Datasources, datasourceName)
+	exampleID := test_utils.AttributeValue(t, project.ProjectIDVar, attributes).AsString()
 	projectName := "project_datasource_" + frame.UniqueResourcesID
-	projectDep, projectID := project_test_dep.Create(t, frame, projectName)
+	_, projectID := project_test_dep.Create(t, frame, projectName)
+	config = strings.Replace(config, exampleID, projectID, 1)
 	test_utils.RunDatasourceTest(
 		t,
 		frame.BaseTestFrame,
-		projectDep,
+		config,
+		[]string{frame.AsOrgDefaultDependency},
 		nil,
 		map[string]string{
 			"org_id":     frame.OrgID,
@@ -37,18 +41,17 @@ func TestAccProjectsDatasources_ID_Name_Match(t *testing.T) {
 	frame := test_utils.NewOrgTestFrame(t, datasourceName)
 	config, attributes := test_utils.ReadExample(t, test_utils.Datasources, datasourceName)
 	exampleName := test_utils.AttributeValue(t, project.NameVar, attributes).AsString()
-	exampleOrg := test_utils.AttributeValue(t, helper.OrgIDVar, attributes).AsString()
 	projectName := fmt.Sprintf("%s-%s", exampleName, frame.UniqueResourcesID)
 	// for-each is not supported in acceptance tests, so we cut the example down to the first block
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/536
 	config = strings.Join(strings.Split(config, "\n")[0:5], "\n")
 	config = strings.Replace(config, exampleName, projectName, 1)
-	config = strings.Replace(config, exampleOrg, frame.OrgID, 1)
 	_, projectID := project_test_dep.Create(t, frame, projectName)
 	test_utils.RunDatasourceTest(
 		t,
 		frame.BaseTestFrame,
 		config,
+		[]string{frame.AsOrgDefaultDependency},
 		checkRemoteDatasourceProperty(frame, projectID)(projectName),
 		map[string]string{
 			"project_ids.0": projectID,
@@ -62,18 +65,17 @@ func TestAccProjectsDatasources_ID_Name_Mismatch(t *testing.T) {
 	frame := test_utils.NewOrgTestFrame(t, datasourceName)
 	config, attributes := test_utils.ReadExample(t, test_utils.Datasources, datasourceName)
 	exampleName := test_utils.AttributeValue(t, project.NameVar, attributes).AsString()
-	exampleOrg := test_utils.AttributeValue(t, helper.OrgIDVar, attributes).AsString()
 	projectName := fmt.Sprintf("%s-%s", exampleName, frame.UniqueResourcesID)
 	// for-each is not supported in acceptance tests, so we cut the example down to the first block
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/536
 	config = strings.Join(strings.Split(config, "\n")[0:5], "\n")
 	config = strings.Replace(config, exampleName, "mismatch", 1)
-	config = strings.Replace(config, exampleOrg, frame.OrgID, 1)
 	_, projectID := project_test_dep.Create(t, frame, projectName)
 	test_utils.RunDatasourceTest(
 		t,
 		frame.BaseTestFrame,
 		config,
+		[]string{frame.AsOrgDefaultDependency},
 		checkRemoteDatasourceProperty(frame, projectID)(projectName),
 		map[string]string{
 			"project_ids.#": "0",

--- a/zitadel/project/project_test_dep/dependency.go
+++ b/zitadel/project/project_test_dep/dependency.go
@@ -10,9 +10,8 @@ import (
 )
 
 func Create(t *testing.T, frame *test_utils.OrgTestFrame, name string) (string, string) {
-	return test_utils.CreateOrgDefaultDependency(t,
+	return test_utils.CreateDefaultDependency(t,
 		"zitadel_project",
-		frame.OrgID,
 		project.ProjectIDVar,
 		func() (string, error) {
 			p, err := frame.AddProject(frame, &management.AddProjectRequest{Name: name})


### PR DESCRIPTION
- Tests singular datasource (Get requests) with example files
- Reuses configs created with dep instead of replacing substrings in examples
- Reduces logic for creating dependencies
- Contains changes from https://github.com/zitadel/terraform-provider-zitadel/pull/148

### Definition of Ready

- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] All non-functional requirements are met
- [ ] The generic lifecycle acceptance test passes for affected resources.
- [ ] Examples are up-to-date and meaningful. The provider version is incremented.
- [ ] Docs are generated.
- [ ] Code is generated where possible.
