### PR TITLE
fix(docs): fix import commands

### DIFF
--- a/examples/provider/resources/action-import.sh
+++ b/examples/provider/resources/action-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<id[:org_id]>`, e.g.
-terraform import action.imported '123456789012345678:123456789012345678'
+terraform import zitadel_action.imported '123456789012345678:123456789012345678'

--- a/examples/provider/resources/application_api-import.sh
+++ b/examples/provider/resources/application_api-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<id:project_id[:org_id][:client_id][:client_secret]>`, e.g.
-terraform import application_api.imported '123456789012345678:123456789012345678:123456789012345678:123456789012345678@zitadel:JuaDFFeOak5DGE655KCYPSAclSkbMVEJXXuX1lEMBT14eLMSs0A0qhafKX5SA2Df'
+terraform import zitadel_application_api.imported '123456789012345678:123456789012345678:123456789012345678:123456789012345678@zitadel:JuaDFFeOak5DGE655KCYPSAclSkbMVEJXXuX1lEMBT14eLMSs0A0qhafKX5SA2Df'

--- a/examples/provider/resources/application_key-import.sh
+++ b/examples/provider/resources/application_key-import.sh
@@ -1,3 +1,3 @@
 # The resource can be imported using the ID format `<id:project_id:app_id[:org_id][:key_details]>`.
 # You can use __SEMICOLON__ to escape :, e.g.
-terraform import application_key.imported "123456789012345678:123456789012345678:123456789012345678:123456789012345678:$(cat ~/Downloads/123456789012345678.json | sed -e 's/:/__SEMICOLON__/g')"
+terraform import zitadel_application_key.imported "123456789012345678:123456789012345678:123456789012345678:123456789012345678:$(cat ~/Downloads/123456789012345678.json | sed -e 's/:/__SEMICOLON__/g')"

--- a/examples/provider/resources/application_oidc-import.sh
+++ b/examples/provider/resources/application_oidc-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<id:project_id[:org_id][:client_id][:client_secret]>`, e.g.
-terraform import application_oidc.imported '123456789012345678:123456789012345678:123456789012345678:123456789012345678@zitadel:JuaDFFeOak5DGE655KCYPSAclSkbMVEJXXuX1lEMBT14eLMSs0A0qhafKX5SA2Df'
+terraform import zitadel_application_oidc.imported '123456789012345678:123456789012345678:123456789012345678:123456789012345678@zitadel:JuaDFFeOak5DGE655KCYPSAclSkbMVEJXXuX1lEMBT14eLMSs0A0qhafKX5SA2Df'

--- a/examples/provider/resources/application_saml-import.sh
+++ b/examples/provider/resources/application_saml-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<id:project_id[:org_id]>`, e.g.
-terraform import application_saml.imported '123456789012345678:123456789012345678:123456789012345678'
+terraform import zitadel_application_saml.imported '123456789012345678:123456789012345678:123456789012345678'

--- a/examples/provider/resources/default_domain_policy-import.sh
+++ b/examples/provider/resources/default_domain_policy-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<>`, e.g.
-terraform import default_domain_policy.imported ''
+terraform import zitadel_default_domain_policy.imported ''

--- a/examples/provider/resources/default_label_policy-import.sh
+++ b/examples/provider/resources/default_label_policy-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<>`, e.g.
-terraform import default_label_policy.imported ''
+terraform import zitadel_default_label_policy.imported ''

--- a/examples/provider/resources/default_lockout_policy-import.sh
+++ b/examples/provider/resources/default_lockout_policy-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<>`, e.g.
-terraform import default_lockout_policy.imported ''
+terraform import zitadel_default_lockout_policy.imported ''

--- a/examples/provider/resources/default_login_policy-import.sh
+++ b/examples/provider/resources/default_login_policy-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<>`, e.g.
-terraform import default_login_policy.imported ''
+terraform import zitadel_default_login_policy.imported ''

