### PR TITLE
feat: query client ID in app datasources

### DIFF
--- a/zitadel/application_api/application_api_test_dep/dependency.go
+++ b/zitadel/application_api/application_api_test_dep/dependency.go
@@ -10,13 +10,15 @@ import (
 	"github.com/zitadel/terraform-provider-zitadel/zitadel/helper/test_utils"
 )
 
-func Create(t *testing.T, frame *test_utils.OrgTestFrame, projectID, name string) (string, string) {
-	return test_utils.CreateDefaultDependency(t, "zitadel_application_api", application_api.AppIDVar, func() (string, error) {
+func Create(t *testing.T, frame *test_utils.OrgTestFrame, projectID, name string) (template, id, clientID string) {
+	template, id = test_utils.CreateDefaultDependency(t, "zitadel_application_api", application_api.AppIDVar, func() (string, error) {
 		apiApp, err := frame.AddAPIApp(frame, &management.AddAPIAppRequest{
 			ProjectId:      projectID,
 			Name:           name,
 			AuthMethodType: app.APIAuthMethodType_API_AUTH_METHOD_TYPE_PRIVATE_KEY_JWT,
 		})
+		clientID = apiApp.GetClientId()
 		return apiApp.GetAppId(), err
 	})
+	return template, id, clientID
 }

--- a/zitadel/application_api/datasource.go
+++ b/zitadel/application_api/datasource.go
@@ -34,6 +34,12 @@ func GetDatasource() *schema.Resource {
 				Computed:    true,
 				Description: "Auth method type",
 			},
+			ClientIDVar: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "generated ID for this config",
+				Sensitive:   true,
+			},
 		},
 		ReadContext: read,
 	}

--- a/zitadel/application_api/datasource_test.go
+++ b/zitadel/application_api/datasource_test.go
@@ -22,7 +22,7 @@ func TestAccApplicationAPIDatasource_ID(t *testing.T) {
 	exampleID := test_utils.AttributeValue(t, application_api.AppIDVar, attributes).AsString()
 	projectDep, projectID := project_test_dep.Create(t, frame, frame.UniqueResourcesID)
 	appName := "application_api_datasource_" + frame.UniqueResourcesID
-	_, appID := application_api_test_dep.Create(t, frame, projectID, appName)
+	_, appID, clientID := application_api_test_dep.Create(t, frame, projectID, appName)
 	config = strings.Replace(config, exampleID, appID, 1)
 	test_utils.RunDatasourceTest(
 		t,
@@ -35,6 +35,7 @@ func TestAccApplicationAPIDatasource_ID(t *testing.T) {
 			"project_id": projectID,
 			"app_id":     appID,
 			"name":       appName,
+			"client_id":  clientID,
 		},
 	)
 }
