### PR TITLE
fix: add skip native app success page boolean for oidc apps

### DIFF
--- a/docs/data-sources/application_oidc.md
+++ b/docs/data-sources/application_oidc.md
@@ -49,4 +49,5 @@ data "zitadel_application_oidc" "default" {
 - `post_logout_redirect_uris` (List of String) Post logout redirect URIs
 - `redirect_uris` (List of String) RedirectURIs
 - `response_types` (List of String) Response type
+- `skip_native_app_success_page` (Boolean) Skip the successful login page on native apps and directly redirect the user to the callback.
 - `version` (String) Version

--- a/docs/resources/application_oidc.md
+++ b/docs/resources/application_oidc.md
@@ -16,21 +16,22 @@ resource "zitadel_application_oidc" "default" {
   project_id = data.zitadel_project.default.id
   org_id     = data.zitadel_org.default.id
 
-  name                        = "applicationoidc"
-  redirect_uris               = ["https://localhost.com"]
-  response_types              = ["OIDC_RESPONSE_TYPE_CODE"]
-  grant_types                 = ["OIDC_GRANT_TYPE_AUTHORIZATION_CODE"]
-  post_logout_redirect_uris   = ["https://localhost.com"]
-  app_type                    = "OIDC_APP_TYPE_WEB"
-  auth_method_type            = "OIDC_AUTH_METHOD_TYPE_BASIC"
-  version                     = "OIDC_VERSION_1_0"
-  clock_skew                  = "0s"
-  dev_mode                    = true
-  access_token_type           = "OIDC_TOKEN_TYPE_BEARER"
-  access_token_role_assertion = false
-  id_token_role_assertion     = false
-  id_token_userinfo_assertion = false
-  additional_origins          = []
+  name                         = "applicationoidc"
+  redirect_uris = ["https://localhost.com"]
+  response_types = ["OIDC_RESPONSE_TYPE_CODE"]
+  grant_types = ["OIDC_GRANT_TYPE_AUTHORIZATION_CODE"]
+  post_logout_redirect_uris = ["https://localhost.com"]
+  app_type                     = "OIDC_APP_TYPE_WEB"
+  auth_method_type             = "OIDC_AUTH_METHOD_TYPE_BASIC"
+  version                      = "OIDC_VERSION_1_0"
+  clock_skew                   = "0s"
+  dev_mode                     = true
+  access_token_type            = "OIDC_TOKEN_TYPE_BEARER"
+  access_token_role_assertion  = false
+  id_token_role_assertion      = false
+  id_token_userinfo_assertion  = false
+  additional_origins = []
+  skip_native_app_success_page = false
 }
 ```
 
@@ -58,6 +59,7 @@ resource "zitadel_application_oidc" "default" {
 - `id_token_userinfo_assertion` (Boolean) Token userinfo assertion
 - `org_id` (String) ID of the organization
 - `post_logout_redirect_uris` (List of String) Post logout redirect URIs
+- `skip_native_app_success_page` (Boolean) Skip the successful login page on native apps and directly redirect the user to the callback.
 - `version` (String) Version, supported values: OIDC_VERSION_1_0
 
 ### Read-Only

--- a/docs/resources/application_oidc.md
+++ b/docs/resources/application_oidc.md
@@ -17,10 +17,10 @@ resource "zitadel_application_oidc" "default" {
   org_id     = data.zitadel_org.default.id
 
   name                         = "applicationoidc"
-  redirect_uris = ["https://localhost.com"]
-  response_types = ["OIDC_RESPONSE_TYPE_CODE"]
-  grant_types = ["OIDC_GRANT_TYPE_AUTHORIZATION_CODE"]
-  post_logout_redirect_uris = ["https://localhost.com"]
+  redirect_uris                = ["https://localhost.com"]
+  response_types               = ["OIDC_RESPONSE_TYPE_CODE"]
+  grant_types                  = ["OIDC_GRANT_TYPE_AUTHORIZATION_CODE"]
+  post_logout_redirect_uris    = ["https://localhost.com"]
   app_type                     = "OIDC_APP_TYPE_WEB"
   auth_method_type             = "OIDC_AUTH_METHOD_TYPE_BASIC"
   version                      = "OIDC_VERSION_1_0"
@@ -30,7 +30,7 @@ resource "zitadel_application_oidc" "default" {
   access_token_role_assertion  = false
   id_token_role_assertion      = false
   id_token_userinfo_assertion  = false
-  additional_origins = []
+  additional_origins           = []
   skip_native_app_success_page = false
 }
 ```

--- a/examples/provider/resources/application_oidc.tf
+++ b/examples/provider/resources/application_oidc.tf
@@ -2,19 +2,20 @@ resource "zitadel_application_oidc" "default" {
   project_id = data.zitadel_project.default.id
   org_id     = data.zitadel_org.default.id
 
-  name                        = "applicationoidc"
-  redirect_uris               = ["https://localhost.com"]
-  response_types              = ["OIDC_RESPONSE_TYPE_CODE"]
-  grant_types                 = ["OIDC_GRANT_TYPE_AUTHORIZATION_CODE"]
-  post_logout_redirect_uris   = ["https://localhost.com"]
-  app_type                    = "OIDC_APP_TYPE_WEB"
-  auth_method_type            = "OIDC_AUTH_METHOD_TYPE_BASIC"
-  version                     = "OIDC_VERSION_1_0"
-  clock_skew                  = "0s"
-  dev_mode                    = true
-  access_token_type           = "OIDC_TOKEN_TYPE_BEARER"
-  access_token_role_assertion = false
-  id_token_role_assertion     = false
-  id_token_userinfo_assertion = false
-  additional_origins          = []
+  name                         = "applicationoidc"
+  redirect_uris = ["https://localhost.com"]
+  response_types = ["OIDC_RESPONSE_TYPE_CODE"]
+  grant_types = ["OIDC_GRANT_TYPE_AUTHORIZATION_CODE"]
+  post_logout_redirect_uris = ["https://localhost.com"]
+  app_type                     = "OIDC_APP_TYPE_WEB"
+  auth_method_type             = "OIDC_AUTH_METHOD_TYPE_BASIC"
+  version                      = "OIDC_VERSION_1_0"
+  clock_skew                   = "0s"
+  dev_mode                     = true
+  access_token_type            = "OIDC_TOKEN_TYPE_BEARER"
+  access_token_role_assertion  = false
+  id_token_role_assertion      = false
+  id_token_userinfo_assertion  = false
+  additional_origins = []
+  skip_native_app_success_page = false
 }

--- a/examples/provider/resources/application_oidc.tf
+++ b/examples/provider/resources/application_oidc.tf
@@ -3,10 +3,10 @@ resource "zitadel_application_oidc" "default" {
   org_id     = data.zitadel_org.default.id
 
   name                         = "applicationoidc"
-  redirect_uris = ["https://localhost.com"]
-  response_types = ["OIDC_RESPONSE_TYPE_CODE"]
-  grant_types = ["OIDC_GRANT_TYPE_AUTHORIZATION_CODE"]
-  post_logout_redirect_uris = ["https://localhost.com"]
+  redirect_uris                = ["https://localhost.com"]
+  response_types               = ["OIDC_RESPONSE_TYPE_CODE"]
+  grant_types                  = ["OIDC_GRANT_TYPE_AUTHORIZATION_CODE"]
+  post_logout_redirect_uris    = ["https://localhost.com"]
   app_type                     = "OIDC_APP_TYPE_WEB"
   auth_method_type             = "OIDC_AUTH_METHOD_TYPE_BASIC"
   version                      = "OIDC_VERSION_1_0"
@@ -16,6 +16,6 @@ resource "zitadel_application_oidc" "default" {
   access_token_role_assertion  = false
   id_token_role_assertion      = false
   id_token_userinfo_assertion  = false
-  additional_origins = []
+  additional_origins           = []
   skip_native_app_success_page = false
 }

--- a/zitadel/application_oidc/const.go
+++ b/zitadel/application_oidc/const.go
@@ -22,4 +22,5 @@ const (
 	additionalOriginsVar        = "additional_origins"
 	ClientIDVar                 = "client_id"
 	ClientSecretVar             = "client_secret"
+	skipNativeAppSuccessPageVar = "skip_native_app_success_page"
 )

--- a/zitadel/application_oidc/datasource.go
+++ b/zitadel/application_oidc/datasource.go
@@ -120,6 +120,11 @@ func GetDatasource() *schema.Resource {
 				Description: "Client ID",
 				Sensitive:   true,
 			},
+			skipNativeAppSuccessPageVar: {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Skip the successful login page on native apps and directly redirect the user to the callback.",
+			},
 		},
 		ReadContext: read,
 	}