--- a/examples/provider/resources/default_notification_policy-import.sh
+++ b/examples/provider/resources/default_notification_policy-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<>`, e.g.
-terraform import default_notification_policy.imported ''
+terraform import zitadel_default_notification_policy.imported ''

--- a/examples/provider/resources/default_password_complexity_policy-import.sh
+++ b/examples/provider/resources/default_password_complexity_policy-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<>`, e.g.
-terraform import default_password_complexity_policy.imported ''
+terraform import zitadel_default_password_complexity_policy.imported ''

--- a/examples/provider/resources/default_privacy_policy-import.sh
+++ b/examples/provider/resources/default_privacy_policy-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<>`, e.g.
-terraform import default_privacy_policy.imported ''
+terraform import zitadel_default_privacy_policy.imported ''

--- a/examples/provider/resources/domain-import.sh
+++ b/examples/provider/resources/domain-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `name[:org_id]`, e.g.
-terraform import domain.imported 'example.com:123456789012345678'
+terraform import zitadel_domain.imported 'example.com:123456789012345678'

--- a/examples/provider/resources/domain_policy-import.sh
+++ b/examples/provider/resources/domain_policy-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<[org_id]>`, e.g.
-terraform import domain_policy.imported '123456789012345678'
+terraform import zitadel_domain_policy.imported '123456789012345678'

--- a/examples/provider/resources/human_user-import.sh
+++ b/examples/provider/resources/human_user-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `id[:org_id][:initial_password]>`, e.g.
-terraform import human_user.imported '123456789012345678:123456789012345678:Password1!'
+terraform import zitadel_human_user.imported '123456789012345678:123456789012345678:Password1!'

--- a/examples/provider/resources/idp_azure_ad-import.sh
+++ b/examples/provider/resources/idp_azure_ad-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<id[:client_secret]>`, e.g.
-terraform import idp_azure_ad.imported '123456789012345678:12345678-1234-1234-1234-123456789012'
+terraform import zitadel_idp_azure_ad.imported '123456789012345678:12345678-1234-1234-1234-123456789012'

--- a/examples/provider/resources/idp_github-import.sh
+++ b/examples/provider/resources/idp_github-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<id[:client_secret]>`, e.g.
-terraform import idp_github.imported '123456789012345678:1234567890123456781234567890123456787890'
+terraform import zitadel_idp_github.imported '123456789012345678:1234567890123456781234567890123456787890'

--- a/examples/provider/resources/idp_github_es-import.sh
+++ b/examples/provider/resources/idp_github_es-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<id[:client_secret]>`, e.g.
-terraform import idp_github_es.imported '123456789012345678:1234567890123456781234567890123456787890'
+terraform import zitadel_idp_github_es.imported '123456789012345678:1234567890123456781234567890123456787890'

--- a/examples/provider/resources/idp_gitlab-import.sh
+++ b/examples/provider/resources/idp_gitlab-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<id[:client_secret]>`, e.g.
-terraform import idp_gitlab.imported '123456789012345678:1234567890abcdef'
+terraform import zitadel_idp_gitlab.imported '123456789012345678:1234567890abcdef'

--- a/examples/provider/resources/idp_gitlab_self_hosted-import.sh
+++ b/examples/provider/resources/idp_gitlab_self_hosted-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<id[:client_secret]>`, e.g.
-terraform import idp_gitlab_self_hosted.imported '123456789012345678:1234567890abcdef'
+terraform import zitadel_idp_gitlab_self_hosted.imported '123456789012345678:1234567890abcdef'

--- a/examples/provider/resources/idp_google-import.sh
+++ b/examples/provider/resources/idp_google-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<id[:client_secret]>`, e.g.
-terraform import idp_google.imported '123456789012345678:G1234567890123'
+terraform import zitadel_idp_google.imported '123456789012345678:G1234567890123'

