### PR TITLE
fix: allow custom org IDs in resource imports

### DIFF
--- a/zitadel/helper/import.go
+++ b/zitadel/helper/import.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	ImportOptionalOrgAttribute = NewImportAttribute(OrgIDVar, ConvertID, true)
+	ImportOptionalOrgAttribute = NewImportAttribute(OrgIDVar, ConvertNonEmpty, true)
 	emptyIDAttribute           = NewImportAttribute(`""`, ConvertEmpty, false)
 	SemicolonPlaceholder       = "__SEMICOLON__"
 )

--- a/zitadel/helper/schema.go
+++ b/zitadel/helper/schema.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/hashicorp/go-cty/cty"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -28,10 +26,6 @@ var (
 		Optional:    true,
 		Description: "ID of the organization. If not provided, the organization of the authenticated user/service account is used.",
 		ForceNew:    true,
-		ValidateDiagFunc: func(i interface{}, path cty.Path) diag.Diagnostics {
-			_, err := ConvertID(i.(string))
-			return diag.FromErr(err)
-		},
 	}
 
 	ResourceIDDatasourceField = &schema.Schema{

--- a/zitadel/org/datasource.go
+++ b/zitadel/org/datasource.go
@@ -18,10 +18,6 @@ func GetDatasource() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "ID of the organization",
-				ValidateDiagFunc: func(i interface{}, path cty.Path) diag.Diagnostics {
-					_, err := helper.ConvertID(i.(string))
-					return diag.FromErr(err)
-				},
 			},
 			NameVar: {
 				Type:        schema.TypeString,

--- a/zitadel/organization/datasource.go
+++ b/zitadel/organization/datasource.go
@@ -18,10 +18,6 @@ func GetDatasource() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "ID of the organization",
-				ValidateDiagFunc: func(i interface{}, path cty.Path) diag.Diagnostics {
-					_, err := helper.ConvertID(i.(string))
-					return diag.FromErr(err)
-				},
 			},
 			NameVar: {
 				Type:        schema.TypeString,


### PR DESCRIPTION
This PR fixes an issue where terraform import failed for resources belonging to organisations with custom IDs.                                                                                                 
                                                                                                                                                                                                                 
When importing resources like `zitadel_org_idp_saml` with a custom org_id, the import would fail with the error: id "test_org_id" does not match regular expression ^\d{18}$                                     
                                                                                                                                                                                                                 Zitadel supports custom org IDs - however, the Terraform provider was still validating org_id fields against the 18-digit pattern used for auto-generated IDs.                                                                                                                                                      
                                                                                                                                                                                                                 
This change removes the overly strict validation from org_id fields across the provider, allowing both auto-generated IDs and custom IDs to be used. The import still validates that org_id is not empty when provided.                                                                                                                                                                                                 
                                                                                                                                                                                                                 
Tested by running the full test suite and adding a regression test that verifies custom org IDs work for all 12 org IDP resources.                                                                             
                                                                                                                                                   
Fixes #344

### Definition of Ready

- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] All non-functional requirements are met
- [x] The generic lifecycle acceptance test passes for affected resources.
- [x] Examples are up-to-date and meaningful. The provider version is incremented.
- [x] Docs are generated.
- [x] Code is generated where possible.
