### PR TITLE
docs: update documentation to match default values

### DIFF
--- a/docs/resources/default_oidc_settings.md
+++ b/docs/resources/default_oidc_settings.md
@@ -15,8 +15,8 @@ Resource representing the default oidc settings.
 resource "zitadel_default_oidc_settings" "default" {
   access_token_lifetime         = "12h0m0s"
   id_token_lifetime             = "12h0m0s"
-  refresh_token_expiration      = "720h0m0s"
-  refresh_token_idle_expiration = "2160h0m0s"
+  refresh_token_expiration      = "2160h0m0s"
+  refresh_token_idle_expiration = "720h0m0s"
 }
 ```
 

--- a/examples/provider/resources/default_oidc_settings.tf
+++ b/examples/provider/resources/default_oidc_settings.tf
@@ -1,6 +1,6 @@
 resource "zitadel_default_oidc_settings" "default" {
   access_token_lifetime         = "12h0m0s"
   id_token_lifetime             = "12h0m0s"
-  refresh_token_expiration      = "720h0m0s"
-  refresh_token_idle_expiration = "2160h0m0s"
+  refresh_token_expiration      = "2160h0m0s"
+  refresh_token_idle_expiration = "720h0m0s"
 }


### PR DESCRIPTION
Example for zitadel_default_oidc_settings had nonsensical defaults. It seems the refresh_token_idle_expiration and refresh_token_expiration were reversed. Edited to match Zitadel defaults.

Note: I did not run terraform format as it changes over 100 files. If that needs to be done, I'm happy to run it, but it seems out of place in this PR. 