### PR TITLE
docs: fix markdown for import code snippets

### DIFF
--- a/docs/resources/action.md
+++ b/docs/resources/action.md
@@ -42,7 +42,7 @@ resource "zitadel_action" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<id[:org_id]>`, e.g.
 terraform import action.imported '123456789012345678:123456789012345678'
 ```

--- a/docs/resources/application_api.md
+++ b/docs/resources/application_api.md
@@ -41,7 +41,7 @@ resource "zitadel_application_api" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<id:project_id[:org_id][:client_id][:client_secret]>`, e.g.
 terraform import application_api.imported '123456789012345678:123456789012345678:123456789012345678:123456789012345678@zitadel:JuaDFFeOak5DGE655KCYPSAclSkbMVEJXXuX1lEMBT14eLMSs0A0qhafKX5SA2Df'
 ```

--- a/docs/resources/application_key.md
+++ b/docs/resources/application_key.md
@@ -42,7 +42,7 @@ resource "zitadel_application_key" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<id:project_id:app_id[:org_id][:key_details]>`.
 # You can use __SEMICOLON__ to escape :, e.g.
 terraform import application_key.imported "123456789012345678:123456789012345678:123456789012345678:123456789012345678:$(cat ~/Downloads/123456789012345678.json | sed -e 's/:/__SEMICOLON__/g')"

--- a/docs/resources/application_oidc.md
+++ b/docs/resources/application_oidc.md
@@ -68,7 +68,7 @@ resource "zitadel_application_oidc" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<id:project_id[:org_id][:client_id][:client_secret]>`, e.g.
 terraform import application_oidc.imported '123456789012345678:123456789012345678:123456789012345678:123456789012345678@zitadel:JuaDFFeOak5DGE655KCYPSAclSkbMVEJXXuX1lEMBT14eLMSs0A0qhafKX5SA2Df'
 ```

--- a/docs/resources/application_saml.md
+++ b/docs/resources/application_saml.md
@@ -39,7 +39,7 @@ resource "zitadel_application_saml" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<id:project_id[:org_id]>`, e.g.
 terraform import application_saml.imported '123456789012345678:123456789012345678:123456789012345678'
 ```

--- a/docs/resources/default_domain_policy.md
+++ b/docs/resources/default_domain_policy.md
@@ -35,7 +35,7 @@ resource "zitadel_default_domain_policy" "default" {
 ## Import
 
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<>`, e.g.
 terraform import default_domain_policy.imported ''
 ```

--- a/docs/resources/default_label_policy.md
+++ b/docs/resources/default_label_policy.md
@@ -79,7 +79,7 @@ resource "zitadel_default_label_policy" "default" {
 ## Import
 
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<>`, e.g.
 terraform import default_label_policy.imported ''
 ```

--- a/docs/resources/default_lockout_policy.md
+++ b/docs/resources/default_lockout_policy.md
@@ -31,7 +31,7 @@ resource "zitadel_default_lockout_policy" "default" {
 ## Import
 
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<>`, e.g.
 terraform import default_lockout_policy.imported ''
 ```

--- a/docs/resources/default_login_policy.md
+++ b/docs/resources/default_login_policy.md
@@ -72,7 +72,7 @@ resource "zitadel_default_login_policy" "default" {
 ## Import
 
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<>`, e.g.
 terraform import default_login_policy.imported ''
 ```

--- a/docs/resources/default_notification_policy.md
+++ b/docs/resources/default_notification_policy.md
@@ -31,7 +31,7 @@ resource "zitadel_default_notification_policy" "default" {
 ## Import
 
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<>`, e.g.
 terraform import default_notification_policy.imported ''
 ```

--- a/docs/resources/default_password_complexity_policy.md
+++ b/docs/resources/default_password_complexity_policy.md
@@ -39,7 +39,7 @@ resource "zitadel_default_password_complexity_policy" "default" {
 ## Import
 
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<>`, e.g.
 terraform import default_password_complexity_policy.imported ''
 ```

--- a/docs/resources/default_privacy_policy.md
+++ b/docs/resources/default_privacy_policy.md
@@ -36,7 +36,7 @@ resource "zitadel_default_privacy_policy" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<>`, e.g.
 terraform import default_privacy_policy.imported ''
 ```

--- a/docs/resources/domain.md
+++ b/docs/resources/domain.md
@@ -39,7 +39,7 @@ resource "zitadel_domain" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `name[:org_id]`, e.g.
 terraform import domain.imported 'example.com:123456789012345678'
 ```

