### PR TITLE
feat: support theme mode

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ terraform {
   required_providers {
     zitadel = {
       source  = "zitadel/zitadel"
-      version = "1.1.0"
+      version = "1.2.0"
     }
   }
 }

--- a/docs/resources/action.md
+++ b/docs/resources/action.md
@@ -44,5 +44,5 @@ resource "zitadel_action" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<id[:org_id]>`, e.g.
-terraform import action.imported '123456789012345678:123456789012345678'
+terraform import zitadel_action.imported '123456789012345678:123456789012345678'
 ```

--- a/docs/resources/application_api.md
+++ b/docs/resources/application_api.md
@@ -43,5 +43,5 @@ resource "zitadel_application_api" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<id:project_id[:org_id][:client_id][:client_secret]>`, e.g.
-terraform import application_api.imported '123456789012345678:123456789012345678:123456789012345678:123456789012345678@zitadel:JuaDFFeOak5DGE655KCYPSAclSkbMVEJXXuX1lEMBT14eLMSs0A0qhafKX5SA2Df'
+terraform import zitadel_application_api.imported '123456789012345678:123456789012345678:123456789012345678:123456789012345678@zitadel:JuaDFFeOak5DGE655KCYPSAclSkbMVEJXXuX1lEMBT14eLMSs0A0qhafKX5SA2Df'
 ```