@@ -50,7 +51,7 @@ func TestAccApplicationAPIsDatasources_ID_Name_Match(t *testing.T) {
 	config = strings.Join(strings.Split(config, "\n")[0:6], "\n")
 	config = strings.Replace(config, exampleName, appName, 1)
 	projectDep, projectID := project_test_dep.Create(t, frame, frame.UniqueResourcesID)
-	_, appID := application_api_test_dep.Create(t, frame, projectID, appName)
+	_, appID, _ := application_api_test_dep.Create(t, frame, projectID, appName)
 	test_utils.RunDatasourceTest(
 		t,
 		frame.BaseTestFrame,
@@ -75,7 +76,7 @@ func TestAccApplicationAPIsDatasources_ID_Name_Mismatch(t *testing.T) {
 	config = strings.Join(strings.Split(config, "\n")[0:6], "\n")
 	config = strings.Replace(config, exampleName, "mismatch", 1)
 	projectDep, projectID := project_test_dep.Create(t, frame, frame.UniqueResourcesID)
-	_, appID := application_api_test_dep.Create(t, frame, projectID, appName)
+	_, appID, _ := application_api_test_dep.Create(t, frame, projectID, appName)
 	test_utils.RunDatasourceTest(
 		t,
 		frame.BaseTestFrame,

--- a/zitadel/application_api/funcs.go
+++ b/zitadel/application_api/funcs.go
@@ -137,6 +137,7 @@ func read(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagn
 		helper.OrgIDVar:   app.GetDetails().GetResourceOwner(),
 		NameVar:           app.GetName(),
 		authMethodTypeVar: api.GetAuthMethodType().String(),
+		ClientIDVar:       api.GetClientId(),
 	}
 	for k, v := range set {
 		if err := d.Set(k, v); err != nil {

--- a/zitadel/application_key/resource_test.go
+++ b/zitadel/application_key/resource_test.go
@@ -21,7 +21,7 @@ func TestAccAppKey(t *testing.T) {
 	exampleProperty := test_utils.AttributeValue(t, application_key.ExpirationDateVar, exampleAttributes).AsString()
 	updatedProperty := "2501-01-01T08:45:00Z"
 	projectDep, projectID := project_test_dep.Create(t, frame, frame.UniqueResourcesID)
-	appDep, appID := application_api_test_dep.Create(t, frame, projectID, frame.UniqueResourcesID)
+	appDep, appID, _ := application_api_test_dep.Create(t, frame, projectID, frame.UniqueResourcesID)
 	test_utils.RunLifecyleTest(
 		t,
 		frame.BaseTestFrame,

--- a/zitadel/application_oidc/application_oidc_test_dep/dependency.go
+++ b/zitadel/application_oidc/application_oidc_test_dep/dependency.go
@@ -9,12 +9,14 @@ import (
 	"github.com/zitadel/terraform-provider-zitadel/zitadel/helper/test_utils"
 )
 
-func Create(t *testing.T, frame *test_utils.OrgTestFrame, projectID, name string) (string, string) {
-	return test_utils.CreateDefaultDependency(t, "zitadel_application_oidc", application_oidc.AppIDVar, func() (string, error) {
+func Create(t *testing.T, frame *test_utils.OrgTestFrame, projectID, name string) (template string, id string, clientId string) {
+	template, id = test_utils.CreateDefaultDependency(t, "zitadel_application_oidc", application_oidc.AppIDVar, func() (string, error) {
 		oidcApp, err := frame.AddOIDCApp(frame, &management.AddOIDCAppRequest{
 			ProjectId: projectID,
 			Name:      name,
 		})
+		clientId = oidcApp.GetClientId()
 		return oidcApp.GetAppId(), err
 	})
+	return template, id, clientId
 }

--- a/zitadel/application_oidc/datasource.go
+++ b/zitadel/application_oidc/datasource.go
@@ -114,6 +114,11 @@ func GetDatasource() *schema.Resource {
 				Computed:    true,
 				Description: "Additional origins",
 			},
+			ClientIDVar: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Client ID",
+			},
 		},
 		ReadContext: read,
 	}

--- a/zitadel/application_oidc/datasource.go
+++ b/zitadel/application_oidc/datasource.go
@@ -118,6 +118,7 @@ func GetDatasource() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Client ID",
+				Sensitive:   true,
 			},
 		},
 		ReadContext: read,

--- a/zitadel/application_oidc/datasource_test.go
+++ b/zitadel/application_oidc/datasource_test.go
@@ -22,7 +22,7 @@ func TestAccApplicationOIDCDatasource_ID(t *testing.T) {
 	exampleID := test_utils.AttributeValue(t, application_oidc.AppIDVar, attributes).AsString()
 	projectDep, projectID := project_test_dep.Create(t, frame, frame.UniqueResourcesID)
 	appName := "application_oidc_datasource_" + frame.UniqueResourcesID
-	_, appID := application_oidc_test_dep.Create(t, frame, projectID, appName)
+	_, appID, clientID := application_oidc_test_dep.Create(t, frame, projectID, appName)
 	config = strings.Replace(config, exampleID, appID, 1)
 	test_utils.RunDatasourceTest(
 		t,
@@ -35,6 +35,7 @@ func TestAccApplicationOIDCDatasource_ID(t *testing.T) {
 			"project_id": projectID,
 			"app_id":     appID,
 			"name":       appName,
+			"client_id":  clientID,
 		},
 	)
 }
@@ -50,7 +51,7 @@ func TestAccApplicationOIDCsDatasources_ID_Name_Match(t *testing.T) {
 	config = strings.Join(strings.Split(config, "\n")[0:6], "\n")
 	config = strings.Replace(config, exampleName, appName, 1)
 	projectDep, projectID := project_test_dep.Create(t, frame, frame.UniqueResourcesID)
-	_, appID := application_oidc_test_dep.Create(t, frame, projectID, appName)
+	_, appID, _ := application_oidc_test_dep.Create(t, frame, projectID, appName)
 	test_utils.RunDatasourceTest(
 		t,
 		frame.BaseTestFrame,
@@ -75,7 +76,7 @@ func TestAccApplicationOIDCsDatasources_ID_Name_Mismatch(t *testing.T) {
 	config = strings.Join(strings.Split(config, "\n")[0:6], "\n")
 	config = strings.Replace(config, exampleName, "mismatch", 1)
 	projectDep, projectID := project_test_dep.Create(t, frame, frame.UniqueResourcesID)
-	_, appID := application_oidc_test_dep.Create(t, frame, projectID, appName)
+	_, appID, _ := application_oidc_test_dep.Create(t, frame, projectID, appName)
 	test_utils.RunDatasourceTest(
 		t,
 		frame.BaseTestFrame,

--- a/zitadel/application_oidc/funcs.go
+++ b/zitadel/application_oidc/funcs.go
@@ -233,6 +233,7 @@ func read(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagn
 		idTokenUserinfoAssertionVar: oidc.GetIdTokenUserinfoAssertion(),
 		clockSkewVar:                clockSkew,
 		additionalOriginsVar:        oidc.GetAdditionalOrigins(),
+		ClientIDVar:                 oidc.GetClientId(),
 	}
 	for k, v := range set {
 		if err := d.Set(k, v); err != nil {


### PR DESCRIPTION
With these changes, the apps client IDs are stored in their datasources state: *zitadel_application_oidc*, *zitadel_application_api*. 

### Definition of Ready

- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] All non-functional requirements are met
- [x] The generic lifecycle acceptance test passes for affected resources.
- [x] Examples are up-to-date and meaningful. The provider version is incremented.
- [x] Docs are generated.
- [x] Code is generated where possible.