--- a/docs/resources/domain_policy.md
+++ b/docs/resources/domain_policy.md
@@ -39,7 +39,7 @@ resource "zitadel_domain_policy" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<[org_id]>`, e.g.
 terraform import domain_policy.imported '123456789012345678'
 ```

--- a/docs/resources/human_user.md
+++ b/docs/resources/human_user.md
@@ -62,7 +62,7 @@ resource "zitadel_human_user" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `id[:org_id][:initial_password]>`, e.g.
 terraform import human_user.imported '123456789012345678:123456789012345678:Password1!'
 ```

--- a/docs/resources/idp_azure_ad.md
+++ b/docs/resources/idp_azure_ad.md
@@ -52,7 +52,7 @@ resource "zitadel_idp_azure_ad" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<id[:client_secret]>`, e.g.
 terraform import idp_azure_ad.imported '123456789012345678:12345678-1234-1234-1234-123456789012'
 ```

--- a/docs/resources/idp_github.md
+++ b/docs/resources/idp_github.md
@@ -47,7 +47,7 @@ resource "zitadel_idp_github" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<id[:client_secret]>`, e.g.
 terraform import idp_github.imported '123456789012345678:1234567890123456781234567890123456787890'
 ```

--- a/docs/resources/idp_github_es.md
+++ b/docs/resources/idp_github_es.md
@@ -53,7 +53,7 @@ resource "zitadel_idp_github_es" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<id[:client_secret]>`, e.g.
 terraform import idp_github_es.imported '123456789012345678:1234567890123456781234567890123456787890'
 ```

--- a/docs/resources/idp_gitlab.md
+++ b/docs/resources/idp_gitlab.md
@@ -47,7 +47,7 @@ resource "zitadel_idp_gitlab" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<id[:client_secret]>`, e.g.
 terraform import idp_gitlab.imported '123456789012345678:1234567890abcdef'
 ```

--- a/docs/resources/idp_gitlab_self_hosted.md
+++ b/docs/resources/idp_gitlab_self_hosted.md
@@ -49,7 +49,7 @@ resource "zitadel_idp_gitlab_self_hosted" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<id[:client_secret]>`, e.g.
 terraform import idp_gitlab_self_hosted.imported '123456789012345678:1234567890abcdef'
 ```

--- a/docs/resources/idp_google.md
+++ b/docs/resources/idp_google.md
@@ -47,7 +47,7 @@ resource "zitadel_idp_google" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<id[:client_secret]>`, e.g.
 terraform import idp_google.imported '123456789012345678:G1234567890123'
 ```

--- a/docs/resources/idp_ldap.md
+++ b/docs/resources/idp_ldap.md
@@ -75,7 +75,7 @@ resource "zitadel_idp_ldap" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<id[:bind_password]>`, e.g.
 terraform import idp_ldap.imported '123456789012345678:b1nd_p4ssw0rd'
 ```

--- a/docs/resources/instance_member.md
+++ b/docs/resources/instance_member.md
@@ -32,7 +32,7 @@ resource "zitadel_instance_member" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<user_id>`, e.g.
 terraform import instance_member.imported '123456789012345678'
 ```

--- a/docs/resources/label_policy.md
+++ b/docs/resources/label_policy.md
@@ -80,7 +80,7 @@ resource "zitadel_label_policy" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<[org_id]>`, e.g.
 terraform import label_policy.imported '123456789012345678'
 ```

--- a/docs/resources/lockout_policy.md
+++ b/docs/resources/lockout_policy.md
@@ -35,7 +35,7 @@ resource "zitadel_lockout_policy" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<[org_id]>`, e.g.
 terraform import lockout_policy.imported '123456789012345678'
 ```

--- a/docs/resources/login_policy.md
+++ b/docs/resources/login_policy.md
@@ -73,7 +73,7 @@ resource "zitadel_login_policy" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<[org_id]>`, e.g.
 terraform import login_policy.imported '123456789012345678'
 ```

--- a/docs/resources/machine_key.md
+++ b/docs/resources/machine_key.md
@@ -40,7 +40,7 @@ resource "zitadel_machine_key" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<id:user_id[:org_id][:key_details]>`, e.g.
 terraform import machine_key.imported '123456789012345678:123456789012345678:123456789012345678:{"type":"serviceaccount","keyId":"123456789012345678","key":"-----BEGIN RSA PRIVATE KEY-----\nMIIEpQ...-----END RSA PRIVATE KEY-----\n","userId":"123456789012345678"}'
 ```

--- a/docs/resources/machine_user.md
+++ b/docs/resources/machine_user.md
@@ -47,7 +47,7 @@ resource "zitadel_machine_user" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<id:has_secret[:org_id][:client_id][:client_secret]>`, e.g.
 terraform import machine_user.imported '123456789012345678:123456789012345678:true:my-machine-user:j76mh34CHVrGGoXPQOg80lch67FIxwc2qIXjBkZoB6oMbf31eGMkB6bvRyaPjR2t'
 ```

--- a/docs/resources/notification_policy.md
+++ b/docs/resources/notification_policy.md
@@ -35,7 +35,7 @@ resource "zitadel_notification_policy" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<[org_id]>`, e.g.
 terraform import notification_policy.imported '123456789012345678'
 ```

--- a/docs/resources/org.md
+++ b/docs/resources/org.md
@@ -36,7 +36,7 @@ resource "zitadel_org" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<id>`, e.g.
 terraform import org.imported '123456789012345678'
 ```

--- a/docs/resources/org_idp_azure_ad.md
+++ b/docs/resources/org_idp_azure_ad.md
@@ -54,7 +54,7 @@ resource "zitadel_org_idp_azure_ad" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<id[:org_id][:client_secret]>`, e.g.
 terraform import org_idp_azure_ad.imported '123456789012345678:123456789012345678:12345678-1234-1234-1234-123456789012'
 ```

--- a/docs/resources/org_idp_github.md
+++ b/docs/resources/org_idp_github.md
@@ -49,7 +49,7 @@ resource "zitadel_org_idp_github" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<id[:org_id][:client_secret]>`, e.g.
 terraform import org_idp_github.imported '123456789012345678:123456789012345678:1234567890123456781234567890123456787890'
 ```

--- a/docs/resources/org_idp_github_es.md
+++ b/docs/resources/org_idp_github_es.md
@@ -55,7 +55,7 @@ resource "zitadel_org_idp_github_es" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<id[:org_id][:client_secret]>`, e.g.
 terraform import org_idp_github_es.imported '123456789012345678:123456789012345678:123456789012345678:123456789012345678'
 ```

--- a/docs/resources/org_idp_gitlab.md
+++ b/docs/resources/org_idp_gitlab.md
@@ -49,7 +49,7 @@ resource "zitadel_org_idp_gitlab" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<id[:org_id][:client_secret]>`, e.g.
 terraform import org_idp_gitlab.imported '123456789012345678:123456789012345678:1234567890abcdef'
 ```

--- a/docs/resources/org_idp_gitlab_self_hosted.md
+++ b/docs/resources/org_idp_gitlab_self_hosted.md
@@ -51,7 +51,7 @@ resource "zitadel_org_idp_gitlab_self_hosted" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<id[:org_id][:client_secret]>`, e.g.
 terraform import org_idp_gitlab_self_hosted.imported '123456789012345678:123456789012345678:1234567890abcdef'
 ```

--- a/docs/resources/org_idp_google.md
+++ b/docs/resources/org_idp_google.md
@@ -49,7 +49,7 @@ resource "zitadel_org_idp_google" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<id[:org_id][:client_secret]>`, e.g.
 terraform import org_idp_google.imported '123456789012345678:123456789012345678:G1234567890123'
 ```

--- a/docs/resources/org_idp_jwt.md
+++ b/docs/resources/org_idp_jwt.md
@@ -47,7 +47,7 @@ resource "zitadel_org_idp_jwt" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<id[:org_id]>`, e.g.
 terraform import org_idp_jwt.imported '123456789012345678:123456789012345678'
 ```

--- a/docs/resources/org_idp_ldap.md
+++ b/docs/resources/org_idp_ldap.md
@@ -77,7 +77,7 @@ resource "zitadel_org_idp_ldap" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<id[:org_id][:bind_password]>`, e.g.
 terraform import org_idp_ldap.imported '123456789012345678:123456789012345678:b1nd_p4ssw0rd'
 ```

--- a/docs/resources/org_idp_oidc.md
+++ b/docs/resources/org_idp_oidc.md
@@ -53,7 +53,7 @@ resource "zitadel_org_idp_oidc" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<id[:org_id][:client_secret]>`, e.g.
 terraform import org_idp_oidc.imported '123456789012345678:123456789012345678:1234567890abcdef'
 ```

--- a/docs/resources/org_member.md
+++ b/docs/resources/org_member.md
@@ -37,7 +37,7 @@ resource "zitadel_org_member" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<user_id[:org_id]>`, e.g.
 terraform import org_member.imported '123456789012345678:123456789012345678'
 ```

--- a/docs/resources/personal_access_token.md
+++ b/docs/resources/personal_access_token.md
@@ -38,7 +38,7 @@ resource "zitadel_personal_access_token" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<id:user_id[:org_id][:token]>`, e.g.
 terraform import personal_access_token.imported '123456789012345678:123456789012345678:123456789012345678:LHt79...'
 ```

--- a/docs/resources/privacy_policy.md
+++ b/docs/resources/privacy_policy.md
@@ -38,7 +38,7 @@ resource "zitadel_privacy_policy" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<[org_id]>`, e.g.
 terraform import privacy_policy.imported '123456789012345678'
 ```

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -44,7 +44,7 @@ resource "zitadel_project" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<id[:org_id]>`, e.g.
 terraform import project.imported '123456789012345678:123456789012345678'
 ```

--- a/docs/resources/project_grant.md
+++ b/docs/resources/project_grant.md
@@ -39,7 +39,7 @@ resource "zitadel_project_grant" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<id:project_id[:org_id]>`, e.g.
 terraform import project_grant.imported '123456789012345678:123456789012345678:123456789012345678'
 ```

--- a/docs/resources/project_grant_member.md
+++ b/docs/resources/project_grant_member.md
@@ -41,7 +41,7 @@ resource "zitadel_project_grant_member" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<project_id:grant_id:user_id[:org_id]>`, e.g.
 terraform import project_grant_member.imported '123456789012345678:123456789012345678:123456789012345678:123456789012345678'
 ```

--- a/docs/resources/project_member.md
+++ b/docs/resources/project_member.md
@@ -39,7 +39,7 @@ resource "zitadel_project_member" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<project_id:user_id[:org_id]>`, e.g.
 terraform import project_member.imported '123456789012345678:123456789012345678:123456789012345678'
 ```

--- a/docs/resources/project_role.md
+++ b/docs/resources/project_role.md
@@ -41,7 +41,7 @@ resource "zitadel_project_role" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<project_id:role_key[:org_id]>`, e.g.
 terraform import project_role.imported '123456789012345678:my-role-key:123456789012345678'
 ```

--- a/docs/resources/sms_provider_twilio.md
+++ b/docs/resources/sms_provider_twilio.md
@@ -34,7 +34,7 @@ resource "zitadel_sms_provider_twilio" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<id[:token]>`, e.g.
 terraform import sms_provider_twilio.imported '123456789012345678:12345678901234567890123456abcdef'
 ```

--- a/docs/resources/smtp_config.md
+++ b/docs/resources/smtp_config.md
@@ -45,7 +45,7 @@ resource "zitadel_smtp_config" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<[password]>`, e.g.
 terraform import smtp_config.imported 'p4ssw0rd'
 ```

--- a/docs/resources/trigger_actions.md
+++ b/docs/resources/trigger_actions.md
@@ -39,7 +39,7 @@ resource "zitadel_trigger_actions" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<flow_type:trigger_type[:org_id]>`, e.g.
 terraform import trigger_actions.imported 'FLOW_TYPE_EXTERNAL_AUTHENTICATION:TRIGGER_TYPE_POST_CREATION:123456789012345678'
 ```

--- a/docs/resources/user_grant.md
+++ b/docs/resources/user_grant.md
@@ -40,7 +40,7 @@ resource "zitadel_user_grant" "default" {
 
 ## Import
 
-```terraform
+```bash
 # The resource can be imported using the ID format `<flow_type:trigger_type[:org_id]>`, e.g.
 terraform import user_grant.imported '123456789012345678:123456789012345678:123456789012345678'
 ```

