### PR TITLE
Add support for authentication with presigned JWT

### DIFF
--- a/zitadel/helper/client.go
+++ b/zitadel/helper/client.go
@@ -18,13 +18,20 @@ import (
 )
 
 const (
-	DomainVar      = "domain"
-	InsecureVar    = "insecure"
-	TokenVar       = "token"
-	PortVar        = "port"
-	JWTFile        = "jwt_file"
-	JWTProfileFile = "jwt_profile_file"
-	JWTProfileJSON = "jwt_profile_json"
+	DomainVar                 = "domain"
+	DomainDescription         = "Domain used to connect to the ZITADEL instance"
+	InsecureVar               = "insecure"
+	InsecureDescription       = "Use insecure connection"
+	TokenVar                  = "token"
+	TokenDescription          = "Path to the file containing credentials to connect to ZITADEL"
+	PortVar                   = "port"
+	PortDescription           = "Used port if not the default ports 80 or 443 are configured"
+	JWTFileVar                = "jwt_file"
+	JWTFileDescription        = "Path to the file containing presigned JWT to connect to ZITADEL. Either 'jwt_file', 'jwt_profile_file' or 'jwt_profile_json' is required"
+	JWTProfileFileVar         = "jwt_profile_file"
+	JWTProfileFileDescription = "Path to the file containing credentials to connect to ZITADEL. Either 'jwt_file', 'jwt_profile_file' or 'jwt_profile_json' is required"
+	JWTProfileJSONVar         = "jwt_profile_json"
+	JWTProfileJSONDescription = "JSON value of credentials to connect to ZITADEL. Either 'jwt_file', 'jwt_profile_file' or 'jwt_profile_json' is required"
 )
 
 type ClientInfo struct {
@@ -53,7 +60,7 @@ func GetClientInfo(ctx context.Context, insecure bool, domain string, token stri
 	} else if jwtProfileJSON != "" {
 		options = append(options, zitadel.WithJWTProfileTokenSource(middleware.JWTProfileFromFileData(context.Background(), []byte(jwtProfileJSON))))
 	} else {
-		return nil, fmt.Errorf("either 'jwt_profile_file', 'jwt_profile_file' or 'jwt_profile_json' is required")
+		return nil, fmt.Errorf("either 'jwt_file', 'jwt_profile_file' or 'jwt_profile_json' is required")
 	}
 
 	issuerScheme := "https://"

--- a/zitadel/helper/form.go
+++ b/zitadel/helper/form.go
@@ -89,7 +89,7 @@ func formFilePost(ctx context.Context, clientInfo *ClientInfo, endpoint, path st
 			return diag.Errorf("failed to create client: %v", err)
 		}
 	} else {
-		return diag.Errorf("either 'jwt_profile_file' or 'jwt_profile_json' is required")
+		return diag.Errorf("either 'jwt_file', 'jwt_profile_file' or 'jwt_profile_json' is required")
 	}
 
 	resp, err := client.Do(r)

--- a/zitadel/provider.go
+++ b/zitadel/provider.go
@@ -111,6 +111,7 @@ type providerModel struct {
 	Domain         types.String `tfsdk:"domain"`
 	Port           types.String `tfsdk:"port"`
 	Token          types.String `tfsdk:"token"`
+	JWTFile        types.String `tfsdk:"jwt_file"`
 	JWTProfileFile types.String `tfsdk:"jwt_profile_file"`
 	JWTProfileJSON types.String `tfsdk:"jwt_profile_json"`
 }
@@ -136,15 +137,20 @@ func (p *providerPV6) GetSchema(_ context.Context) (tfsdk.Schema, fdiag.Diagnost
 				Optional:    true,
 				Description: "Path to the file containing credentials to connect to ZITADEL",
 			},