--- a/zitadel/application_oidc/funcs.go
+++ b/zitadel/application_oidc/funcs.go
@@ -78,6 +78,7 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 		idTokenUserinfoAssertionVar,
 		clockSkewVar,
 		additionalOriginsVar,
+		skipNativeAppSuccessPageVar,
 	) {
 		respTypes := make([]app.OIDCResponseType, 0)
 		for _, respType := range d.Get(responseTypesVar).([]interface{}) {
@@ -108,6 +109,7 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 			IdTokenUserinfoAssertion: d.Get(idTokenUserinfoAssertionVar).(bool),
 			AdditionalOrigins:        interfaceToStringSlice(d.Get(additionalOriginsVar)),
 			ClockSkew:                durationpb.New(dur),
+			SkipNativeAppSuccessPage: d.Get(skipNativeAppSuccessPageVar).(bool),
 		})
 		if err != nil {
 			return diag.Errorf("failed to update applicationOIDC: %v", err)
@@ -160,6 +162,7 @@ func create(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 		ClockSkew:                durationpb.New(dur),
 		AdditionalOrigins:        interfaceToStringSlice(d.Get(additionalOriginsVar)),
 		Version:                  app.OIDCVersion(app.OIDCVersion_value[d.Get(versionVar).(string)]),
+		SkipNativeAppSuccessPage: d.Get(skipNativeAppSuccessPageVar).(bool),
 	})
 
 	set := map[string]interface{}{
@@ -234,6 +237,7 @@ func read(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagn
 		clockSkewVar:                clockSkew,
 		additionalOriginsVar:        oidc.GetAdditionalOrigins(),
 		ClientIDVar:                 oidc.GetClientId(),
+		skipNativeAppSuccessPageVar: oidc.GetSkipNativeAppSuccessPage(),
 	}
 	for k, v := range set {
 		if err := d.Set(k, v); err != nil {

--- a/zitadel/application_oidc/resource.go
+++ b/zitadel/application_oidc/resource.go
@@ -145,6 +145,11 @@ func GetResource() *schema.Resource {
 				Description: "generated secret for this config",
 				Sensitive:   true,
 			},
+			skipNativeAppSuccessPageVar: {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Skip the successful login page on native apps and directly redirect the user to the callback.",
+			},
 		},
 		DeleteContext: delete,
 		CreateContext: create,


### PR DESCRIPTION
Add boolean to skip native app success page for oidc applications.

### Definition of Ready

- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] All non-functional requirements are met
- [x] The generic lifecycle acceptance test passes for affected resources.
- [x] Examples are up-to-date and meaningful. The provider version is incremented.
- [x] Docs are generated.
- [x] Code is generated where possible.

Closes #181 