--- a/templates/resources/action.md.tmpl
+++ b/templates/resources/action.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/action-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/action-import.sh" }}

--- a/templates/resources/application_api.md.tmpl
+++ b/templates/resources/application_api.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/application_api-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/application_api-import.sh" }}

--- a/templates/resources/application_key.md.tmpl
+++ b/templates/resources/application_key.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/application_key-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/application_key-import.sh" }}

--- a/templates/resources/application_oidc.md.tmpl
+++ b/templates/resources/application_oidc.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/application_oidc-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/application_oidc-import.sh" }}

--- a/templates/resources/application_saml.md.tmpl
+++ b/templates/resources/application_saml.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/application_saml-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/application_saml-import.sh" }}

--- a/templates/resources/default_domain_policy.md.tmpl
+++ b/templates/resources/default_domain_policy.md.tmpl
@@ -18,4 +18,4 @@ description: |-
 ## Import
 
 
-{{ tffile "examples/provider/resources/default_domain_policy-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/default_domain_policy-import.sh" }}

--- a/templates/resources/default_label_policy.md.tmpl
+++ b/templates/resources/default_label_policy.md.tmpl
@@ -18,4 +18,4 @@ description: |-
 ## Import
 
 
-{{ tffile "examples/provider/resources/default_label_policy-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/default_label_policy-import.sh" }}