--- a/examples/provider/resources/idp_ldap-import.sh
+++ b/examples/provider/resources/idp_ldap-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<id[:bind_password]>`, e.g.
-terraform import idp_ldap.imported '123456789012345678:b1nd_p4ssw0rd'
+terraform import zitadel_idp_ldap.imported '123456789012345678:b1nd_p4ssw0rd'

--- a/examples/provider/resources/instance_member-import.sh
+++ b/examples/provider/resources/instance_member-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<user_id>`, e.g.
-terraform import instance_member.imported '123456789012345678'
+terraform import zitadel_instance_member.imported '123456789012345678'

--- a/examples/provider/resources/label_policy-import.sh
+++ b/examples/provider/resources/label_policy-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<[org_id]>`, e.g.
-terraform import label_policy.imported '123456789012345678'
+terraform import zitadel_label_policy.imported '123456789012345678'

--- a/examples/provider/resources/lockout_policy-import.sh
+++ b/examples/provider/resources/lockout_policy-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<[org_id]>`, e.g.
-terraform import lockout_policy.imported '123456789012345678'
+terraform import zitadel_lockout_policy.imported '123456789012345678'

--- a/examples/provider/resources/login_policy-import.sh
+++ b/examples/provider/resources/login_policy-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<[org_id]>`, e.g.
-terraform import login_policy.imported '123456789012345678'
+terraform import zitadel_login_policy.imported '123456789012345678'

--- a/examples/provider/resources/machine_key-import.sh
+++ b/examples/provider/resources/machine_key-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<id:user_id[:org_id][:key_details]>`, e.g.
-terraform import machine_key.imported '123456789012345678:123456789012345678:123456789012345678:{"type":"serviceaccount","keyId":"123456789012345678","key":"-----BEGIN RSA PRIVATE KEY-----\nMIIEpQ...-----END RSA PRIVATE KEY-----\n","userId":"123456789012345678"}'
+terraform import zitadel_machine_key.imported '123456789012345678:123456789012345678:123456789012345678:{"type":"serviceaccount","keyId":"123456789012345678","key":"-----BEGIN RSA PRIVATE KEY-----\nMIIEpQ...-----END RSA PRIVATE KEY-----\n","userId":"123456789012345678"}'

--- a/examples/provider/resources/machine_user-import.sh
+++ b/examples/provider/resources/machine_user-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<id:has_secret[:org_id][:client_id][:client_secret]>`, e.g.
-terraform import machine_user.imported '123456789012345678:123456789012345678:true:my-machine-user:j76mh34CHVrGGoXPQOg80lch67FIxwc2qIXjBkZoB6oMbf31eGMkB6bvRyaPjR2t'
+terraform import zitadel_machine_user.imported '123456789012345678:123456789012345678:true:my-machine-user:j76mh34CHVrGGoXPQOg80lch67FIxwc2qIXjBkZoB6oMbf31eGMkB6bvRyaPjR2t'

--- a/examples/provider/resources/notification_policy-import.sh
+++ b/examples/provider/resources/notification_policy-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<[org_id]>`, e.g.
-terraform import notification_policy.imported '123456789012345678'
+terraform import zitadel_notification_policy.imported '123456789012345678'

--- a/examples/provider/resources/org-import.sh
+++ b/examples/provider/resources/org-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<id>`, e.g.
-terraform import org.imported '123456789012345678'
+terraform import zitadel_org.imported '123456789012345678'

--- a/examples/provider/resources/org_idp_azure_ad-import.sh
+++ b/examples/provider/resources/org_idp_azure_ad-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<id[:org_id][:client_secret]>`, e.g.
-terraform import org_idp_azure_ad.imported '123456789012345678:123456789012345678:12345678-1234-1234-1234-123456789012'
+terraform import zitadel_org_idp_azure_ad.imported '123456789012345678:123456789012345678:12345678-1234-1234-1234-123456789012'

