### PR TITLE
fix: stale state in login policy Read for empty collection fields

### DIFF
--- a/zitadel/default_login_policy/funcs.go
+++ b/zitadel/default_login_policy/funcs.go
@@ -233,37 +233,31 @@ func read(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagn
 	if err != nil {
 		return diag.Errorf("failed to get login policy secondfactors: %v", err)
 	}
-	if len(respSecond.GetResult()) > 0 {
-		factors := make([]string, 0)
-		for _, item := range respSecond.GetResult() {
-			factors = append(factors, item.String())
-		}
-		set[secondFactorsVar] = factors
+	secondFactors := make([]string, 0, len(respSecond.GetResult()))
+	for _, item := range respSecond.GetResult() {
+		secondFactors = append(secondFactors, item.String())
 	}
+	set[secondFactorsVar] = secondFactors
 
 	respMulti, err := client.ListLoginPolicyMultiFactors(ctx, &admin.ListLoginPolicyMultiFactorsRequest{})
 	if err != nil {
 		return diag.Errorf("failed to get login policy multifactors: %v", err)
 	}
-	if len(respMulti.GetResult()) > 0 {
-		factors := make([]string, 0)
-		for _, item := range respMulti.GetResult() {
-			factors = append(factors, item.String())
-		}
-		set[multiFactorsVar] = factors
+	multiFactors := make([]string, 0, len(respMulti.GetResult()))
+	for _, item := range respMulti.GetResult() {
+		multiFactors = append(multiFactors, item.String())
 	}
+	set[multiFactorsVar] = multiFactors
 
 	respIDPs, err := client.ListLoginPolicyIDPs(ctx, &admin.ListLoginPolicyIDPsRequest{})
 	if err != nil {
 		return diag.Errorf("failed to get login policy idps: %v", err)
 	}
-	if len(respIDPs.GetResult()) > 0 {
-		idps := make([]string, 0)
-		for _, idpItem := range respIDPs.GetResult() {
-			idps = append(idps, idpItem.IdpId)
-		}
-		set[idpsVar] = idps
+	idps := make([]string, 0, len(respIDPs.GetResult()))
+	for _, idpItem := range respIDPs.GetResult() {
+		idps = append(idps, idpItem.IdpId)
 	}
+	set[idpsVar] = idps
 
 	for k, v := range set {
 		if err := d.Set(k, v); err != nil {

--- a/zitadel/login_policy/funcs.go
+++ b/zitadel/login_policy/funcs.go
@@ -329,35 +329,31 @@ func read(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagn
 	if err != nil {
 		return diag.Errorf("failed to get login policy secondfactors: %v", err)
 	}
-	if len(respSecond.GetResult()) > 0 {
-		factors := make([]string, 0)
-		for _, item := range respSecond.GetResult() {
-			factors = append(factors, item.String())
-		}
-		set[secondFactorsVar] = factors
+	secondFactors := make([]string, 0, len(respSecond.GetResult()))
+	for _, item := range respSecond.GetResult() {
+		secondFactors = append(secondFactors, item.String())
 	}
+	set[secondFactorsVar] = secondFactors
+
 	respMulti, err := client.ListLoginPolicyMultiFactors(helper.CtxWithID(ctx, d), &management.ListLoginPolicyMultiFactorsRequest{})
 	if err != nil {
 		return diag.Errorf("failed to get login policy multifactors: %v", err)
 	}
-	if len(respMulti.GetResult()) > 0 {
-		factors := make([]string, 0)
-		for _, item := range respMulti.GetResult() {
-			factors = append(factors, item.String())
-		}
-		set[multiFactorsVar] = factors
+	multiFactors := make([]string, 0, len(respMulti.GetResult()))
+	for _, item := range respMulti.GetResult() {
+		multiFactors = append(multiFactors, item.String())
 	}
+	set[multiFactorsVar] = multiFactors
+
 	respIDPs, err := client.ListLoginPolicyIDPs(helper.CtxWithID(ctx, d), &management.ListLoginPolicyIDPsRequest{})
 	if err != nil {
 		return diag.Errorf("failed to get login policy idps: %v", err)
 	}
-	if len(respIDPs.GetResult()) > 0 {
-		idps := make([]string, 0)
-		for _, idpItem := range respIDPs.GetResult() {
-			idps = append(idps, idpItem.IdpId)
-		}
-		set[idpsVar] = idps
+	idps := make([]string, 0, len(respIDPs.GetResult()))
+	for _, idpItem := range respIDPs.GetResult() {
+		idps = append(idps, idpItem.IdpId)
 	}
+	set[idpsVar] = idps
 	for k, v := range set {
 		if err := d.Set(k, v); err != nil {
 			return diag.Errorf("failed to set %s of login policy: %v", k, err)

--- a/zitadel/login_policy/resource_test.go
+++ b/zitadel/login_policy/resource_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/management"
+	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/policy"
 
 	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/helper"
 	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/helper/test_utils"
@@ -100,6 +101,60 @@ resource "zitadel_login_policy" "default" {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(frame.TerraformName, "second_factors.#", "2"),
 					resource.TestCheckResourceAttr(frame.TerraformName, "multi_factors.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccLoginPolicyRefreshDetectsExternalSecondFactorRemoval(t *testing.T) {
+	frame := test_utils.NewOrgTestFrame(t, "zitadel_login_policy")
+
+	config := fmt.Sprintf(`
+%s
+%s
+resource "zitadel_login_policy" "default" {
+  org_id                        = data.zitadel_org.default.id
+  user_login                    = true
+  allow_register                = false
+  allow_external_idp            = false
+  force_mfa                     = false
+  force_mfa_local_only          = false
+  passwordless_type             = "PASSWORDLESS_TYPE_ALLOWED"
+  hide_password_reset           = false
+  password_check_lifetime       = "240h0m0s"
+  external_login_check_lifetime = "240h0m0s"
+  multi_factor_check_lifetime   = "24h0m0s"
+  mfa_init_skip_lifetime        = "720h0m0s"
+  second_factor_check_lifetime  = "24h0m0s"
+  ignore_unknown_usernames      = false
+  default_redirect_uri          = "localhost:8080"
+  second_factors                = ["SECOND_FACTOR_TYPE_OTP"]
+}
+`, frame.ProviderSnippet, frame.AsOrgDefaultDependency)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: frame.V6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(frame.TerraformName, "second_factors.#", "1"),
+					resource.TestCheckResourceAttr(frame.TerraformName, "second_factors.0", "SECOND_FACTOR_TYPE_OTP"),
+				),
+			},
+			{
+				PreConfig: func() {
+					if _, err := frame.RemoveSecondFactorFromLoginPolicy(frame, &management.RemoveSecondFactorFromLoginPolicyRequest{
+						Type: policy.SecondFactorType_SECOND_FACTOR_TYPE_OTP,
+					}); err != nil {
+						t.Fatalf("failed to externally remove OTP factor: %v", err)
+					}
+				},
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(frame.TerraformName, "second_factors.#", "0"),
 				),
 			},
 		},


### PR DESCRIPTION
The `read` functions for `zitadel_login_policy` and `zitadel_default_login_policy` guarded `d.Set` on `second_factors`, `multi_factors` and `idps` behind `if len(...) > 0`. When those collections were emptied outside tf (e.g. removed directly via the management API), the next `terraform refresh` observed the empty API response but left the previous value in state.

This PR removes those guards for the two login-policy resources so the read always writes the current collection to state, including the empty case.

Closes #382

### Definition of Ready

- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] All non-functional requirements are met
- [x] The generic lifecycle acceptance test passes for affected resources.
- [x] Examples are up-to-date and meaningful. The provider version is incremented.
- [x] Docs are generated.
- [x] Code is generated where possible.