--- a/templates/resources/default_lockout_policy.md.tmpl
+++ b/templates/resources/default_lockout_policy.md.tmpl
@@ -18,4 +18,4 @@ description: |-
 ## Import
 
 
-{{ tffile "examples/provider/resources/default_lockout_policy-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/default_lockout_policy-import.sh" }}

--- a/templates/resources/default_login_policy.md.tmpl
+++ b/templates/resources/default_login_policy.md.tmpl
@@ -18,4 +18,4 @@ description: |-
 ## Import
 
 
-{{ tffile "examples/provider/resources/default_login_policy-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/default_login_policy-import.sh" }}

--- a/templates/resources/default_notification_policy.md.tmpl
+++ b/templates/resources/default_notification_policy.md.tmpl
@@ -18,4 +18,4 @@ description: |-
 ## Import
 
 
-{{ tffile "examples/provider/resources/default_notification_policy-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/default_notification_policy-import.sh" }}

--- a/templates/resources/default_password_complexity_policy.md.tmpl
+++ b/templates/resources/default_password_complexity_policy.md.tmpl
@@ -18,4 +18,4 @@ description: |-
 ## Import
 
 
-{{ tffile "examples/provider/resources/default_password_complexity_policy-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/default_password_complexity_policy-import.sh" }}

