### PR TITLE
Fix instance custom domain consistency and acceptance test

### DIFF
--- a/zitadel/instance_custom_domain/funcs.go
+++ b/zitadel/instance_custom_domain/funcs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -38,6 +39,12 @@ func create(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", instanceID, domain))
+
+	// The add call can return before list APIs reflect the new domain.
+	if err := waitUntilCustomDomainExists(ctx, client, instanceID, domain); err != nil {
+		return diag.Errorf("failed waiting for custom domain to be readable: %v", err)
+	}
+
 	return read(ctx, d, m)
 }
 
@@ -70,7 +77,7 @@ func read(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagn
 
 	found := false
 	for _, domainEntry := range resp.GetDomains() {
-		if domainEntry.GetDomain() == domain {
+		if equalsDomain(domainEntry.GetDomain(), domain) {
 			found = true
 			break
 		}
@@ -93,6 +100,44 @@ func read(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagn
 	}
 
 	return nil
+}
+
+func waitUntilCustomDomainExists(ctx context.Context, client instance.InstanceServiceClient, instanceID, domain string) error {
+	deadline := time.Now().Add(30 * time.Second)
+
+	for {
+		resp, err := client.ListCustomDomains(ctx, &instance.ListCustomDomainsRequest{
+			InstanceId: instanceID,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to list custom domains: %w", err)
+		}
+
+		for _, domainEntry := range resp.GetDomains() {
+			if equalsDomain(domainEntry.GetDomain(), domain) {
+				return nil
+			}
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf(
+				"custom domain %q was not found for instance %q before deadline %s",
+				domain,
+				instanceID,
+				deadline.Format(time.RFC3339Nano),
+			)
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
+	}
+}
+
+func equalsDomain(a, b string) bool {
+	return strings.EqualFold(strings.TrimSuffix(a, "."), strings.TrimSuffix(b, "."))
 }
 
 func delete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/zitadel/instance_custom_domain/resource_test.go
+++ b/zitadel/instance_custom_domain/resource_test.go
@@ -1,37 +1,50 @@
 package instance_custom_domain_test
 
 import (
+	"context"
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	instancev2 "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/instance/v2"
 
+	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/helper"
 	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/helper/test_utils"
 )
 
 func TestAccInstanceCustomDomain(t *testing.T) {
-	t.Skip("Skipping test - requires system-level credentials with system.domain.write permission")
-	frame := test_utils.NewInstanceTestFrame(t, "zitadel_instance_custom_domain")
+	frame := test_utils.NewSystemTestFrame(t, "zitadel_instance_custom_domain")
+
+	instanceClient, err := helper.GetInstanceClient(context.Background(), frame.ClientInfo)
+	if err != nil {
+		t.Fatalf("failed to get instance client: %v", err)
+	}
+
+	instanceResp, err := instanceClient.GetInstance(context.Background(), &instancev2.GetInstanceRequest{})
+	if err != nil {
+		t.Fatalf("failed to get instance: %v", err)
+	}
+	instanceID := instanceResp.GetInstance().GetId()
+	testID := strings.ToLower(frame.UniqueResourcesID)
 
 	resourceConfig := func(domain string, _ string) string {
 		return fmt.Sprintf(`
 resource "zitadel_instance_custom_domain" "default" {
-    instance_id = data.zitadel_instance.current.id
+    instance_id = "%s"
     domain      = "%s"
 }
-
-data "zitadel_instance" "current" {}
-`, domain)
+`, instanceID, domain)
 	}
 
 	test_utils.RunLifecyleTest(
 		t,
-		frame.BaseTestFrame,
+		*frame,
 		nil,
 		resourceConfig,
-		"login.example.com",
-		"login.example2.com",
+		fmt.Sprintf("login-%s.example.com", testID),
+		fmt.Sprintf("login-%s-2.example.com", testID),
 		"",
 		"",
 		"",
@@ -42,7 +55,7 @@ data "zitadel_instance" "current" {}
 		regexp.MustCompile(`^.+$`),
 		test_utils.CheckNothing,
 		test_utils.ChainImportStateIdFuncs(
-			test_utils.ImportResourceId(frame.BaseTestFrame),
+			test_utils.ImportResourceId(*frame),
 		),
 	)
 }


### PR DESCRIPTION
## Summary
- fix `zitadel_instance_custom_domain` create/read consistency by waiting until the new domain appears before the post-create read
- compare domains case-insensitively and tolerate a trailing dot when matching listed domains
- enable `TestAccInstanceCustomDomain` and switch it to system API auth via `NewSystemTestFrame`
- make custom-domain acceptance test domains unique per run to avoid `AlreadyExists` failures on repeated runs
- improve timeout error text to include the actual computed deadline value

## Validation
- `env -u GOROOT TF_ACC=1 go test -v ./zitadel/instance_custom_domain -run TestAccInstanceCustomDomain -count=1`

## Why is this needed?

```
Initializing the backend...
Initializing provider plugins...
- Finding zitadel/zitadel versions matching "2.8.1"...
- Using previously-installed zitadel/zitadel v2.8.1

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
data.zitadel_instance.default: Reading...
data.zitadel_instance.default: Read complete after 2s [id=360574951113097219]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # zitadel_instance_custom_domain.internal will be created
  + resource "zitadel_instance_custom_domain" "internal" {
      + domain      = "zitadel"
      + id          = (known after apply)
      + instance_id = "360574951113097219"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
zitadel_instance_custom_domain.internal: Creating...
╷
│ Error: Provider produced inconsistent result after apply
│
│ When applying changes to zitadel_instance_custom_domain.internal, provider
│ "provider[\"registry.terraform.io/zitadel/zitadel\"]" produced an
│ unexpected new value: Root object was present, but now absent.
│
│ This is a bug in the provider, which should be reported in the provider's
│ own issue tracker.
╵
```