--- a/docs/resources/application_key.md
+++ b/docs/resources/application_key.md
@@ -45,5 +45,5 @@ resource "zitadel_application_key" "default" {
 ```bash
 # The resource can be imported using the ID format `<id:project_id:app_id[:org_id][:key_details]>`.
 # You can use __SEMICOLON__ to escape :, e.g.
-terraform import application_key.imported "123456789012345678:123456789012345678:123456789012345678:123456789012345678:$(cat ~/Downloads/123456789012345678.json | sed -e 's/:/__SEMICOLON__/g')"
+terraform import zitadel_application_key.imported "123456789012345678:123456789012345678:123456789012345678:123456789012345678:$(cat ~/Downloads/123456789012345678.json | sed -e 's/:/__SEMICOLON__/g')"
 ```

--- a/docs/resources/application_oidc.md
+++ b/docs/resources/application_oidc.md
@@ -70,5 +70,5 @@ resource "zitadel_application_oidc" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<id:project_id[:org_id][:client_id][:client_secret]>`, e.g.
-terraform import application_oidc.imported '123456789012345678:123456789012345678:123456789012345678:123456789012345678@zitadel:JuaDFFeOak5DGE655KCYPSAclSkbMVEJXXuX1lEMBT14eLMSs0A0qhafKX5SA2Df'
+terraform import zitadel_application_oidc.imported '123456789012345678:123456789012345678:123456789012345678:123456789012345678@zitadel:JuaDFFeOak5DGE655KCYPSAclSkbMVEJXXuX1lEMBT14eLMSs0A0qhafKX5SA2Df'
 ```

--- a/docs/resources/application_saml.md
+++ b/docs/resources/application_saml.md
@@ -41,5 +41,5 @@ resource "zitadel_application_saml" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<id:project_id[:org_id]>`, e.g.
-terraform import application_saml.imported '123456789012345678:123456789012345678:123456789012345678'
+terraform import zitadel_application_saml.imported '123456789012345678:123456789012345678:123456789012345678'
 ```

--- a/docs/resources/default_domain_policy.md
+++ b/docs/resources/default_domain_policy.md
@@ -37,5 +37,5 @@ resource "zitadel_default_domain_policy" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<>`, e.g.
-terraform import default_domain_policy.imported ''
+terraform import zitadel_default_domain_policy.imported ''
 ```

--- a/docs/resources/default_label_policy.md
+++ b/docs/resources/default_label_policy.md
@@ -34,6 +34,7 @@ resource "zitadel_default_label_policy" "default" {
   icon_dark_path         = "/path/to/icon_dark.jpg"
   font_hash              = filemd5("/path/to/font.tff")
   font_path              = "/path/to/font.tff"
+  theme_mode             = "THEME_MODE_DARK"
 }
 ```
 
@@ -66,6 +67,7 @@ resource "zitadel_default_label_policy" "default" {
 - `logo_hash` (String)
 - `logo_path` (String)
 - `set_active` (Boolean) set the label policy active after creating/updating
+- `theme_mode` (String) theme mode, supported values: THEME_MODE_UNSPECIFIED, THEME_MODE_AUTO, THEME_MODE_DARK, THEME_MODE_LIGHT
 
 ### Read-Only
 
@@ -81,5 +83,5 @@ resource "zitadel_default_label_policy" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<>`, e.g.
-terraform import default_label_policy.imported ''
+terraform import zitadel_default_label_policy.imported ''
 ```

--- a/docs/resources/default_lockout_policy.md
+++ b/docs/resources/default_lockout_policy.md
@@ -33,5 +33,5 @@ resource "zitadel_default_lockout_policy" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<>`, e.g.
-terraform import default_lockout_policy.imported ''
+terraform import zitadel_default_lockout_policy.imported ''
 ```

--- a/docs/resources/default_login_policy.md
+++ b/docs/resources/default_login_policy.md
@@ -74,5 +74,5 @@ resource "zitadel_default_login_policy" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<>`, e.g.
-terraform import default_login_policy.imported ''
+terraform import zitadel_default_login_policy.imported ''
 ```

--- a/docs/resources/default_notification_policy.md
+++ b/docs/resources/default_notification_policy.md
@@ -33,5 +33,5 @@ resource "zitadel_default_notification_policy" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<>`, e.g.
-terraform import default_notification_policy.imported ''
+terraform import zitadel_default_notification_policy.imported ''
 ```

--- a/docs/resources/default_password_complexity_policy.md
+++ b/docs/resources/default_password_complexity_policy.md
@@ -41,5 +41,5 @@ resource "zitadel_default_password_complexity_policy" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<>`, e.g.
-terraform import default_password_complexity_policy.imported ''
+terraform import zitadel_default_password_complexity_policy.imported ''
 ```

--- a/docs/resources/default_privacy_policy.md
+++ b/docs/resources/default_privacy_policy.md
@@ -38,5 +38,5 @@ resource "zitadel_default_privacy_policy" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<>`, e.g.
-terraform import default_privacy_policy.imported ''
+terraform import zitadel_default_privacy_policy.imported ''
 ```

--- a/docs/resources/default_verify_phone_message_text.md
+++ b/docs/resources/default_verify_phone_message_text.md
@@ -15,7 +15,7 @@ description: |-
 resource "zitadel_default_verify_phone_message_text" "default" {
   language = "en"
 
-  text        = "text example"
+  text = "text example"
 }
 ```
 

--- a/docs/resources/default_verify_sms_otp_message_text.md
+++ b/docs/resources/default_verify_sms_otp_message_text.md
@@ -15,7 +15,7 @@ description: |-
 resource "zitadel_default_verify_sms_otp_message_text" "default" {
   language = "en"
 
-  text        = "text example"
+  text = "text example"
 }
 ```
 

--- a/docs/resources/domain.md
+++ b/docs/resources/domain.md
@@ -41,5 +41,5 @@ resource "zitadel_domain" "default" {
 
 ```bash
 # The resource can be imported using the ID format `name[:org_id]`, e.g.
-terraform import domain.imported 'example.com:123456789012345678'
+terraform import zitadel_domain.imported 'example.com:123456789012345678'
 ```

--- a/docs/resources/domain_policy.md
+++ b/docs/resources/domain_policy.md
@@ -41,5 +41,5 @@ resource "zitadel_domain_policy" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<[org_id]>`, e.g.
-terraform import domain_policy.imported '123456789012345678'
+terraform import zitadel_domain_policy.imported '123456789012345678'
 ```

--- a/docs/resources/human_user.md
+++ b/docs/resources/human_user.md
@@ -64,5 +64,5 @@ resource "zitadel_human_user" "default" {
 
 ```bash
 # The resource can be imported using the ID format `id[:org_id][:initial_password]>`, e.g.
-terraform import human_user.imported '123456789012345678:123456789012345678:Password1!'
+terraform import zitadel_human_user.imported '123456789012345678:123456789012345678:Password1!'
 ```

--- a/docs/resources/idp_azure_ad.md
+++ b/docs/resources/idp_azure_ad.md
@@ -54,5 +54,5 @@ resource "zitadel_idp_azure_ad" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<id[:client_secret]>`, e.g.
-terraform import idp_azure_ad.imported '123456789012345678:12345678-1234-1234-1234-123456789012'
+terraform import zitadel_idp_azure_ad.imported '123456789012345678:12345678-1234-1234-1234-123456789012'
 ```

--- a/docs/resources/idp_github.md
+++ b/docs/resources/idp_github.md
@@ -49,5 +49,5 @@ resource "zitadel_idp_github" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<id[:client_secret]>`, e.g.
-terraform import idp_github.imported '123456789012345678:1234567890123456781234567890123456787890'
+terraform import zitadel_idp_github.imported '123456789012345678:1234567890123456781234567890123456787890'
 ```

--- a/docs/resources/idp_github_es.md
+++ b/docs/resources/idp_github_es.md
@@ -55,5 +55,5 @@ resource "zitadel_idp_github_es" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<id[:client_secret]>`, e.g.
-terraform import idp_github_es.imported '123456789012345678:1234567890123456781234567890123456787890'
+terraform import zitadel_idp_github_es.imported '123456789012345678:1234567890123456781234567890123456787890'
 ```

--- a/docs/resources/idp_gitlab.md
+++ b/docs/resources/idp_gitlab.md
@@ -49,5 +49,5 @@ resource "zitadel_idp_gitlab" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<id[:client_secret]>`, e.g.
-terraform import idp_gitlab.imported '123456789012345678:1234567890abcdef'
+terraform import zitadel_idp_gitlab.imported '123456789012345678:1234567890abcdef'
 ```

--- a/docs/resources/idp_gitlab_self_hosted.md
+++ b/docs/resources/idp_gitlab_self_hosted.md
@@ -51,5 +51,5 @@ resource "zitadel_idp_gitlab_self_hosted" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<id[:client_secret]>`, e.g.
-terraform import idp_gitlab_self_hosted.imported '123456789012345678:1234567890abcdef'
+terraform import zitadel_idp_gitlab_self_hosted.imported '123456789012345678:1234567890abcdef'
 ```

--- a/docs/resources/idp_google.md
+++ b/docs/resources/idp_google.md
@@ -49,5 +49,5 @@ resource "zitadel_idp_google" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<id[:client_secret]>`, e.g.
-terraform import idp_google.imported '123456789012345678:G1234567890123'
+terraform import zitadel_idp_google.imported '123456789012345678:G1234567890123'
 ```

--- a/docs/resources/idp_ldap.md
+++ b/docs/resources/idp_ldap.md
@@ -77,5 +77,5 @@ resource "zitadel_idp_ldap" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<id[:bind_password]>`, e.g.
-terraform import idp_ldap.imported '123456789012345678:b1nd_p4ssw0rd'
+terraform import zitadel_idp_ldap.imported '123456789012345678:b1nd_p4ssw0rd'
 ```

--- a/docs/resources/instance_member.md
+++ b/docs/resources/instance_member.md
@@ -34,5 +34,5 @@ resource "zitadel_instance_member" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<user_id>`, e.g.
-terraform import instance_member.imported '123456789012345678'
+terraform import zitadel_instance_member.imported '123456789012345678'
 ```

--- a/docs/resources/label_policy.md
+++ b/docs/resources/label_policy.md
@@ -35,6 +35,7 @@ resource "zitadel_label_policy" "default" {
   icon_dark_path         = "/path/to/icon_dark.jpg"
   font_hash              = filemd5("/path/to/font.tff")
   font_path              = "/path/to/font.tff"
+  theme_mode             = "THEME_MODE_DARK"
 }
 ```
 
@@ -68,6 +69,7 @@ resource "zitadel_label_policy" "default" {
 - `logo_path` (String)
 - `org_id` (String) ID of the organization
 - `set_active` (Boolean) set the label policy active after creating/updating
+- `theme_mode` (String) theme mode, supported values: THEME_MODE_UNSPECIFIED, THEME_MODE_AUTO, THEME_MODE_DARK, THEME_MODE_LIGHT
 
 ### Read-Only
 
@@ -82,5 +84,5 @@ resource "zitadel_label_policy" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<[org_id]>`, e.g.
-terraform import label_policy.imported '123456789012345678'
+terraform import zitadel_label_policy.imported '123456789012345678'
 ```

--- a/docs/resources/lockout_policy.md
+++ b/docs/resources/lockout_policy.md
@@ -37,5 +37,5 @@ resource "zitadel_lockout_policy" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<[org_id]>`, e.g.
-terraform import lockout_policy.imported '123456789012345678'
+terraform import zitadel_lockout_policy.imported '123456789012345678'
 ```

--- a/docs/resources/login_policy.md
+++ b/docs/resources/login_policy.md
@@ -75,5 +75,5 @@ resource "zitadel_login_policy" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<[org_id]>`, e.g.
-terraform import login_policy.imported '123456789012345678'
+terraform import zitadel_login_policy.imported '123456789012345678'
 ```

--- a/docs/resources/machine_key.md
+++ b/docs/resources/machine_key.md
@@ -42,5 +42,5 @@ resource "zitadel_machine_key" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<id:user_id[:org_id][:key_details]>`, e.g.
-terraform import machine_key.imported '123456789012345678:123456789012345678:123456789012345678:{"type":"serviceaccount","keyId":"123456789012345678","key":"-----BEGIN RSA PRIVATE KEY-----\nMIIEpQ...-----END RSA PRIVATE KEY-----\n","userId":"123456789012345678"}'
+terraform import zitadel_machine_key.imported '123456789012345678:123456789012345678:123456789012345678:{"type":"serviceaccount","keyId":"123456789012345678","key":"-----BEGIN RSA PRIVATE KEY-----\nMIIEpQ...-----END RSA PRIVATE KEY-----\n","userId":"123456789012345678"}'
 ```

--- a/docs/resources/machine_user.md
+++ b/docs/resources/machine_user.md
@@ -49,5 +49,5 @@ resource "zitadel_machine_user" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<id:has_secret[:org_id][:client_id][:client_secret]>`, e.g.
-terraform import machine_user.imported '123456789012345678:123456789012345678:true:my-machine-user:j76mh34CHVrGGoXPQOg80lch67FIxwc2qIXjBkZoB6oMbf31eGMkB6bvRyaPjR2t'
+terraform import zitadel_machine_user.imported '123456789012345678:123456789012345678:true:my-machine-user:j76mh34CHVrGGoXPQOg80lch67FIxwc2qIXjBkZoB6oMbf31eGMkB6bvRyaPjR2t'
 ```

--- a/docs/resources/notification_policy.md
+++ b/docs/resources/notification_policy.md
@@ -37,5 +37,5 @@ resource "zitadel_notification_policy" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<[org_id]>`, e.g.
-terraform import notification_policy.imported '123456789012345678'
+terraform import zitadel_notification_policy.imported '123456789012345678'
 ```

--- a/docs/resources/org.md
+++ b/docs/resources/org.md
@@ -38,5 +38,5 @@ resource "zitadel_org" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<id>`, e.g.
-terraform import org.imported '123456789012345678'
+terraform import zitadel_org.imported '123456789012345678'
 ```

--- a/docs/resources/org_idp_azure_ad.md
+++ b/docs/resources/org_idp_azure_ad.md
@@ -56,5 +56,5 @@ resource "zitadel_org_idp_azure_ad" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<id[:org_id][:client_secret]>`, e.g.
-terraform import org_idp_azure_ad.imported '123456789012345678:123456789012345678:12345678-1234-1234-1234-123456789012'
+terraform import zitadel_org_idp_azure_ad.imported '123456789012345678:123456789012345678:12345678-1234-1234-1234-123456789012'
 ```

--- a/docs/resources/org_idp_github.md
+++ b/docs/resources/org_idp_github.md
@@ -51,5 +51,5 @@ resource "zitadel_org_idp_github" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<id[:org_id][:client_secret]>`, e.g.
-terraform import org_idp_github.imported '123456789012345678:123456789012345678:1234567890123456781234567890123456787890'
+terraform import zitadel_org_idp_github.imported '123456789012345678:123456789012345678:1234567890123456781234567890123456787890'
 ```

--- a/docs/resources/org_idp_github_es.md
+++ b/docs/resources/org_idp_github_es.md
@@ -57,5 +57,5 @@ resource "zitadel_org_idp_github_es" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<id[:org_id][:client_secret]>`, e.g.
-terraform import org_idp_github_es.imported '123456789012345678:123456789012345678:123456789012345678:123456789012345678'
+terraform import zitadel_org_idp_github_es.imported '123456789012345678:123456789012345678:123456789012345678:123456789012345678'
 ```

--- a/docs/resources/org_idp_gitlab.md
+++ b/docs/resources/org_idp_gitlab.md
@@ -51,5 +51,5 @@ resource "zitadel_org_idp_gitlab" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<id[:org_id][:client_secret]>`, e.g.
-terraform import org_idp_gitlab.imported '123456789012345678:123456789012345678:1234567890abcdef'
+terraform import zitadel_org_idp_gitlab.imported '123456789012345678:123456789012345678:1234567890abcdef'
 ```

--- a/docs/resources/org_idp_gitlab_self_hosted.md
+++ b/docs/resources/org_idp_gitlab_self_hosted.md
@@ -53,5 +53,5 @@ resource "zitadel_org_idp_gitlab_self_hosted" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<id[:org_id][:client_secret]>`, e.g.
-terraform import org_idp_gitlab_self_hosted.imported '123456789012345678:123456789012345678:1234567890abcdef'
+terraform import zitadel_org_idp_gitlab_self_hosted.imported '123456789012345678:123456789012345678:1234567890abcdef'
 ```

--- a/docs/resources/org_idp_google.md
+++ b/docs/resources/org_idp_google.md
@@ -51,5 +51,5 @@ resource "zitadel_org_idp_google" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<id[:org_id][:client_secret]>`, e.g.
-terraform import org_idp_google.imported '123456789012345678:123456789012345678:G1234567890123'
+terraform import zitadel_org_idp_google.imported '123456789012345678:123456789012345678:G1234567890123'
 ```

--- a/docs/resources/org_idp_jwt.md
+++ b/docs/resources/org_idp_jwt.md
@@ -49,5 +49,5 @@ resource "zitadel_org_idp_jwt" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<id[:org_id]>`, e.g.
-terraform import org_idp_jwt.imported '123456789012345678:123456789012345678'
+terraform import zitadel_org_idp_jwt.imported '123456789012345678:123456789012345678'
 ```

--- a/docs/resources/org_idp_ldap.md
+++ b/docs/resources/org_idp_ldap.md
@@ -79,5 +79,5 @@ resource "zitadel_org_idp_ldap" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<id[:org_id][:bind_password]>`, e.g.
-terraform import org_idp_ldap.imported '123456789012345678:123456789012345678:b1nd_p4ssw0rd'
+terraform import zitadel_org_idp_ldap.imported '123456789012345678:123456789012345678:b1nd_p4ssw0rd'
 ```

--- a/docs/resources/org_idp_oidc.md
+++ b/docs/resources/org_idp_oidc.md
@@ -55,5 +55,5 @@ resource "zitadel_org_idp_oidc" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<id[:org_id][:client_secret]>`, e.g.
-terraform import org_idp_oidc.imported '123456789012345678:123456789012345678:1234567890abcdef'
+terraform import zitadel_org_idp_oidc.imported '123456789012345678:123456789012345678:1234567890abcdef'
 ```

--- a/docs/resources/org_member.md
+++ b/docs/resources/org_member.md
@@ -39,5 +39,5 @@ resource "zitadel_org_member" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<user_id[:org_id]>`, e.g.
-terraform import org_member.imported '123456789012345678:123456789012345678'
+terraform import zitadel_org_member.imported '123456789012345678:123456789012345678'
 ```

--- a/docs/resources/personal_access_token.md
+++ b/docs/resources/personal_access_token.md
@@ -40,5 +40,5 @@ resource "zitadel_personal_access_token" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<id:user_id[:org_id][:token]>`, e.g.
-terraform import personal_access_token.imported '123456789012345678:123456789012345678:123456789012345678:LHt79...'
+terraform import zitadel_personal_access_token.imported '123456789012345678:123456789012345678:123456789012345678:LHt79...'
 ```

--- a/docs/resources/privacy_policy.md
+++ b/docs/resources/privacy_policy.md
@@ -40,5 +40,5 @@ resource "zitadel_privacy_policy" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<[org_id]>`, e.g.
-terraform import privacy_policy.imported '123456789012345678'
+terraform import zitadel_privacy_policy.imported '123456789012345678'
 ```

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -46,5 +46,5 @@ resource "zitadel_project" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<id[:org_id]>`, e.g.
-terraform import project.imported '123456789012345678:123456789012345678'
+terraform import zitadel_project.imported '123456789012345678:123456789012345678'
 ```

--- a/docs/resources/project_grant.md
+++ b/docs/resources/project_grant.md
@@ -41,5 +41,5 @@ resource "zitadel_project_grant" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<id:project_id[:org_id]>`, e.g.
-terraform import project_grant.imported '123456789012345678:123456789012345678:123456789012345678'
+terraform import zitadel_project_grant.imported '123456789012345678:123456789012345678:123456789012345678'
 ```

--- a/docs/resources/project_grant_member.md
+++ b/docs/resources/project_grant_member.md
@@ -43,5 +43,5 @@ resource "zitadel_project_grant_member" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<project_id:grant_id:user_id[:org_id]>`, e.g.
-terraform import project_grant_member.imported '123456789012345678:123456789012345678:123456789012345678:123456789012345678'
+terraform import zitadel_project_grant_member.imported '123456789012345678:123456789012345678:123456789012345678:123456789012345678'
 ```

--- a/docs/resources/project_member.md
+++ b/docs/resources/project_member.md
@@ -41,5 +41,5 @@ resource "zitadel_project_member" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<project_id:user_id[:org_id]>`, e.g.
-terraform import project_member.imported '123456789012345678:123456789012345678:123456789012345678'
+terraform import zitadel_project_member.imported '123456789012345678:123456789012345678:123456789012345678'
 ```

--- a/docs/resources/project_role.md
+++ b/docs/resources/project_role.md
@@ -43,5 +43,5 @@ resource "zitadel_project_role" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<project_id:role_key[:org_id]>`, e.g.
-terraform import project_role.imported '123456789012345678:my-role-key:123456789012345678'
+terraform import zitadel_project_role.imported '123456789012345678:my-role-key:123456789012345678'
 ```

--- a/docs/resources/sms_provider_twilio.md
+++ b/docs/resources/sms_provider_twilio.md
@@ -36,5 +36,5 @@ resource "zitadel_sms_provider_twilio" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<id[:token]>`, e.g.
-terraform import sms_provider_twilio.imported '123456789012345678:12345678901234567890123456abcdef'
+terraform import zitadel_sms_provider_twilio.imported '123456789012345678:12345678901234567890123456abcdef'
 ```

--- a/docs/resources/smtp_config.md
+++ b/docs/resources/smtp_config.md
@@ -47,5 +47,5 @@ resource "zitadel_smtp_config" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<[password]>`, e.g.
-terraform import smtp_config.imported 'p4ssw0rd'
+terraform import zitadel_smtp_config.imported 'p4ssw0rd'
 ```

--- a/docs/resources/trigger_actions.md
+++ b/docs/resources/trigger_actions.md
@@ -41,5 +41,5 @@ resource "zitadel_trigger_actions" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<flow_type:trigger_type[:org_id]>`, e.g.
-terraform import trigger_actions.imported 'FLOW_TYPE_EXTERNAL_AUTHENTICATION:TRIGGER_TYPE_POST_CREATION:123456789012345678'
+terraform import zitadel_trigger_actions.imported 'FLOW_TYPE_EXTERNAL_AUTHENTICATION:TRIGGER_TYPE_POST_CREATION:123456789012345678'
 ```

--- a/docs/resources/user_grant.md
+++ b/docs/resources/user_grant.md
@@ -42,5 +42,5 @@ resource "zitadel_user_grant" "default" {
 
 ```bash
 # The resource can be imported using the ID format `<flow_type:trigger_type[:org_id]>`, e.g.
-terraform import user_grant.imported '123456789012345678:123456789012345678:123456789012345678'
+terraform import zitadel_user_grant.imported '123456789012345678:123456789012345678:123456789012345678'
 ```

--- a/docs/resources/verify_phone_message_text.md
+++ b/docs/resources/verify_phone_message_text.md
@@ -16,7 +16,7 @@ resource "zitadel_verify_phone_message_text" "default" {
   org_id   = data.zitadel_org.default.id
   language = "en"
 
-  text        = "text example"
+  text = "text example"
 }
 ```
 

--- a/docs/resources/verify_sms_otp_message_text.md
+++ b/docs/resources/verify_sms_otp_message_text.md
@@ -16,7 +16,7 @@ resource "zitadel_verify_sms_otp_message_text" "default" {
   org_id   = data.zitadel_org.default.id
   language = "en"
 
-  text        = "text example"
+  text = "text example"
 }
 ```
 

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     zitadel = {
       source  = "zitadel/zitadel"
-      version = "1.1.0"
+      version = "1.2.0"
     }
   }
 }

--- a/examples/provider/resources/default_label_policy.tf
+++ b/examples/provider/resources/default_label_policy.tf
@@ -20,4 +20,5 @@ resource "zitadel_default_label_policy" "default" {
   icon_dark_path         = "/path/to/icon_dark.jpg"
   font_hash              = filemd5("/path/to/font.tff")
   font_path              = "/path/to/font.tff"
+  theme_mode             = "THEME_MODE_DARK"
 }

--- a/examples/provider/resources/default_verify_phone_message_text.tf
+++ b/examples/provider/resources/default_verify_phone_message_text.tf
@@ -1,5 +1,5 @@
 resource "zitadel_default_verify_phone_message_text" "default" {
   language = "en"
 
-  text        = "text example"
+  text = "text example"
 }

--- a/examples/provider/resources/default_verify_sms_otp_message_text.tf
+++ b/examples/provider/resources/default_verify_sms_otp_message_text.tf
@@ -1,5 +1,5 @@
 resource "zitadel_default_verify_sms_otp_message_text" "default" {
   language = "en"
 
-  text        = "text example"
+  text = "text example"
 }

--- a/examples/provider/resources/label_policy.tf
+++ b/examples/provider/resources/label_policy.tf
@@ -21,4 +21,5 @@ resource "zitadel_label_policy" "default" {
   icon_dark_path         = "/path/to/icon_dark.jpg"
   font_hash              = filemd5("/path/to/font.tff")
   font_path              = "/path/to/font.tff"
+  theme_mode             = "THEME_MODE_DARK"
 }

--- a/examples/provider/resources/verify_phone_message_text.tf
+++ b/examples/provider/resources/verify_phone_message_text.tf
@@ -2,5 +2,5 @@ resource "zitadel_verify_phone_message_text" "default" {
   org_id   = data.zitadel_org.default.id
   language = "en"
 
-  text        = "text example"
+  text = "text example"
 }

--- a/examples/provider/resources/verify_sms_otp_message_text.tf
+++ b/examples/provider/resources/verify_sms_otp_message_text.tf
@@ -2,5 +2,5 @@ resource "zitadel_verify_sms_otp_message_text" "default" {
   org_id   = data.zitadel_org.default.id
   language = "en"
 
-  text        = "text example"
+  text = "text example"
 }

--- a/zitadel/default_label_policy/const.go
+++ b/zitadel/default_label_policy/const.go
@@ -27,6 +27,7 @@ const (
 	FontHashVar            = "font_hash"
 	fontURLVar             = "font_url"
 	SetActiveVar           = "set_active"
+	themeModeVar           = "theme_mode"
 )
 
 const (

--- a/zitadel/default_label_policy/funcs.go
+++ b/zitadel/default_label_policy/funcs.go
@@ -2,6 +2,7 @@ package default_label_policy
 
 import (
 	"context"
+	"github.com/zitadel/zitadel-go/v2/pkg/client/zitadel/policy"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -41,6 +42,7 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 		warnColorDarkVar,
 		fontColorDarkVar,
 		disableWatermarkVar,
+		themeModeVar,
 	) {
 		resp, err := client.UpdateLabelPolicy(ctx, &admin.UpdateLabelPolicyRequest{
 			PrimaryColor:        d.Get(PrimaryColorVar).(string),
@@ -53,6 +55,7 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 			WarnColorDark:       d.Get(warnColorDarkVar).(string),
 			FontColorDark:       d.Get(fontColorDarkVar).(string),
 			DisableWatermark:    d.Get(disableWatermarkVar).(bool),
+			ThemeMode:           policy.ThemeMode(policy.ThemeMode_value[d.Get(themeModeVar).(string)]),
 		})
 		if helper.IgnorePreconditionError(err) != nil {
 			return diag.Errorf("failed to update default label policy: %v", err)
@@ -112,6 +115,7 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 		IconHashVar,
 		IconDarkHashVar,
 		FontHashVar,
+		themeModeVar,
 	) {
 		if d.Get(SetActiveVar).(bool) {
 			if _, err := client.ActivateLabelPolicy(ctx, &admin.ActivateLabelPolicyRequest{}); err != nil {
@@ -161,6 +165,7 @@ func read(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagn
 		logoURLDarkVar:         policy.GetLogoUrlDark(),
 		iconURLDarkVar:         policy.GetIconUrlDark(),
 		fontURLVar:             policy.GetFontUrl(),
+		themeModeVar:           policy.GetThemeMode().String(),
 	}
 
 	for k, v := range set {

--- a/zitadel/default_label_policy/funcs.go
+++ b/zitadel/default_label_policy/funcs.go
@@ -2,12 +2,12 @@ package default_label_policy
 
 import (
 	"context"
-	"github.com/zitadel/zitadel-go/v2/pkg/client/zitadel/policy"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/zitadel/zitadel-go/v2/pkg/client/zitadel/admin"
+	"github.com/zitadel/zitadel-go/v2/pkg/client/zitadel/policy"
 
 	"github.com/zitadel/terraform-provider-zitadel/zitadel/helper"
 )

--- a/zitadel/default_label_policy/resource.go
+++ b/zitadel/default_label_policy/resource.go
@@ -1,7 +1,10 @@
 package default_label_policy
 
 import (
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/zitadel/zitadel-go/v2/pkg/client/zitadel/policy"
 
 	"github.com/zitadel/terraform-provider-zitadel/zitadel/helper"
 )
@@ -139,6 +142,15 @@ func GetResource() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: "set the label policy active after creating/updating",
+			},
+			themeModeVar: {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "theme mode" + helper.DescriptionEnumValuesList(policy.ThemeMode_name),
+				ValidateDiagFunc: func(value interface{}, path cty.Path) diag.Diagnostics {
+					return helper.EnumValueValidation(themeModeVar, value, policy.ThemeMode_value)
+				},
+				Default: policy.ThemeMode_THEME_MODE_AUTO.String(),
 			},
 		},
 		ReadContext:   read,

--- a/zitadel/label_policy/const.go
+++ b/zitadel/label_policy/const.go
@@ -27,6 +27,7 @@ const (
 	FontHashVar            = "font_hash"
 	fontURLVar             = "font_url"
 	SetActiveVar           = "set_active"
+	themeModeVar           = "theme_mode"
 )
 
 const (

--- a/zitadel/label_policy/funcs.go
+++ b/zitadel/label_policy/funcs.go
@@ -2,6 +2,7 @@ package label_policy
 
 import (
 	"context"
+	"github.com/zitadel/zitadel-go/v2/pkg/client/zitadel/policy"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -56,6 +57,7 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 		warnColorDarkVar,
 		fontColorDarkVar,
 		disableWatermarkVar,
+		themeModeVar,
 	) {
 		resp, err := client.UpdateCustomLabelPolicy(helper.CtxWithID(ctx, d), &management.UpdateCustomLabelPolicyRequest{
 			PrimaryColor:        d.Get(primaryColorVar).(string),
@@ -68,6 +70,7 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 			WarnColorDark:       d.Get(warnColorDarkVar).(string),
 			FontColorDark:       d.Get(fontColorDarkVar).(string),
 			DisableWatermark:    d.Get(disableWatermarkVar).(bool),
+			ThemeMode:           policy.ThemeMode(policy.ThemeMode_value[d.Get(themeModeVar).(string)]),
 		})
 		if err != nil {
 			return diag.Errorf("failed to update label policy: %v", err)
@@ -117,6 +120,7 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 		IconHashVar,
 		IconDarkHashVar,
 		FontHashVar,
+		themeModeVar,
 	) {
 		if d.Get(SetActiveVar).(bool) {
 			if _, err := client.ActivateCustomLabelPolicy(helper.CtxWithID(ctx, d), &management.ActivateCustomLabelPolicyRequest{}); err != nil {

--- a/zitadel/label_policy/funcs.go
+++ b/zitadel/label_policy/funcs.go
@@ -242,6 +242,7 @@ func read(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagn
 		logoURLDarkVar:         policy.GetLogoUrlDark(),
 		iconURLDarkVar:         policy.GetIconUrlDark(),
 		fontURLVar:             policy.GetFontUrl(),
+		themeModeVar:           policy.GetThemeMode().String(),
 	}
 
 	for k, v := range set {

--- a/zitadel/label_policy/funcs.go
+++ b/zitadel/label_policy/funcs.go
@@ -2,12 +2,12 @@ package label_policy
 
 import (
 	"context"
-	"github.com/zitadel/zitadel-go/v2/pkg/client/zitadel/policy"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/zitadel/zitadel-go/v2/pkg/client/zitadel/management"
+	"github.com/zitadel/zitadel-go/v2/pkg/client/zitadel/policy"
 
 	"github.com/zitadel/terraform-provider-zitadel/zitadel/helper"
 )

--- a/zitadel/label_policy/funcs.go
+++ b/zitadel/label_policy/funcs.go
@@ -156,6 +156,7 @@ func create(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 		WarnColorDark:       d.Get(warnColorDarkVar).(string),
 		FontColorDark:       d.Get(fontColorDarkVar).(string),
 		DisableWatermark:    d.Get(disableWatermarkVar).(bool),
+		ThemeMode:           policy.ThemeMode(policy.ThemeMode_value[d.Get(themeModeVar).(string)]),
 	})
 	if err != nil {
 		return diag.Errorf("failed to create label policy: %v", err)

--- a/zitadel/label_policy/resource.go
+++ b/zitadel/label_policy/resource.go
@@ -1,7 +1,10 @@
 package label_policy
 
 import (
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/zitadel/zitadel-go/v2/pkg/client/zitadel/policy"
 
 	"github.com/zitadel/terraform-provider-zitadel/zitadel/helper"
 )
@@ -140,6 +143,15 @@ func GetResource() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: "set the label policy active after creating/updating",
+			},
+			themeModeVar: {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "theme mode" + helper.DescriptionEnumValuesList(policy.ThemeMode_name),
+				ValidateDiagFunc: func(value interface{}, path cty.Path) diag.Diagnostics {
+					return helper.EnumValueValidation(themeModeVar, value, policy.ThemeMode_value)
+				},
+				Default: policy.ThemeMode_THEME_MODE_AUTO.String(),
 			},
 		},
 		ReadContext:   read,


### PR DESCRIPTION
Adds support for setting the theme mode in the org and instance label policy.
Default is THEME_MODE_AUTO.
Validates the input to be a valid enum field.

Closes #173
Closes #138

### Definition of Ready

- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] All non-functional requirements are met
- [x] The generic lifecycle acceptance test passes for affected resources.
- [x] Examples are up-to-date and meaningful. The provider version is incremented.
- [x] Docs are generated.
- [x] Code is generated where possible.
