### PR TITLE
chore: increase acceptance test health check retries

### DIFF
--- a/acceptance/docker-compose.yaml
+++ b/acceptance/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
       test: ['CMD', '/app/zitadel', 'ready', "--config", "/zitadel.yaml"]
       interval: '2s'
       timeout: '30s'
-      retries: 5
+      retries: 60
     depends_on:
       db:
         condition: 'service_healthy'


### PR DESCRIPTION
Increases the retries for the zitadel health checks, because the acceptance setup job depends on it. If ZITADEL is not healthy in time, the setup is not executed and errors like the following appear:

`unable to set instance using origin http://instance-level-tests.default.127.0.0.1.sslip.io:8080 (ExternalDomain is org-level-tests.default.127.0.0.1.sslip.io): ID=QUERY-1kIjX Message=Instance not found. Make sure you got the domain right. Check out https://zitadel.com/docs/apis/introduction#domains`

We only rely on the docker compose health check feature for setting up the environment for acceptance tests. We don't want to have a reliable ZITADEL service scheduled here. So increasing the number of retries is fine in this case.

### Definition of Ready

- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] All non-functional requirements are met
- [x] The generic lifecycle acceptance test passes for affected resources.
- [x] Examples are up-to-date and meaningful. The provider version is incremented.
- [x] Docs are generated.
- [x] Code is generated where possible.
