### PR TITLE
fix: correct clockSkew value when reading duration

### DIFF
--- a/zitadel/application_oidc/funcs.go
+++ b/zitadel/application_oidc/funcs.go
@@ -211,7 +211,7 @@ func read(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagn
 	for _, responseType := range oidc.GetResponseTypes() {
 		responseTypes = append(responseTypes, responseType.String())
 	}
-	clockSkew := oidc.GetClockSkew().String()
+	clockSkew := oidc.GetClockSkew().AsDuration().String()
 	if clockSkew == "" {
 		clockSkew = "0s"
 	}


### PR DESCRIPTION
### Definition of Ready

Correct clockSkew value when reading duration
Fixes #187 

- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] All non-functional requirements are met
- [x] The generic lifecycle acceptance test passes for affected resources.
- [x] Examples are up-to-date and meaningful. The provider version is incremented.
- [x] Docs are generated.
- [x] Code is generated where possible.