--- a/templates/resources/default_privacy_policy.md.tmpl
+++ b/templates/resources/default_privacy_policy.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/default_privacy_policy-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/default_privacy_policy-import.sh" }}

--- a/templates/resources/domain.md.tmpl
+++ b/templates/resources/domain.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/domain-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/domain-import.sh" }}

--- a/templates/resources/domain_policy.md.tmpl
+++ b/templates/resources/domain_policy.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/domain_policy-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/domain_policy-import.sh" }}

--- a/templates/resources/human_user.md.tmpl
+++ b/templates/resources/human_user.md.tmpl
@@ -19,4 +19,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/human_user-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/human_user-import.sh" }}

--- a/templates/resources/idp_azure_ad.md.tmpl
+++ b/templates/resources/idp_azure_ad.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/idp_azure_ad-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/idp_azure_ad-import.sh" }}

--- a/templates/resources/idp_github.md.tmpl
+++ b/templates/resources/idp_github.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/idp_github-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/idp_github-import.sh" }}

--- a/templates/resources/idp_github_es.md.tmpl
+++ b/templates/resources/idp_github_es.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/idp_github_es-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/idp_github_es-import.sh" }}

--- a/templates/resources/idp_gitlab.md.tmpl
+++ b/templates/resources/idp_gitlab.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/idp_gitlab-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/idp_gitlab-import.sh" }}

