### PR TITLE
docs: fix broken link to ZITADEL managers documentation

### DIFF
--- a/docs/resources/instance_member.md
+++ b/docs/resources/instance_member.md
@@ -23,7 +23,7 @@ resource "zitadel_instance_member" "default" {
 
 ### Required
 
-- `roles` (Set of String) List of roles granted. Instance member roles must start with 'IAM_' (e.g., IAM_OWNER, IAM_OWNER_VIEWER). See https://zitadel.com/docs/guides/manage/console/managers for available roles.
+- `roles` (Set of String) List of roles granted. Instance member roles must start with 'IAM_' (e.g., IAM_OWNER, IAM_OWNER_VIEWER). See https://zitadel.com/docs/guides/manage/console/administrators for available roles.
 - `user_id` (String) ID of the user
 
 ### Read-Only

--- a/docs/resources/org_member.md
+++ b/docs/resources/org_member.md
@@ -24,7 +24,7 @@ resource "zitadel_org_member" "default" {
 
 ### Required
 
-- `roles` (Set of String) List of roles granted. Organization member roles must start with 'ORG_' (e.g., ORG_OWNER, ORG_USER_MANAGER). See https://zitadel.com/docs/guides/manage/console/managers for available roles.
+- `roles` (Set of String) List of roles granted. Organization member roles must start with 'ORG_' (e.g., ORG_OWNER, ORG_USER_MANAGER). See https://zitadel.com/docs/guides/manage/console/administrators for available roles.
 - `user_id` (String) ID of the user
 
 ### Optional

--- a/docs/resources/project_member.md
+++ b/docs/resources/project_member.md
@@ -26,7 +26,7 @@ resource "zitadel_project_member" "default" {
 ### Required
 
 - `project_id` (String) ID of the project
-- `roles` (Set of String) List of roles granted. Project member roles must start with 'PROJECT_' (e.g., PROJECT_OWNER, PROJECT_OWNER_VIEWER). See https://zitadel.com/docs/guides/manage/console/managers for available roles.
+- `roles` (Set of String) List of roles granted. Project member roles must start with 'PROJECT_' (e.g., PROJECT_OWNER, PROJECT_OWNER_VIEWER). See https://zitadel.com/docs/guides/manage/console/administrators for available roles.
 - `user_id` (String) ID of the user
 
 ### Optional

--- a/zitadel/instance_member/resource.go
+++ b/zitadel/instance_member/resource.go
@@ -22,7 +22,7 @@ func GetResource() *schema.Resource {
 					Type: schema.TypeString,
 				},
 				Required:    true,
-				Description: "List of roles granted. Instance member roles must start with 'IAM_' (e.g., IAM_OWNER, IAM_OWNER_VIEWER). See https://zitadel.com/docs/guides/manage/console/managers for available roles.",
+				Description: "List of roles granted. Instance member roles must start with 'IAM_' (e.g., IAM_OWNER, IAM_OWNER_VIEWER). See https://zitadel.com/docs/guides/manage/console/administrators for available roles.",
 			},
 		},
 		DeleteContext: delete,

--- a/zitadel/org_member/resource.go
+++ b/zitadel/org_member/resource.go
@@ -23,7 +23,7 @@ func GetResource() *schema.Resource {
 					Type: schema.TypeString,
 				},
 				Required:    true,
-				Description: "List of roles granted. Organization member roles must start with 'ORG_' (e.g., ORG_OWNER, ORG_USER_MANAGER). See https://zitadel.com/docs/guides/manage/console/managers for available roles.",
+				Description: "List of roles granted. Organization member roles must start with 'ORG_' (e.g., ORG_OWNER, ORG_USER_MANAGER). See https://zitadel.com/docs/guides/manage/console/administrators for available roles.",
 			},
 		},
 		DeleteContext: delete,

--- a/zitadel/project_member/resource.go
+++ b/zitadel/project_member/resource.go
@@ -29,7 +29,7 @@ func GetResource() *schema.Resource {
 					Type: schema.TypeString,
 				},
 				Required:    true,
-				Description: "List of roles granted. Project member roles must start with 'PROJECT_' (e.g., PROJECT_OWNER, PROJECT_OWNER_VIEWER). See https://zitadel.com/docs/guides/manage/console/managers for available roles.",
+				Description: "List of roles granted. Project member roles must start with 'PROJECT_' (e.g., PROJECT_OWNER, PROJECT_OWNER_VIEWER). See https://zitadel.com/docs/guides/manage/console/administrators for available roles.",
 			},
 		},
 		DeleteContext: delete,


### PR DESCRIPTION
The roles description in `org_member`, `instance_member`, and `project_member` resources linked to `/docs/guides/manage/console/managers` which returns a 404. Updated all references to the correct URL at `/docs/guides/manage/console/administrators`.

Closes #388

### Definition of Ready

- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] All non-functional requirements are met
- [x] The generic lifecycle acceptance test passes for affected resources.
- [x] Examples are up-to-date and meaningful. The provider version is incremented.
- [x] Docs are generated.
- [x] Code is generated where possible.