+			helper.JWTFile: {
+				Type:        types.StringType,
+				Optional:    true,
+				Description: "Path to the file containing presigned JWT to connect to ZITADEL. Either 'jwt_file', 'jwt_profile_file' or 'jwt_profile_json' is required",
+			},
 			helper.JWTProfileFile: {
 				Type:        types.StringType,
 				Optional:    true,
-				Description: "Path to the file containing credentials to connect to ZITADEL. Either 'jwt_profile_file' or 'jwt_profile_json' is required",
+				Description: "Path to the file containing credentials to connect to ZITADEL. Either 'jwt_file', 'jwt_profile_file' or 'jwt_profile_json' is required",
 			},
 			helper.JWTProfileJSON: {
 				Type:        types.StringType,
 				Optional:    true,
-				Description: "JSON value of credentials to connect to ZITADEL. Either 'jwt_profile_file' or 'jwt_profile_json' is required",
+				Description: "JSON value of credentials to connect to ZITADEL. Either 'jwt_file', 'jwt_profile_file' or 'jwt_profile_json' is required",
 			},
 			helper.PortVar: {
 				Type:        types.StringType,
@@ -167,6 +173,7 @@ func (p *providerPV6) Configure(ctx context.Context, req provider.ConfigureReque
 		config.Insecure.ValueBool(),
 		config.Domain.ValueString(),
 		config.Token.ValueString(),
+		config.JWTFile.ValueString(),
 		config.JWTProfileFile.ValueString(),
 		config.JWTProfileJSON.ValueString(),
 		config.Port.ValueString(),
@@ -267,6 +274,11 @@ func Provider() *schema.Provider {
 				Optional:    true,
 				Description: "Path to the file containing credentials to connect to ZITADEL",
 			},
+			helper.JWTFile: {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Path to the file containing presigned JWT to connect to ZITADEL. Either 'jwt_file', 'jwt_profile_file' or 'jwt_profile_json' is required",
+			},
 			helper.JWTProfileFile: {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -354,6 +366,7 @@ func ProviderConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		d.Get(helper.InsecureVar).(bool),
 		d.Get(helper.DomainVar).(string),
 		d.Get(helper.TokenVar).(string),
+		d.Get(helper.JWTFile).(string),
 		d.Get(helper.JWTProfileFile).(string),
 		d.Get(helper.JWTProfileJSON).(string),
 		d.Get(helper.PortVar).(string),

--- a/zitadel/provider.go
+++ b/zitadel/provider.go
@@ -125,37 +125,37 @@ func (p *providerPV6) GetSchema(_ context.Context) (tfsdk.Schema, fdiag.Diagnost
 			helper.DomainVar: {
 				Type:        types.StringType,
 				Required:    true,
-				Description: "Domain used to connect to the ZITADEL instance",
+				Description: helper.DomainDescription,
 			},
 			helper.InsecureVar: {
 				Type:        types.BoolType,
 				Optional:    true,
-				Description: "Use insecure connection",
+				Description: helper.InsecureDescription,
 			},
 			helper.TokenVar: {
 				Type:        types.StringType,
 				Optional:    true,
-				Description: "Path to the file containing credentials to connect to ZITADEL",
+				Description: helper.TokenDescription,
 			},
-			helper.JWTFile: {
+			helper.JWTFileVar: {
 				Type:        types.StringType,
 				Optional:    true,
-				Description: "Path to the file containing presigned JWT to connect to ZITADEL. Either 'jwt_file', 'jwt_profile_file' or 'jwt_profile_json' is required",
+				Description: helper.JWTFileDescription,
 			},
-			helper.JWTProfileFile: {
+			helper.JWTProfileFileVar: {
 				Type:        types.StringType,
 				Optional:    true,
-				Description: "Path to the file containing credentials to connect to ZITADEL. Either 'jwt_file', 'jwt_profile_file' or 'jwt_profile_json' is required",
+				Description: helper.JWTProfileFileDescription,
 			},
-			helper.JWTProfileJSON: {
+			helper.JWTProfileJSONVar: {
 				Type:        types.StringType,
 				Optional:    true,
-				Description: "JSON value of credentials to connect to ZITADEL. Either 'jwt_file', 'jwt_profile_file' or 'jwt_profile_json' is required",
+				Description: helper.JWTProfileJSONDescription,
 			},
 			helper.PortVar: {
 				Type:        types.StringType,
 				Optional:    true,
-				Description: "Used port if not the default ports 80 or 443 are configured",
+				Description: helper.PortDescription,
 			},
 		},
 	}, nil
@@ -262,37 +262,37 @@ func Provider() *schema.Provider {
 			helper.DomainVar: {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "Domain used to connect to the ZITADEL instance",
+				Description: helper.DomainDescription,
 			},
 			helper.InsecureVar: {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Description: "Use insecure connection",
+				Description: helper.InsecureDescription,
 			},
 			helper.TokenVar: {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Path to the file containing credentials to connect to ZITADEL",
+				Description: helper.TokenDescription,
 			},
-			helper.JWTFile: {
+			helper.JWTFileVar: {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Path to the file containing presigned JWT to connect to ZITADEL. Either 'jwt_file', 'jwt_profile_file' or 'jwt_profile_json' is required",
+				Description: helper.JWTFileDescription,
 			},
-			helper.JWTProfileFile: {
+			helper.JWTProfileFileVar: {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Path to the file containing credentials to connect to ZITADEL. Either 'jwt_profile_file' or 'jwt_profile_json' is required",
+				Description: helper.JWTProfileFileDescription,
 			},
-			helper.JWTProfileJSON: {
+			helper.JWTProfileJSONVar: {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "JSON value of credentials to connect to ZITADEL. Either 'jwt_profile_file' or 'jwt_profile_json' is required",
+				Description: helper.JWTProfileJSONDescription,
 			},
 			helper.PortVar: {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Used port if not the default ports 80 or 443 are configured",
+				Description: helper.PortDescription,
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
@@ -366,9 +366,9 @@ func ProviderConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		d.Get(helper.InsecureVar).(bool),
 		d.Get(helper.DomainVar).(string),
 		d.Get(helper.TokenVar).(string),
-		d.Get(helper.JWTFile).(string),
-		d.Get(helper.JWTProfileFile).(string),
-		d.Get(helper.JWTProfileJSON).(string),
+		d.Get(helper.JWTFileVar).(string),
+		d.Get(helper.JWTProfileFileVar).(string),
+		d.Get(helper.JWTProfileJSONVar).(string),
 		d.Get(helper.PortVar).(string),
 	)
 	if err != nil {


### PR DESCRIPTION
This feature provides support for authentication using pre-signed JWT tokens. Here are some use cases for this:

- Automated, declarative provisioning of Zitadel, where public/private key pairs are used for authentication of the provisioner.
- Using smart cards or cloud HSMs for authentication.

### Definition of Ready

- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] All non-functional requirements are met
- [ ] The generic lifecycle acceptance test passes for affected resources.
- [ ] Examples are up-to-date and meaningful. The provider version is incremented.
- [ ] Docs are generated.
- [ ] Code is generated where possible.
