### PR TITLE
refactor(test): standardize test frame parameters to pointers

### DIFF
--- a/zitadel/default_domain_policy/resource_test.go
+++ b/zitadel/default_domain_policy/resource_test.go
@@ -30,14 +30,14 @@ func TestAccDefaultDomainPolicy(t *testing.T) {
 		exampleProperty, !exampleProperty,
 		"", "", "",
 		false,
-		checkRemoteProperty(*frame),
+		checkRemoteProperty(frame),
 		helper.ZitadelGeneratedIdOnlyRegex,
 		test_utils.CheckNothing,
 		test_utils.ImportNothing,
 	)
 }
 
-func checkRemoteProperty(frame test_utils.InstanceTestFrame) func(bool) resource.TestCheckFunc {
+func checkRemoteProperty(frame *test_utils.InstanceTestFrame) func(bool) resource.TestCheckFunc {
 	return func(expect bool) resource.TestCheckFunc {
 		return func(state *terraform.State) error {
 			resp, err := frame.GetDomainPolicy(frame, &admin.GetDomainPolicyRequest{})

--- a/zitadel/default_label_policy/resource_test.go
+++ b/zitadel/default_label_policy/resource_test.go
@@ -38,7 +38,7 @@ func TestAccDefaultLabelPolicy(t *testing.T) {
 		exampleProperty, "#5469d3",
 		"", "", "",
 		false,
-		checkRemoteProperty(*frame),
+		checkRemoteProperty(frame),
 		helper.ZitadelGeneratedIdOnlyRegex,
 		test_utils.CheckNothing,
 		test_utils.ImportNothing,
@@ -56,7 +56,7 @@ func TestAccDefaultLabelPolicy(t *testing.T) {
 	)
 }
 
-func checkRemoteProperty(frame test_utils.InstanceTestFrame) func(string) resource.TestCheckFunc {
+func checkRemoteProperty(frame *test_utils.InstanceTestFrame) func(string) resource.TestCheckFunc {
 	return func(expect string) resource.TestCheckFunc {
 		return func(state *terraform.State) error {
 			resp, err := frame.GetLabelPolicy(frame, &admin.GetLabelPolicyRequest{})

--- a/zitadel/default_lockout_policy/resource_test.go
+++ b/zitadel/default_lockout_policy/resource_test.go
@@ -29,14 +29,14 @@ func TestAccDefaultLockoutPolicy(t *testing.T) {
 		exampleProperty, 10,
 		"", "", "",
 		false,
-		checkRemoteProperty(*frame),
+		checkRemoteProperty(frame),
 		helper.ZitadelGeneratedIdOnlyRegex,
 		test_utils.CheckNothing,
 		test_utils.ImportNothing,
 	)
 }
 
-func checkRemoteProperty(frame test_utils.InstanceTestFrame) func(uint64) resource.TestCheckFunc {
+func checkRemoteProperty(frame *test_utils.InstanceTestFrame) func(uint64) resource.TestCheckFunc {
 	return func(expect uint64) resource.TestCheckFunc {
 		return func(state *terraform.State) error {
 			resp, err := frame.GetLockoutPolicy(frame, &admin.GetLockoutPolicyRequest{})

--- a/zitadel/default_login_policy/resource_test.go
+++ b/zitadel/default_login_policy/resource_test.go
@@ -29,14 +29,14 @@ func TestAccDefaultLoginPolicy(t *testing.T) {
 		exampleProperty, "localhost:9090",
 		"", "", "",
 		false,
-		checkRemoteProperty(*frame),
+		checkRemoteProperty(frame),
 		helper.ZitadelGeneratedIdOnlyRegex,
 		test_utils.CheckNothing,
 		test_utils.ImportNothing,
 	)
 }
 
-func checkRemoteProperty(frame test_utils.InstanceTestFrame) func(string) resource.TestCheckFunc {
+func checkRemoteProperty(frame *test_utils.InstanceTestFrame) func(string) resource.TestCheckFunc {
 	return func(expect string) resource.TestCheckFunc {
 		return func(state *terraform.State) error {
 			resp, err := frame.GetLoginPolicy(frame, &admin.GetLoginPolicyRequest{})

--- a/zitadel/default_notification_policy/resource_test.go
+++ b/zitadel/default_notification_policy/resource_test.go
@@ -26,14 +26,14 @@ func TestAccDefaultNotificationPolicy(t *testing.T) {
 		initialProperty, updatedProperty,
 		"", "", "",
 		false,
-		checkRemoteProperty(*frame),
+		checkRemoteProperty(frame),
 		helper.ZitadelGeneratedIdOnlyRegex,
 		test_utils.CheckNothing,
 		test_utils.ImportNothing,
 	)
 }
 
-func checkRemoteProperty(frame test_utils.InstanceTestFrame) func(bool) resource.TestCheckFunc {
+func checkRemoteProperty(frame *test_utils.InstanceTestFrame) func(bool) resource.TestCheckFunc {
 	return func(expect bool) resource.TestCheckFunc {
 		return func(state *terraform.State) error {
 			resp, err := frame.GetNotificationPolicy(frame, &admin.GetNotificationPolicyRequest{})

--- a/zitadel/default_oidc_settings/resource_test.go
+++ b/zitadel/default_oidc_settings/resource_test.go
@@ -25,14 +25,14 @@ func TestAccDefaultOIDCSettings(t *testing.T) {
 		exampleProperty, "456h0m0s",
 		"", "", "",
 		false,
-		checkRemoteProperty(*frame),
+		checkRemoteProperty(frame),
 		helper.ZitadelGeneratedIdOnlyRegex,
 		test_utils.CheckNothing,
 		test_utils.ImportNothing,
 	)
 }
 
-func checkRemoteProperty(frame test_utils.InstanceTestFrame) func(string) resource.TestCheckFunc {
+func checkRemoteProperty(frame *test_utils.InstanceTestFrame) func(string) resource.TestCheckFunc {
 	return func(expect string) resource.TestCheckFunc {
 		return func(state *terraform.State) error {
 			resp, err := frame.GetOIDCSettings(frame, &admin.GetOIDCSettingsRequest{})

--- a/zitadel/default_password_age_policy/resource_test.go
+++ b/zitadel/default_password_age_policy/resource_test.go
@@ -32,14 +32,14 @@ func TestDefaultPasswordAgePolicy(t *testing.T) {
 		maxAgeDays, 60,
 		"", "", "",
 		false,
-		checkRemoteProperty(*frame),
+		checkRemoteProperty(frame),
 		helper.ZitadelGeneratedIdOnlyRegex,
 		test_utils.CheckNothing,
 		test_utils.ImportNothing,
 	)
 }
 
-func checkRemoteProperty(frame test_utils.OrgTestFrame) func(uint64) resource.TestCheckFunc {
+func checkRemoteProperty(frame *test_utils.OrgTestFrame) func(uint64) resource.TestCheckFunc {
 	return func(expect uint64) resource.TestCheckFunc {
 		return func(state *terraform.State) error {
 			resp, err := frame.Admin.GetPasswordAgePolicy(frame, &admin.GetPasswordAgePolicyRequest{})

--- a/zitadel/default_password_complexity_policy/resource_test.go
+++ b/zitadel/default_password_complexity_policy/resource_test.go
@@ -29,14 +29,14 @@ func TestAccDefaultPasswordComplexityPolicy(t *testing.T) {
 		exampleProperty, 10,
 		"", "", "",
 		false,
-		checkRemoteProperty(*frame),
+		checkRemoteProperty(frame),
 		helper.ZitadelGeneratedIdOnlyRegex,
 		test_utils.CheckNothing,
 		test_utils.ImportNothing,
 	)
 }
 
-func checkRemoteProperty(frame test_utils.InstanceTestFrame) func(uint64) resource.TestCheckFunc {
+func checkRemoteProperty(frame *test_utils.InstanceTestFrame) func(uint64) resource.TestCheckFunc {
 	return func(expect uint64) resource.TestCheckFunc {
 		return func(state *terraform.State) error {
 			resp, err := frame.GetPasswordComplexityPolicy(frame, &admin.GetPasswordComplexityPolicyRequest{})

--- a/zitadel/default_privacy_policy/resource_test.go
+++ b/zitadel/default_privacy_policy/resource_test.go
@@ -25,14 +25,14 @@ func TestAccDefaultPrivacyPolicy(t *testing.T) {
 		exampleProperty, "http://example.com/acctest",
 		"", "", "",
 		false,
-		checkRemoteProperty(*frame),
+		checkRemoteProperty(frame),
 		helper.ZitadelGeneratedIdOnlyRegex,
 		test_utils.CheckNothing,
 		test_utils.ImportNothing,
 	)
 }
 
-func checkRemoteProperty(frame test_utils.InstanceTestFrame) func(string) resource.TestCheckFunc {
+func checkRemoteProperty(frame *test_utils.InstanceTestFrame) func(string) resource.TestCheckFunc {
 	return func(expect string) resource.TestCheckFunc {
 		return func(state *terraform.State) error {
 			resp, err := frame.GetPrivacyPolicy(frame, &admin.GetPrivacyPolicyRequest{})

--- a/zitadel/default_security_settings/resource_test.go
+++ b/zitadel/default_security_settings/resource_test.go
@@ -39,14 +39,14 @@ resource "zitadel_default_security_settings" "default" {
 		true, false,
 		"", "", "",
 		false,
-		checkRemoteProperty(*frame),
+		checkRemoteProperty(frame),
 		regexp.MustCompile(`^default_security_settings$`),
 		test_utils.CheckNothing,
 		test_utils.ImportNothing,
 	)
 }
 
-func checkRemoteProperty(frame test_utils.InstanceTestFrame) func(bool) resource.TestCheckFunc {
+func checkRemoteProperty(frame *test_utils.InstanceTestFrame) func(bool) resource.TestCheckFunc {
 	return func(expect bool) resource.TestCheckFunc {
 		return func(state *terraform.State) error {
 			client, err := helper.GetSecuritySettingsClient(context.Background(), frame.ClientInfo)

--- a/zitadel/domain_policy/resource_test.go
+++ b/zitadel/domain_policy/resource_test.go
@@ -31,14 +31,14 @@ func TestAccDomainPolicy(t *testing.T) {
 		exampleProperty, !exampleProperty,
 		"", "", "",
 		false,
-		checkRemoteProperty(*otherFrame),
+		checkRemoteProperty(otherFrame),
 		helper.ZitadelGeneratedIdOnlyRegex,
-		checkRemoteProperty(*otherFrame)(false),
+		checkRemoteProperty(otherFrame)(false),
 		test_utils.ImportOrgId(otherFrame),
 	)
 }
 
-func checkRemoteProperty(frame test_utils.OrgTestFrame) func(bool) resource.TestCheckFunc {
+func checkRemoteProperty(frame *test_utils.OrgTestFrame) func(bool) resource.TestCheckFunc {
 	return func(expect bool) resource.TestCheckFunc {
 		return func(state *terraform.State) error {
 			resp, err := frame.GetDomainPolicy(frame, &management.GetDomainPolicyRequest{})

--- a/zitadel/email_provider_http/resource_test.go
+++ b/zitadel/email_provider_http/resource_test.go
@@ -25,7 +25,7 @@ func TestAccEmailHttpProvider(t *testing.T) {
 		exampleProperty, "https://relay.example.com/test",
 		"", "", "",
 		false,
-		checkRemoteProperty(*frame),
+		checkRemoteProperty(frame),
 		helper.ZitadelGeneratedIdOnlyRegex,
 		test_utils.CheckNothing,
 		test_utils.ChainImportStateIdFuncs(
@@ -35,7 +35,7 @@ func TestAccEmailHttpProvider(t *testing.T) {
 	)
 }
 
-func checkRemoteProperty(frame test_utils.InstanceTestFrame) func(string) resource.TestCheckFunc {
+func checkRemoteProperty(frame *test_utils.InstanceTestFrame) func(string) resource.TestCheckFunc {
 	return func(expect string) resource.TestCheckFunc {
 		return func(state *terraform.State) error {
 			resp, err := frame.GetEmailProviderById(frame, &admin.GetEmailProviderByIdRequest{Id: frame.State(state).ID})

--- a/zitadel/instance_member/resource_test.go
+++ b/zitadel/instance_member/resource_test.go
@@ -29,14 +29,14 @@ func TestAccInstanceMember(t *testing.T) {
 		exampleProperty, "IAM_OWNER_VIEWER",
 		"", "", "",
 		true,
-		checkRemoteProperty(*frame, userID),
+		checkRemoteProperty(frame, userID),
 		regexp.MustCompile(fmt.Sprintf("^%s_%s$", helper.ZitadelGeneratedIdPattern, helper.ZitadelGeneratedIdPattern)),
-		test_utils.CheckIsNotFoundFromPropertyCheck(checkRemoteProperty(*frame, userID), ""),
+		test_utils.CheckIsNotFoundFromPropertyCheck(checkRemoteProperty(frame, userID), ""),
 		test_utils.ImportStateAttribute(frame.BaseTestFrame, instance_member.UserIDVar),
 	)
 }
 
-func checkRemoteProperty(frame test_utils.OrgTestFrame, userID string) func(string) resource.TestCheckFunc {
+func checkRemoteProperty(frame *test_utils.OrgTestFrame, userID string) func(string) resource.TestCheckFunc {
 	return func(expect string) resource.TestCheckFunc {
 		return func(state *terraform.State) error {
 			resp, err := frame.Admin.ListIAMMembers(frame, &admin.ListIAMMembersRequest{

--- a/zitadel/label_policy/resource_test.go
+++ b/zitadel/label_policy/resource_test.go
@@ -38,9 +38,9 @@ func TestAccLabelPolicy(t *testing.T) {
 		exampleProperty, "#5469d3",
 		"", "", "",
 		false,
-		checkRemoteProperty(*frame),
+		checkRemoteProperty(frame),
 		helper.ZitadelGeneratedIdOnlyRegex,
-		checkRemoteProperty(*frame)(exampleProperty),
+		checkRemoteProperty(frame)(exampleProperty),
 		test_utils.ImportOrgId(frame),
 		label_policy.SetActiveVar,
 		label_policy.LogoHashVar,
@@ -56,7 +56,7 @@ func TestAccLabelPolicy(t *testing.T) {
 	)
 }
 
-func checkRemoteProperty(frame test_utils.OrgTestFrame) func(string) resource.TestCheckFunc {
+func checkRemoteProperty(frame *test_utils.OrgTestFrame) func(string) resource.TestCheckFunc {
 	return func(expect string) resource.TestCheckFunc {
 		return func(state *terraform.State) error {
 			resp, err := frame.GetLabelPolicy(frame, &management.GetLabelPolicyRequest{})

--- a/zitadel/lockout_policy/resource_test.go
+++ b/zitadel/lockout_policy/resource_test.go
@@ -33,14 +33,14 @@ func TestAccLockoutPolicy(t *testing.T) {
 		exampleProperty, 10,
 		"", "", "",
 		false,
-		checkRemoteProperty(*frame),
+		checkRemoteProperty(frame),
 		helper.ZitadelGeneratedIdOnlyRegex,
-		checkRemoteProperty(*frame)(0),
+		checkRemoteProperty(frame)(0),
 		test_utils.ImportOrgId(frame),
 	)
 }
 
-func checkRemoteProperty(frame test_utils.OrgTestFrame) func(uint64) resource.TestCheckFunc {
+func checkRemoteProperty(frame *test_utils.OrgTestFrame) func(uint64) resource.TestCheckFunc {
 	return func(expect uint64) resource.TestCheckFunc {
 		return func(state *terraform.State) error {
 			resp, err := frame.GetLockoutPolicy(frame, &management.GetLockoutPolicyRequest{})

--- a/zitadel/login_policy/resource_test.go
+++ b/zitadel/login_policy/resource_test.go
@@ -29,14 +29,14 @@ func TestAccLoginPolicy(t *testing.T) {
 		exampleProperty, "localhost:9090",
 		"", "", "",
 		false,
-		checkRemoteProperty(*frame),
+		checkRemoteProperty(frame),
 		helper.ZitadelGeneratedIdOnlyRegex,
-		checkRemoteProperty(*frame)(""),
+		checkRemoteProperty(frame)(""),
 		test_utils.ImportOrgId(frame),
 	)
 }
 
-func checkRemoteProperty(frame test_utils.OrgTestFrame) func(string) resource.TestCheckFunc {
+func checkRemoteProperty(frame *test_utils.OrgTestFrame) func(string) resource.TestCheckFunc {
 	return func(expect string) resource.TestCheckFunc {
 		return func(state *terraform.State) error {
 			resp, err := frame.GetLoginPolicy(frame, &management.GetLoginPolicyRequest{})

--- a/zitadel/machine_key/resource_test.go
+++ b/zitadel/machine_key/resource_test.go
@@ -31,9 +31,9 @@ func TestAccMachineKey(t *testing.T) {
 		exampleProperty, "2051-01-01T00:00:00Z",
 		"", "", "",
 		false,
-		checkRemoteProperty(*frame, userID),
+		checkRemoteProperty(frame, userID),
 		helper.ZitadelGeneratedIdOnlyRegex,
-		test_utils.CheckIsNotFoundFromPropertyCheck(checkRemoteProperty(*frame, userID), ""),
+		test_utils.CheckIsNotFoundFromPropertyCheck(checkRemoteProperty(frame, userID), ""),
 		test_utils.ChainImportStateIdFuncs(
 			test_utils.ImportResourceId(frame.BaseTestFrame),
 			test_utils.ImportStateAttribute(frame.BaseTestFrame, machine_key.UserIDVar),
@@ -56,9 +56,9 @@ func TestAccMachineKeyWithPublicKey(t *testing.T) {
 		exampleProperty, "2051-01-01T00:00:00Z",
 		"", "", "",
 		false,
-		checkRemoteProperty(*frame, userID),
+		checkRemoteProperty(frame, userID),
 		helper.ZitadelGeneratedIdOnlyRegex,
-		test_utils.CheckIsNotFoundFromPropertyCheck(checkRemoteProperty(*frame, userID), ""),
+		test_utils.CheckIsNotFoundFromPropertyCheck(checkRemoteProperty(frame, userID), ""),
 		test_utils.ChainImportStateIdFuncs(
 			test_utils.ImportResourceId(frame.BaseTestFrame),
 			test_utils.ImportStateAttribute(frame.BaseTestFrame, machine_key.UserIDVar),
@@ -90,7 +90,7 @@ func importStateAttributeBase64(frame test_utils.BaseTestFrame, attr string) res
 	}
 }
 
-func checkRemoteProperty(frame test_utils.OrgTestFrame, userID string) func(string) resource.TestCheckFunc {
+func checkRemoteProperty(frame *test_utils.OrgTestFrame, userID string) func(string) resource.TestCheckFunc {
 	return func(expect string) resource.TestCheckFunc {
 		return func(state *terraform.State) error {
 			resp, err := frame.GetMachineKeyByIDs(frame, &management.GetMachineKeyByIDsRequest{

--- a/zitadel/notification_policy/resource_test.go
+++ b/zitadel/notification_policy/resource_test.go
@@ -26,14 +26,14 @@ func TestAccNotificationPolicy(t *testing.T) {
 		initialProperty, updatedProperty,
 		"", "", "",
 		false,
-		checkRemoteProperty(*frame),
+		checkRemoteProperty(frame),
 		helper.ZitadelGeneratedIdOnlyRegex,
-		checkRemoteProperty(*frame)(true),
+		checkRemoteProperty(frame)(true),
 		test_utils.ImportOrgId(frame),
 	)
 }
 
-func checkRemoteProperty(frame test_utils.OrgTestFrame) func(bool) resource.TestCheckFunc {
+func checkRemoteProperty(frame *test_utils.OrgTestFrame) func(bool) resource.TestCheckFunc {
 	return func(expect bool) resource.TestCheckFunc {
 		return func(state *terraform.State) error {
 			resp, err := frame.GetNotificationPolicy(frame, &management.GetNotificationPolicyRequest{})

--- a/zitadel/org_idp_jwt/resource_test.go
+++ b/zitadel/org_idp_jwt/resource_test.go
@@ -29,9 +29,9 @@ func TestAccOrgIDPJWT(t *testing.T) {
 		exampleProperty, updatedProperty,
 		"", "", "",
 		true,
-		checkRemoteProperty(*frame),
+		checkRemoteProperty(frame),
 		helper.ZitadelGeneratedIdOnlyRegex,
-		test_utils.CheckIsNotFoundFromPropertyCheck(checkRemoteProperty(*frame), updatedProperty),
+		test_utils.CheckIsNotFoundFromPropertyCheck(checkRemoteProperty(frame), updatedProperty),
 		test_utils.ChainImportStateIdFuncs(
 			test_utils.ImportResourceId(frame.BaseTestFrame),
 			test_utils.ImportOrgId(frame),
@@ -39,7 +39,7 @@ func TestAccOrgIDPJWT(t *testing.T) {
 	)
 }
 
-func checkRemoteProperty(frame test_utils.OrgTestFrame) func(string) resource.TestCheckFunc {
+func checkRemoteProperty(frame *test_utils.OrgTestFrame) func(string) resource.TestCheckFunc {
 	return func(expect string) resource.TestCheckFunc {
 		return func(state *terraform.State) error {
 			resp, err := frame.GetOrgIDPByID(frame, &management.GetOrgIDPByIDRequest{

--- a/zitadel/org_member/resource_test.go
+++ b/zitadel/org_member/resource_test.go
@@ -30,9 +30,9 @@ func TestAccOrgMember(t *testing.T) {
 		exampleProperty, updatedProperty,
 		"", "", "",
 		true,
-		checkRemoteProperty(*frame, userID),
+		checkRemoteProperty(frame, userID),
 		regexp.MustCompile(fmt.Sprintf("^%s_%s$", helper.ZitadelGeneratedIdPattern, helper.ZitadelGeneratedIdPattern)),
-		test_utils.CheckIsNotFoundFromPropertyCheck(checkRemoteProperty(*frame, userID), ""),
+		test_utils.CheckIsNotFoundFromPropertyCheck(checkRemoteProperty(frame, userID), ""),
 		test_utils.ChainImportStateIdFuncs(
 			test_utils.ImportStateAttribute(frame.BaseTestFrame, org_member.UserIDVar),
 			test_utils.ImportOrgId(frame),
@@ -40,7 +40,7 @@ func TestAccOrgMember(t *testing.T) {
 	)
 }
 
-func checkRemoteProperty(frame test_utils.OrgTestFrame, userID string) func(string) resource.TestCheckFunc {
+func checkRemoteProperty(frame *test_utils.OrgTestFrame, userID string) func(string) resource.TestCheckFunc {
 	return func(expect string) resource.TestCheckFunc {
 		return func(state *terraform.State) error {
 			resp, err := frame.ListOrgMembers(frame, &management.ListOrgMembersRequest{

--- a/zitadel/org_metadata/resource_test.go
+++ b/zitadel/org_metadata/resource_test.go
@@ -27,9 +27,9 @@ func TestAccOrgMetadata(t *testing.T) {
 		exampleProperty, updatedProperty,
 		"", "", "",
 		false,
-		checkRemoteProperty(*frame),
+		checkRemoteProperty(frame),
 		regexp.MustCompile(fmt.Sprintf(`^%s$`, keyProperty)),
-		test_utils.CheckIsNotFoundFromPropertyCheck(checkRemoteProperty(*frame), ""),
+		test_utils.CheckIsNotFoundFromPropertyCheck(checkRemoteProperty(frame), ""),
 		test_utils.ChainImportStateIdFuncs(
 			test_utils.ImportStateAttribute(frame.BaseTestFrame, org_metadata.KeyVar),
 			test_utils.ImportOrgId(frame),
@@ -37,7 +37,7 @@ func TestAccOrgMetadata(t *testing.T) {
 	)
 }
 
-func checkRemoteProperty(frame test_utils.OrgTestFrame) func(string) resource.TestCheckFunc {
+func checkRemoteProperty(frame *test_utils.OrgTestFrame) func(string) resource.TestCheckFunc {
 	return func(expect string) resource.TestCheckFunc {
 		return func(state *terraform.State) error {
 			resp, err := frame.GetOrgMetadata(frame, &management.GetOrgMetadataRequest{

--- a/zitadel/password_age_policy/resource_test.go
+++ b/zitadel/password_age_policy/resource_test.go
@@ -33,14 +33,14 @@ func TestPasswordAgePolicy(t *testing.T) {
 		maxAgeDays, updatedProperty,
 		"", "", "",
 		false,
-		checkRemoteProperty(*frame),
+		checkRemoteProperty(frame),
 		helper.ZitadelGeneratedIdOnlyRegex,
 		test_utils.CheckNothing,
 		test_utils.ImportOrgId(frame),
 	)
 }
 
-func checkRemoteProperty(frame test_utils.OrgTestFrame) func(uint64) resource.TestCheckFunc {
+func checkRemoteProperty(frame *test_utils.OrgTestFrame) func(uint64) resource.TestCheckFunc {
 	return func(expect uint64) resource.TestCheckFunc {
 		return func(state *terraform.State) error {
 			resp, err := frame.GetPasswordAgePolicy(frame, &management.GetPasswordAgePolicyRequest{})

--- a/zitadel/password_complexity_policy/resource_test.go
+++ b/zitadel/password_complexity_policy/resource_test.go
@@ -29,14 +29,14 @@ func TestAccPasswordComplexityPolicy(t *testing.T) {
 		exampleProperty, updatedProperty,
 		"", "", "",
 		false,
-		checkRemoteProperty(*frame),
+		checkRemoteProperty(frame),
 		helper.ZitadelGeneratedIdOnlyRegex,
-		checkRemoteProperty(*frame)(exampleProperty),
+		checkRemoteProperty(frame)(exampleProperty),
 		test_utils.ImportOrgId(frame),
 	)
 }
 
-func checkRemoteProperty(frame test_utils.OrgTestFrame) func(uint64) resource.TestCheckFunc {
+func checkRemoteProperty(frame *test_utils.OrgTestFrame) func(uint64) resource.TestCheckFunc {
 	return func(expect uint64) resource.TestCheckFunc {
 		return func(state *terraform.State) error {
 			resp, err := frame.GetPasswordComplexityPolicy(frame, &management.GetPasswordComplexityPolicyRequest{})

--- a/zitadel/pat/resource_test.go
+++ b/zitadel/pat/resource_test.go
@@ -28,9 +28,9 @@ func TestAccPersonalAccessToken(t *testing.T) {
 		exampleProperty, updatedProperty,
 		"", "", "",
 		false,
-		checkRemoteProperty(*frame, userID),
+		checkRemoteProperty(frame, userID),
 		helper.ZitadelGeneratedIdOnlyRegex,
-		test_utils.CheckIsNotFoundFromPropertyCheck(checkRemoteProperty(*frame, userID), ""),
+		test_utils.CheckIsNotFoundFromPropertyCheck(checkRemoteProperty(frame, userID), ""),
 		test_utils.ChainImportStateIdFuncs(
 			test_utils.ImportResourceId(frame.BaseTestFrame),
 			test_utils.ImportStateAttribute(frame.BaseTestFrame, pat.UserIDVar),
@@ -40,7 +40,7 @@ func TestAccPersonalAccessToken(t *testing.T) {
 	)
 }
 
-func checkRemoteProperty(frame test_utils.OrgTestFrame, userID string) func(string) resource.TestCheckFunc {
+func checkRemoteProperty(frame *test_utils.OrgTestFrame, userID string) func(string) resource.TestCheckFunc {
 	return func(expect string) resource.TestCheckFunc {
 		return func(state *terraform.State) error {
 			resp, err := frame.GetPersonalAccessTokenByIDs(frame, &management.GetPersonalAccessTokenByIDsRequest{

--- a/zitadel/privacy_policy/resource_test.go
+++ b/zitadel/privacy_policy/resource_test.go
@@ -25,14 +25,14 @@ func TestAccPrivacyPolicy(t *testing.T) {
 		exampleProperty, "http://example.com/acctest",
 		"", "", "",
 		false,
-		checkRemoteProperty(*frame),
+		checkRemoteProperty(frame),
 		helper.ZitadelGeneratedIdOnlyRegex,
-		checkRemoteProperty(*frame)(""),
+		checkRemoteProperty(frame)(""),
 		test_utils.ImportOrgId(frame),
 	)
 }
 
-func checkRemoteProperty(frame test_utils.OrgTestFrame) func(string) resource.TestCheckFunc {
+func checkRemoteProperty(frame *test_utils.OrgTestFrame) func(string) resource.TestCheckFunc {
 	return func(expect string) resource.TestCheckFunc {
 		return func(state *terraform.State) error {
 			resp, err := frame.GetPrivacyPolicy(frame, &management.GetPrivacyPolicyRequest{})

--- a/zitadel/project_grant/resource_test.go
+++ b/zitadel/project_grant/resource_test.go
@@ -32,9 +32,9 @@ func TestAccProjectGrant(t *testing.T) {
 		exampleProperty, updatedProperty,
 		"", "", "",
 		false,
-		checkRemoteProperty(*frame, projectID),
+		checkRemoteProperty(frame, projectID),
 		helper.ZitadelGeneratedIdOnlyRegex,
-		test_utils.CheckIsNotFoundFromPropertyCheck(checkRemoteProperty(*frame, projectID), ""),
+		test_utils.CheckIsNotFoundFromPropertyCheck(checkRemoteProperty(frame, projectID), ""),
 		test_utils.ChainImportStateIdFuncs(
 			test_utils.ImportResourceId(frame.BaseTestFrame),
 			test_utils.ImportStateAttribute(frame.BaseTestFrame, project_grant.ProjectIDVar),
@@ -43,7 +43,7 @@ func TestAccProjectGrant(t *testing.T) {
 	)
 }
 
-func checkRemoteProperty(frame test_utils.OrgTestFrame, projectID string) func(string) resource.TestCheckFunc {
+func checkRemoteProperty(frame *test_utils.OrgTestFrame, projectID string) func(string) resource.TestCheckFunc {
 	return func(expect string) resource.TestCheckFunc {
 		return func(state *terraform.State) error {
 			resp, err := frame.GetProjectGrantByID(frame, &management.GetProjectGrantByIDRequest{

--- a/zitadel/project_grant_member/resource_test.go
+++ b/zitadel/project_grant_member/resource_test.go
@@ -38,7 +38,7 @@ func TestAccProjectGrantMember(t *testing.T) {
 		exampleProperty, "PROJECT_GRANT_OWNER_VIEWER",
 		"", "", "",
 		true,
-		checkRemoteProperty(*frame, projectID, grantID, userID),
+		checkRemoteProperty(frame, projectID, grantID, userID),
 		regexp.MustCompile(fmt.Sprintf(
 			"^%s_%s_%s_%s$",
 			helper.ZitadelGeneratedIdPattern,
@@ -46,7 +46,7 @@ func TestAccProjectGrantMember(t *testing.T) {
 			helper.ZitadelGeneratedIdPattern,
 			helper.ZitadelGeneratedIdPattern,
 		)),
-		test_utils.CheckIsNotFoundFromPropertyCheck(checkRemoteProperty(*frame, projectID, grantID, userID), ""),
+		test_utils.CheckIsNotFoundFromPropertyCheck(checkRemoteProperty(frame, projectID, grantID, userID), ""),
 		test_utils.ChainImportStateIdFuncs(
 			test_utils.ImportStateAttribute(frame.BaseTestFrame, project_grant_member.ProjectIDVar),
 			test_utils.ImportStateAttribute(frame.BaseTestFrame, project_grant_member.GrantIDVar),
@@ -56,7 +56,7 @@ func TestAccProjectGrantMember(t *testing.T) {
 	)
 }
 
-func checkRemoteProperty(frame test_utils.OrgTestFrame, projectID, grantID, userID string) func(string) resource.TestCheckFunc {
+func checkRemoteProperty(frame *test_utils.OrgTestFrame, projectID, grantID, userID string) func(string) resource.TestCheckFunc {
 	return func(expect string) resource.TestCheckFunc {
 		return func(state *terraform.State) error {
 			resp, err := frame.ListProjectGrantMembers(frame, &management.ListProjectGrantMembersRequest{

--- a/zitadel/project_member/resource_test.go
+++ b/zitadel/project_member/resource_test.go
@@ -32,9 +32,9 @@ func TestAccProjectMember(t *testing.T) {
 		exampleProperty, "PROJECT_OWNER_VIEWER",
 		"", "", "",
 		true,
-		checkRemoteProperty(*frame, projectID, userID),
+		checkRemoteProperty(frame, projectID, userID),
 		regexp.MustCompile(fmt.Sprintf("^%s_%s_%s$", helper.ZitadelGeneratedIdPattern, helper.ZitadelGeneratedIdPattern, helper.ZitadelGeneratedIdPattern)),
-		test_utils.CheckIsNotFoundFromPropertyCheck(checkRemoteProperty(*frame, projectID, userID), ""),
+		test_utils.CheckIsNotFoundFromPropertyCheck(checkRemoteProperty(frame, projectID, userID), ""),
 		test_utils.ChainImportStateIdFuncs(
 			test_utils.ImportStateAttribute(frame.BaseTestFrame, project_member.ProjectIDVar),
 			test_utils.ImportStateAttribute(frame.BaseTestFrame, project_member.UserIDVar),
@@ -43,7 +43,7 @@ func TestAccProjectMember(t *testing.T) {
 	)
 }
 
-func checkRemoteProperty(frame test_utils.OrgTestFrame, projectID, userID string) func(string) resource.TestCheckFunc {
+func checkRemoteProperty(frame *test_utils.OrgTestFrame, projectID, userID string) func(string) resource.TestCheckFunc {
 	return func(expect string) resource.TestCheckFunc {
 		return func(state *terraform.State) error {
 			resp, err := frame.ListProjectMembers(frame, &management.ListProjectMembersRequest{

--- a/zitadel/project_role/resource_test.go
+++ b/zitadel/project_role/resource_test.go
@@ -30,9 +30,9 @@ func TestAccProjectRole(t *testing.T) {
 		exampleProperty, updatedProperty,
 		"", "", "",
 		true,
-		checkRemoteProperty(*frame, projectID),
+		checkRemoteProperty(frame, projectID),
 		regexp.MustCompile(fmt.Sprintf("^%s_%s_(%s|%s)$", helper.ZitadelGeneratedIdPattern, helper.ZitadelGeneratedIdPattern, exampleProperty, updatedProperty)),
-		test_utils.CheckIsNotFoundFromPropertyCheck(checkRemoteProperty(*frame, projectID), ""),
+		test_utils.CheckIsNotFoundFromPropertyCheck(checkRemoteProperty(frame, projectID), ""),
 		test_utils.ChainImportStateIdFuncs(
 			test_utils.ImportStateAttribute(frame.BaseTestFrame, project_role.ProjectIDVar),
 			test_utils.ImportStateAttribute(frame.BaseTestFrame, project_role.KeyVar),
@@ -41,7 +41,7 @@ func TestAccProjectRole(t *testing.T) {
 	)
 }
 
-func checkRemoteProperty(frame test_utils.OrgTestFrame, projectID string) func(string) resource.TestCheckFunc {
+func checkRemoteProperty(frame *test_utils.OrgTestFrame, projectID string) func(string) resource.TestCheckFunc {
 	return func(expect string) resource.TestCheckFunc {
 		return func(state *terraform.State) error {
 			resp, err := frame.ListProjectRoles(frame, &management.ListProjectRolesRequest{

--- a/zitadel/sms_provider_http/resource_test.go
+++ b/zitadel/sms_provider_http/resource_test.go
@@ -25,7 +25,7 @@ func TestAccSMSHttpProvider(t *testing.T) {
 		exampleProperty, "https://relay.example.com/test",
 		"", "", "",
 		false,
-		checkRemoteProperty(*frame),
+		checkRemoteProperty(frame),
 		helper.ZitadelGeneratedIdOnlyRegex,
 		test_utils.CheckNothing,
 		test_utils.ChainImportStateIdFuncs(
@@ -34,7 +34,7 @@ func TestAccSMSHttpProvider(t *testing.T) {
 	)
 }
 
-func checkRemoteProperty(frame test_utils.InstanceTestFrame) func(string) resource.TestCheckFunc {
+func checkRemoteProperty(frame *test_utils.InstanceTestFrame) func(string) resource.TestCheckFunc {
 	return func(expect string) resource.TestCheckFunc {
 		return func(state *terraform.State) error {
 			resp, err := frame.GetSMSProvider(frame, &admin.GetSMSProviderRequest{Id: frame.State(state).ID})

--- a/zitadel/sms_provider_twilio/resource_test.go
+++ b/zitadel/sms_provider_twilio/resource_test.go
@@ -26,7 +26,7 @@ func TestAccSMSProviderTwilio(t *testing.T) {
 		exampleProperty, "987654321",
 		sms_provider_twilio.TokenVar, exampleSecret, "updatedSecret",
 		false,
-		checkRemoteProperty(*frame),
+		checkRemoteProperty(frame),
 		helper.ZitadelGeneratedIdOnlyRegex,
 		test_utils.CheckNothing,
 		test_utils.ChainImportStateIdFuncs(
@@ -36,7 +36,7 @@ func TestAccSMSProviderTwilio(t *testing.T) {
 	)
 }
 
-func checkRemoteProperty(frame test_utils.InstanceTestFrame) func(string) resource.TestCheckFunc {
+func checkRemoteProperty(frame *test_utils.InstanceTestFrame) func(string) resource.TestCheckFunc {
 	return func(expect string) resource.TestCheckFunc {
 		return func(state *terraform.State) error {
 			resp, err := frame.GetSMSProvider(frame, &admin.GetSMSProviderRequest{Id: frame.State(state).ID})

--- a/zitadel/trigger_actions/resource_test.go
+++ b/zitadel/trigger_actions/resource_test.go
@@ -31,9 +31,9 @@ func TestAccTriggerActions(t *testing.T) {
 		exampleProperty, updatedProperty,
 		"", "", "",
 		false,
-		checkRemoteProperty(*frame, flowType),
+		checkRemoteProperty(frame, flowType),
 		regexp.MustCompile(fmt.Sprintf("^%s_([A-Z_]+)_(%s|%s)$", helper.ZitadelGeneratedIdPattern, exampleProperty, updatedProperty)),
-		test_utils.CheckIsNotFoundFromPropertyCheck(checkRemoteProperty(*frame, flowType), exampleProperty),
+		test_utils.CheckIsNotFoundFromPropertyCheck(checkRemoteProperty(frame, flowType), exampleProperty),
 		test_utils.ChainImportStateIdFuncs(
 			test_utils.ImportStateAttribute(frame.BaseTestFrame, trigger_actions.FlowTypeVar),
 			test_utils.ImportStateAttribute(frame.BaseTestFrame, trigger_actions.TriggerTypeVar),
@@ -42,7 +42,7 @@ func TestAccTriggerActions(t *testing.T) {
 	)
 }
 
-func checkRemoteProperty(frame test_utils.OrgTestFrame, flowType string) func(string) resource.TestCheckFunc {
+func checkRemoteProperty(frame *test_utils.OrgTestFrame, flowType string) func(string) resource.TestCheckFunc {
 	return func(expect string) resource.TestCheckFunc {
 		return func(state *terraform.State) error {
 			flowTypeValues := helper.EnumValueMap(trigger_actions.FlowTypes())

--- a/zitadel/user_grant/resource_test.go
+++ b/zitadel/user_grant/resource_test.go
@@ -32,9 +32,9 @@ func TestAccUserGrant(t *testing.T) {
 		exampleProperty, updatedProperty,
 		"", "", "",
 		true,
-		checkRemoteProperty(*frame, userID),
+		checkRemoteProperty(frame, userID),
 		helper.ZitadelGeneratedIdOnlyRegex,
-		test_utils.CheckIsNotFoundFromPropertyCheck(checkRemoteProperty(*frame, userID), ""),
+		test_utils.CheckIsNotFoundFromPropertyCheck(checkRemoteProperty(frame, userID), ""),
 		test_utils.ChainImportStateIdFuncs(
 			test_utils.ImportResourceId(frame.BaseTestFrame),
 			test_utils.ImportStateAttribute(frame.BaseTestFrame, user_grant.UserIDVar),
@@ -43,7 +43,7 @@ func TestAccUserGrant(t *testing.T) {
 	)
 }
 
-func checkRemoteProperty(frame test_utils.OrgTestFrame, userID string) func(string) resource.TestCheckFunc {
+func checkRemoteProperty(frame *test_utils.OrgTestFrame, userID string) func(string) resource.TestCheckFunc {
 	return func(expect string) resource.TestCheckFunc {
 		return func(state *terraform.State) error {
 			resp, err := frame.GetUserGrantByID(frame, &management.GetUserGrantByIDRequest{

--- a/zitadel/user_metadata/resource_test.go
+++ b/zitadel/user_metadata/resource_test.go
@@ -30,9 +30,9 @@ func TestAccUserMetadata(t *testing.T) {
 		exampleProperty, updatedProperty,
 		"", "", "",
 		false,
-		checkRemoteProperty(*frame, userID, keyProperty),
+		checkRemoteProperty(frame, userID, keyProperty),
 		regexp.MustCompile(fmt.Sprintf(`^%s_%s$`, helper.ZitadelGeneratedIdPattern, keyProperty)),
-		test_utils.CheckIsNotFoundFromPropertyCheck(checkRemoteProperty(*frame, userID, keyProperty), ""),
+		test_utils.CheckIsNotFoundFromPropertyCheck(checkRemoteProperty(frame, userID, keyProperty), ""),
 		test_utils.ChainImportStateIdFuncs(
 			test_utils.ImportStateAttribute(frame.BaseTestFrame, user_metadata.UserIDVar),
 			test_utils.ImportStateAttribute(frame.BaseTestFrame, user_metadata.KeyVar),
@@ -41,7 +41,7 @@ func TestAccUserMetadata(t *testing.T) {
 	)
 }
 
-func checkRemoteProperty(frame test_utils.OrgTestFrame, userID, key string) func(string) resource.TestCheckFunc {
+func checkRemoteProperty(frame *test_utils.OrgTestFrame, userID, key string) func(string) resource.TestCheckFunc {
 	return func(expect string) resource.TestCheckFunc {
 		return func(state *terraform.State) error {
 			resp, err := frame.GetUserMetadata(frame, &management.GetUserMetadataRequest{


### PR DESCRIPTION
This pull request standardises all test helper functions to use pointer receivers for OrgTestFrame and InstanceTestFrame instead of passing them by value. This change aligns with the established pattern used in newer resources and dependency helpers, avoids unnecessary struct copying, and matches the pointer receiver methods already defined on these frame types. All call sites have been updated to pass frames directly rather than dereferencing them, ensuring consistency across the entire test suite.

### Definition of Ready

- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] All non-functional requirements are met
- [x] The generic lifecycle acceptance test passes for affected resources.
- [x] Examples are up-to-date and meaningful. The provider version is incremented.
- [x] Docs are generated.
- [x] Code is generated where possible.