--- a/templates/resources/idp_gitlab_self_hosted.md.tmpl
+++ b/templates/resources/idp_gitlab_self_hosted.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/idp_gitlab_self_hosted-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/idp_gitlab_self_hosted-import.sh" }}

--- a/templates/resources/idp_google.md.tmpl
+++ b/templates/resources/idp_google.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/idp_google-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/idp_google-import.sh" }}

--- a/templates/resources/idp_ldap.md.tmpl
+++ b/templates/resources/idp_ldap.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/idp_ldap-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/idp_ldap-import.sh" }}

--- a/templates/resources/instance_member.md.tmpl
+++ b/templates/resources/instance_member.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/instance_member-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/instance_member-import.sh" }}

--- a/templates/resources/label_policy.md.tmpl
+++ b/templates/resources/label_policy.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/label_policy-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/label_policy-import.sh" }}

--- a/templates/resources/lockout_policy.md.tmpl
+++ b/templates/resources/lockout_policy.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/lockout_policy-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/lockout_policy-import.sh" }}

--- a/templates/resources/login_policy.md.tmpl
+++ b/templates/resources/login_policy.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/login_policy-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/login_policy-import.sh" }}

--- a/templates/resources/machine_key.md.tmpl
+++ b/templates/resources/machine_key.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/machine_key-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/machine_key-import.sh" }}

--- a/templates/resources/machine_user.md.tmpl
+++ b/templates/resources/machine_user.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/machine_user-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/machine_user-import.sh" }}

--- a/templates/resources/notification_policy.md.tmpl
+++ b/templates/resources/notification_policy.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/notification_policy-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/notification_policy-import.sh" }}

--- a/templates/resources/org.md.tmpl
+++ b/templates/resources/org.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/org-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/org-import.sh" }}

--- a/templates/resources/org_idp_azure_ad.md.tmpl
+++ b/templates/resources/org_idp_azure_ad.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/org_idp_azure_ad-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/org_idp_azure_ad-import.sh" }}

--- a/templates/resources/org_idp_github.md.tmpl
+++ b/templates/resources/org_idp_github.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/org_idp_github-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/org_idp_github-import.sh" }}