--- a/examples/provider/resources/org_idp_github-import.sh
+++ b/examples/provider/resources/org_idp_github-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<id[:org_id][:client_secret]>`, e.g.
-terraform import org_idp_github.imported '123456789012345678:123456789012345678:1234567890123456781234567890123456787890'
+terraform import zitadel_org_idp_github.imported '123456789012345678:123456789012345678:1234567890123456781234567890123456787890'

--- a/examples/provider/resources/org_idp_github_es-import.sh
+++ b/examples/provider/resources/org_idp_github_es-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<id[:org_id][:client_secret]>`, e.g.
-terraform import org_idp_github_es.imported '123456789012345678:123456789012345678:123456789012345678:123456789012345678'
+terraform import zitadel_org_idp_github_es.imported '123456789012345678:123456789012345678:123456789012345678:123456789012345678'

--- a/examples/provider/resources/org_idp_gitlab-import.sh
+++ b/examples/provider/resources/org_idp_gitlab-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<id[:org_id][:client_secret]>`, e.g.
-terraform import org_idp_gitlab.imported '123456789012345678:123456789012345678:1234567890abcdef'
+terraform import zitadel_org_idp_gitlab.imported '123456789012345678:123456789012345678:1234567890abcdef'

--- a/examples/provider/resources/org_idp_gitlab_self_hosted-import.sh
+++ b/examples/provider/resources/org_idp_gitlab_self_hosted-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<id[:org_id][:client_secret]>`, e.g.
-terraform import org_idp_gitlab_self_hosted.imported '123456789012345678:123456789012345678:1234567890abcdef'
+terraform import zitadel_org_idp_gitlab_self_hosted.imported '123456789012345678:123456789012345678:1234567890abcdef'

--- a/examples/provider/resources/org_idp_google-import.sh
+++ b/examples/provider/resources/org_idp_google-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<id[:org_id][:client_secret]>`, e.g.
-terraform import org_idp_google.imported '123456789012345678:123456789012345678:G1234567890123'
+terraform import zitadel_org_idp_google.imported '123456789012345678:123456789012345678:G1234567890123'

--- a/examples/provider/resources/org_idp_jwt-import.sh
+++ b/examples/provider/resources/org_idp_jwt-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<id[:org_id]>`, e.g.
-terraform import org_idp_jwt.imported '123456789012345678:123456789012345678'
+terraform import zitadel_org_idp_jwt.imported '123456789012345678:123456789012345678'

--- a/examples/provider/resources/org_idp_ldap-import.sh
+++ b/examples/provider/resources/org_idp_ldap-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<id[:org_id][:bind_password]>`, e.g.
-terraform import org_idp_ldap.imported '123456789012345678:123456789012345678:b1nd_p4ssw0rd'
+terraform import zitadel_org_idp_ldap.imported '123456789012345678:123456789012345678:b1nd_p4ssw0rd'

--- a/examples/provider/resources/org_idp_oidc-import.sh
+++ b/examples/provider/resources/org_idp_oidc-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<id[:org_id][:client_secret]>`, e.g.
-terraform import org_idp_oidc.imported '123456789012345678:123456789012345678:1234567890abcdef'
+terraform import zitadel_org_idp_oidc.imported '123456789012345678:123456789012345678:1234567890abcdef'

--- a/examples/provider/resources/org_member-import.sh
+++ b/examples/provider/resources/org_member-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<user_id[:org_id]>`, e.g.
-terraform import org_member.imported '123456789012345678:123456789012345678'
+terraform import zitadel_org_member.imported '123456789012345678:123456789012345678'

--- a/examples/provider/resources/personal_access_token-import.sh
+++ b/examples/provider/resources/personal_access_token-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<id:user_id[:org_id][:token]>`, e.g.
-terraform import personal_access_token.imported '123456789012345678:123456789012345678:123456789012345678:LHt79...'
+terraform import zitadel_personal_access_token.imported '123456789012345678:123456789012345678:123456789012345678:LHt79...'

