### PR TITLE
Fix two error handling errors causing existing resources to be removed

### DIFF
--- a/zitadel/action/funcs.go
+++ b/zitadel/action/funcs.go
@@ -120,10 +120,6 @@ func read(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagn
 			}},
 		},
 	})
-	if err != nil && helper.IgnoreIfNotFoundError(err) == nil {
-		d.SetId("")
-		return nil
-	}
 	if err != nil {
 		return diag.Errorf("failed to list actions")
 	}

--- a/zitadel/project_role/funcs.go
+++ b/zitadel/project_role/funcs.go
@@ -118,9 +118,8 @@ func read(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagn
 			}},
 		},
 	})
-	if err != nil || resp.Result == nil || len(resp.Result) == 0 {
-		d.SetId("")
-		return nil
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
 	if len(resp.Result) == 1 {

--- a/zitadel/project_role/funcs.go
+++ b/zitadel/project_role/funcs.go
@@ -119,7 +119,7 @@ func read(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagn
 		},
 	})
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Errorf("failed to list project roles")
 	}
 
 	if len(resp.Result) == 1 {


### PR DESCRIPTION
We encountered two issues where the database was unavailable while running
the Terraform Zitadel provider with an `action` or `project_role` resource.

#### action resource
After some debugging we found that Zitadel itself returned an error, but
it looks like the middleware (potentially as obfuscation strategy)
converts the error into a `NotFound` error:
https://github.com/zitadel/zitadel/blob/main/internal/api/grpc/server/middleware/instance_interceptor.go#L92-L111

So considering this behavior in the Zitadel API it seem to be a bug to
depend on the error code to determine if the resource should be removed
from the state.

In our case it caused the resource to be removed while it actually did
exist. So trying to run another `terraform apply` when the database was
running again, caused errors like:

```
Error: failed to create action: rpc error: code = AlreadyExists desc =
Errors.Action.AlreadyExists (V3-DKcYh)
```

#### project_role resource
After some debugging we found that Zitadel itself returned an error
(FATAL: the database system is shutting down (SQLSTATE 57P03)), but the
Zitadel provider ignored this error and removed the project role from
the state.

This, of course, caused issues when we tried to execute `terraform
apply` again when the database was restarted. As now the Zitadel
provider thought the roles didn't exist yet and tried to create them
resulting in like:

```
Error: failed to create project role: rpc error: code = AlreadyExists
desc = Role already exists (V3-DKcYh)
```