--- a/templates/resources/org_idp_github_es.md.tmpl
+++ b/templates/resources/org_idp_github_es.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/org_idp_github_es-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/org_idp_github_es-import.sh" }}

--- a/templates/resources/org_idp_gitlab.md.tmpl
+++ b/templates/resources/org_idp_gitlab.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/org_idp_gitlab-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/org_idp_gitlab-import.sh" }}

--- a/templates/resources/org_idp_gitlab_self_hosted.md.tmpl
+++ b/templates/resources/org_idp_gitlab_self_hosted.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/org_idp_gitlab_self_hosted-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/org_idp_gitlab_self_hosted-import.sh" }}

--- a/templates/resources/org_idp_google.md.tmpl
+++ b/templates/resources/org_idp_google.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/org_idp_google-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/org_idp_google-import.sh" }}

--- a/templates/resources/org_idp_jwt.md.tmpl
+++ b/templates/resources/org_idp_jwt.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/org_idp_jwt-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/org_idp_jwt-import.sh" }}

--- a/templates/resources/org_idp_ldap.md.tmpl
+++ b/templates/resources/org_idp_ldap.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/org_idp_ldap-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/org_idp_ldap-import.sh" }}

--- a/templates/resources/org_idp_oidc.md.tmpl
+++ b/templates/resources/org_idp_oidc.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/org_idp_oidc-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/org_idp_oidc-import.sh" }}

--- a/templates/resources/org_member.md.tmpl
+++ b/templates/resources/org_member.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/org_member-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/org_member-import.sh" }}

--- a/templates/resources/personal_access_token.md.tmpl
+++ b/templates/resources/personal_access_token.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/personal_access_token-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/personal_access_token-import.sh" }}

--- a/templates/resources/privacy_policy.md.tmpl
+++ b/templates/resources/privacy_policy.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/privacy_policy-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/privacy_policy-import.sh" }}

--- a/templates/resources/project.md.tmpl
+++ b/templates/resources/project.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/project-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/project-import.sh" }}

--- a/templates/resources/project_grant.md.tmpl
+++ b/templates/resources/project_grant.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/project_grant-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/project_grant-import.sh" }}

--- a/templates/resources/project_grant_member.md.tmpl
+++ b/templates/resources/project_grant_member.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/project_grant_member-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/project_grant_member-import.sh" }}

--- a/templates/resources/project_member.md.tmpl
+++ b/templates/resources/project_member.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/project_member-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/project_member-import.sh" }}

--- a/templates/resources/project_role.md.tmpl
+++ b/templates/resources/project_role.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/project_role-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/project_role-import.sh" }}

--- a/templates/resources/sms_provider_twilio.md.tmpl
+++ b/templates/resources/sms_provider_twilio.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/sms_provider_twilio-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/sms_provider_twilio-import.sh" }}

--- a/templates/resources/smtp_config.md.tmpl
+++ b/templates/resources/smtp_config.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/smtp_config-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/smtp_config-import.sh" }}

--- a/templates/resources/trigger_actions.md.tmpl
+++ b/templates/resources/trigger_actions.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/trigger_actions-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/trigger_actions-import.sh" }}

--- a/templates/resources/user_grant.md.tmpl
+++ b/templates/resources/user_grant.md.tmpl
@@ -17,4 +17,4 @@ description: |-
 
 ## Import
 
-{{ tffile "examples/provider/resources/user_grant-import.sh" }}
+{{ codefile "bash" "examples/provider/resources/user_grant-import.sh" }}


### PR DESCRIPTION
Uses `codefile "bash"` in templates for import commands, so that the templates render \`\`\`bash codeblocks instead of \`\`\`terraform codeblocks

### Definition of Ready

- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] All non-functional requirements are met
- [ ] The generic lifecycle acceptance test passes for affected resources.
- [ ] Examples are up-to-date and meaningful. The provider version is incremented.
- [ ] Docs are generated.
- [ ] Code is generated where possible.