--- a/examples/provider/resources/privacy_policy-import.sh
+++ b/examples/provider/resources/privacy_policy-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<[org_id]>`, e.g.
-terraform import privacy_policy.imported '123456789012345678'
+terraform import zitadel_privacy_policy.imported '123456789012345678'

--- a/examples/provider/resources/project-import.sh
+++ b/examples/provider/resources/project-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<id[:org_id]>`, e.g.
-terraform import project.imported '123456789012345678:123456789012345678'
+terraform import zitadel_project.imported '123456789012345678:123456789012345678'

--- a/examples/provider/resources/project_grant-import.sh
+++ b/examples/provider/resources/project_grant-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<id:project_id[:org_id]>`, e.g.
-terraform import project_grant.imported '123456789012345678:123456789012345678:123456789012345678'
+terraform import zitadel_project_grant.imported '123456789012345678:123456789012345678:123456789012345678'

--- a/examples/provider/resources/project_grant_member-import.sh
+++ b/examples/provider/resources/project_grant_member-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<project_id:grant_id:user_id[:org_id]>`, e.g.
-terraform import project_grant_member.imported '123456789012345678:123456789012345678:123456789012345678:123456789012345678'
+terraform import zitadel_project_grant_member.imported '123456789012345678:123456789012345678:123456789012345678:123456789012345678'

--- a/examples/provider/resources/project_member-import.sh
+++ b/examples/provider/resources/project_member-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<project_id:user_id[:org_id]>`, e.g.
-terraform import project_member.imported '123456789012345678:123456789012345678:123456789012345678'
+terraform import zitadel_project_member.imported '123456789012345678:123456789012345678:123456789012345678'

--- a/examples/provider/resources/project_role-import.sh
+++ b/examples/provider/resources/project_role-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<project_id:role_key[:org_id]>`, e.g.
-terraform import project_role.imported '123456789012345678:my-role-key:123456789012345678'
+terraform import zitadel_project_role.imported '123456789012345678:my-role-key:123456789012345678'

--- a/examples/provider/resources/sms_provider_twilio-import.sh
+++ b/examples/provider/resources/sms_provider_twilio-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<id[:token]>`, e.g.
-terraform import sms_provider_twilio.imported '123456789012345678:12345678901234567890123456abcdef'
+terraform import zitadel_sms_provider_twilio.imported '123456789012345678:12345678901234567890123456abcdef'

--- a/examples/provider/resources/smtp_config-import.sh
+++ b/examples/provider/resources/smtp_config-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<[password]>`, e.g.
-terraform import smtp_config.imported 'p4ssw0rd'
+terraform import zitadel_smtp_config.imported 'p4ssw0rd'

--- a/examples/provider/resources/trigger_actions-import.sh
+++ b/examples/provider/resources/trigger_actions-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<flow_type:trigger_type[:org_id]>`, e.g.
-terraform import trigger_actions.imported 'FLOW_TYPE_EXTERNAL_AUTHENTICATION:TRIGGER_TYPE_POST_CREATION:123456789012345678'
+terraform import zitadel_trigger_actions.imported 'FLOW_TYPE_EXTERNAL_AUTHENTICATION:TRIGGER_TYPE_POST_CREATION:123456789012345678'

--- a/examples/provider/resources/user_grant-import.sh
+++ b/examples/provider/resources/user_grant-import.sh
@@ -1,2 +1,2 @@
 # The resource can be imported using the ID format `<flow_type:trigger_type[:org_id]>`, e.g.
-terraform import user_grant.imported '123456789012345678:123456789012345678:123456789012345678'
+terraform import zitadel_user_grant.imported '123456789012345678:123456789012345678:123456789012345678'


### PR DESCRIPTION
All resources are prefixed with zitadel_. Importing without this prefix doesn't work. This PR prepends the prefix in the import commands.

### Definition of Ready

- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] All non-functional requirements are met
- [ ] The generic lifecycle acceptance test passes for affected resources.
- [ ] Examples are up-to-date and meaningful. The provider version is incremented.
- [ ] Docs are generated.
- [ ] Code is generated where possible.
