### PR TITLE
fix: Zitadel provider fails to upload images using resource "zitadel_label_policy" #152

### DIFF
--- a/zitadel/helper/client.go
+++ b/zitadel/helper/client.go
@@ -41,7 +41,7 @@ func GetClientInfo(insecure bool, domain string, token string, jwtProfileFile st
 		keyPath = token
 	} else if jwtProfileFile != "" {
 		options = append(options, zitadel.WithJWTProfileTokenSource(middleware.JWTProfileFromPath(jwtProfileFile)))
-		keyPath = token
+		keyPath = jwtProfileFile
 	} else if jwtProfileJSON != "" {
 		options = append(options, zitadel.WithJWTProfileTokenSource(middleware.JWTProfileFromFileData([]byte(jwtProfileJSON))))
 	} else {


### PR DESCRIPTION
This pull request refers to the issue #152 (Zitadel provider fails to upload images using resource "zitadel_label_policy")
### Definition of Ready

- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story ( https://github.com/zitadel/terraform-provider-zitadel/issues/152 )
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [ ] All non-functional requirements are met
- [ ] The generic lifecycle acceptance test passes for affected resources.
- [ ] Examples are up-to-date and meaningful. The provider version is incremented.
- [ ] Docs are generated.
- [ ] Code is generated where possible.
