### PR TITLE
feat: add property `signing_key` to `sms_provider_http` resource

### DIFF
--- a/docs/resources/sms_provider_http.md
+++ b/docs/resources/sms_provider_http.md
@@ -34,6 +34,7 @@ resource "zitadel_sms_provider_http" "default" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+- `signing_key` (String, Sensitive) Key used to sign and check payload sent to the HTTP provider
 
 ## Import
 

--- a/zitadel/sms_provider_http/const.go
+++ b/zitadel/sms_provider_http/const.go
@@ -4,5 +4,6 @@ const (
 	IDVar          = "id"
 	EndPointVar    = "endpoint"
 	DescriptionVar = "description"
+	SigningKeyVar  = "signing_key"
 	setActiveVar   = "set_active"
 )

--- a/zitadel/sms_provider_http/funcs.go
+++ b/zitadel/sms_provider_http/funcs.go
@@ -53,6 +53,10 @@ func create(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 	}
 	d.SetId(resp.Id)
 
+	if err := d.Set(SigningKeyVar, resp.SigningKey); err != nil {
+		return diag.Errorf("failed to set signing_key: %v", err)
+	}
+
 	if d.Get(setActiveVar).(bool) {
 		if _, err := client.ActivateSMSProvider(ctx, &admin.ActivateSMSProviderRequest{Id: d.Id()}); err != nil {
 			return diag.Errorf("failed to activate sms http provider config: %v", err)
@@ -120,6 +124,7 @@ func read(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagn
 	set := map[string]interface{}{
 		EndPointVar:    resp.GetConfig().GetHttp().GetEndpoint(),
 		DescriptionVar: resp.GetConfig().GetDescription(),
+		SigningKeyVar:  d.Get(SigningKeyVar).(string),
 		setActiveVar:   d.Get(setActiveVar).(bool),
 	}
 

--- a/zitadel/sms_provider_http/resource.go
+++ b/zitadel/sms_provider_http/resource.go
@@ -25,11 +25,17 @@ func GetResource() *schema.Resource {
 				Optional:    true,
 				Description: "Set the SMS provider as active after creating/updating.",
 			},
+			SigningKeyVar: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Sensitive:   true,
+				Description: "Key used to sign and check payload sent to the HTTP provider",
+			},
 		},
 		CreateContext: create,
 		DeleteContext: delete,
 		ReadContext:   read,
 		UpdateContext: update,
-		Importer:      helper.ImportWithID(IDVar),
+		Importer:      helper.ImportWithIDAndOptionalSecret(IDVar, SigningKeyVar),
 	}
 }

--- a/zitadel/sms_provider_http/resource_test.go
+++ b/zitadel/sms_provider_http/resource_test.go
@@ -30,6 +30,7 @@ func TestAccSMSHttpProvider(t *testing.T) {
 		test_utils.CheckNothing,
 		test_utils.ChainImportStateIdFuncs(
 			test_utils.ImportResourceId(frame.BaseTestFrame),
+			test_utils.ImportStateAttribute(frame.BaseTestFrame, sms_provider_http.SigningKeyVar),
 		),
 	)
 }


### PR DESCRIPTION
The property `signing_key` is required to be able to confirm that sent data is not manipulated.

Since the property already exists in the `email_provider_http` resource, I've took the code from that resource.

### Definition of Ready

- [X] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [X] No debug or dead code
- [ ] My code has no repetitions
- [ ] All non-functional requirements are met
- [ ] The generic lifecycle acceptance test passes for affected resources.
- [X] Examples are up-to-date and meaningful. The provider version is incremented.
- [X] Docs are generated.
- [X] Code is generated where possible.
