### PR TITLE
fix: deprecate misleading token provider field

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ provider "zitadel" {
 - `jwt_profile_json` (String) JSON value of credentials to connect to ZITADEL. Either 'access_token', 'jwt_file', 'jwt_profile_file', 'jwt_profile_json' or 'system_api' is required
 - `port` (String) Used port if not the default ports 80 or 443 are configured
 - `system_api` (Block List) Configuration block for authenticating with the ZITADEL System API using a PEM encoded key. (see [below for nested schema](#nestedblock--system_api))
-- `token` (String, Deprecated) Deprecated: Use jwt_profile_file instead. Path to the file containing a JWT Profile key to connect to ZITADEL.
+- `token` (String, Deprecated) Deprecated: Use `access_token` for Personal Access Tokens or `jwt_profile_file` for JWT profile credentials instead. Path to the file containing a JWT Profile key to connect to ZITADEL.
 - `transport_headers` (Map of String) Custom headers to add to both HTTP (authentication) and gRPC (API) requests. Useful for proxy authentication (e.g., GCP IAP with Proxy-Authorization header).
 
 <a id="nestedblock--system_api"></a>

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ provider "zitadel" {
 - `jwt_profile_json` (String) JSON value of credentials to connect to ZITADEL. Either 'access_token', 'jwt_file', 'jwt_profile_file', 'jwt_profile_json' or 'system_api' is required
 - `port` (String) Used port if not the default ports 80 or 443 are configured
 - `system_api` (Block List) Configuration block for authenticating with the ZITADEL System API using a PEM encoded key. (see [below for nested schema](#nestedblock--system_api))
-- `token` (String) Path to the file containing credentials to connect to ZITADEL
+- `token` (String, Deprecated) Deprecated: Use jwt_profile_file instead. Path to the file containing a JWT Profile key to connect to ZITADEL.
 - `transport_headers` (Map of String) Custom headers to add to both HTTP (authentication) and gRPC (API) requests. Useful for proxy authentication (e.g., GCP IAP with Proxy-Authorization header).
 
 <a id="nestedblock--system_api"></a>

--- a/zitadel/helper/client.go
+++ b/zitadel/helper/client.go
@@ -34,7 +34,7 @@ const (
 	AccessTokenVar            = "access_token"
 	AccessTokenDescription    = "Personal Access Token to connect to ZITADEL. Either 'access_token', 'jwt_file', 'jwt_profile_file', 'jwt_profile_json' or 'system_api' is required"
 	TokenVar                  = "token"
-	TokenDescription          = "Deprecated: Use jwt_profile_file instead. Path to the file containing a JWT Profile key to connect to ZITADEL."
+	TokenDescription          = "Deprecated: Use 'access_token' for Personal Access Tokens or 'jwt_profile_file' for JWT Profile credentials instead. Path to the file containing a JWT Profile key to connect to ZITADEL."
 	PortVar                   = "port"
 	PortDescription           = "Used port if not the default ports 80 or 443 are configured"
 	JWTFileVar                = "jwt_file"

--- a/zitadel/helper/client.go
+++ b/zitadel/helper/client.go
@@ -34,7 +34,7 @@ const (
 	AccessTokenVar            = "access_token"
 	AccessTokenDescription    = "Personal Access Token to connect to ZITADEL. Either 'access_token', 'jwt_file', 'jwt_profile_file', 'jwt_profile_json' or 'system_api' is required"
 	TokenVar                  = "token"
-	TokenDescription          = "Path to the file containing credentials to connect to ZITADEL"
+	TokenDescription          = "Deprecated: Use jwt_profile_file instead. Path to the file containing a JWT Profile key to connect to ZITADEL."
 	PortVar                   = "port"
 	PortDescription           = "Used port if not the default ports 80 or 443 are configured"
 	JWTFileVar                = "jwt_file"

--- a/zitadel/provider.go
+++ b/zitadel/provider.go
@@ -178,8 +178,9 @@ func (p *providerPV6) Schema(_ context.Context, _ provider.SchemaRequest, resp *
 				Description: helper.AccessTokenDescription,
 			},
 			helper.TokenVar: providerschema.StringAttribute{
-				Optional:    true,
-				Description: helper.TokenDescription,
+				Optional:           true,
+				Description:        helper.TokenDescription,
+				DeprecationMessage: "Use jwt_profile_file instead. For Personal Access Tokens, use access_token.",
 			},
 			helper.JWTFileVar: providerschema.StringAttribute{
 				Optional:    true,
@@ -471,6 +472,7 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: helper.TokenDescription,
+				Deprecated:  "Use jwt_profile_file instead. For Personal Access Tokens, use access_token.",
 				ConflictsWith: []string{
 					helper.AccessTokenVar,
 					helper.JWTFileVar,


### PR DESCRIPTION
The `token` provider field is an undocumented alias for `jwt_profile_file` — both accept a path to a JWT Profile key file. The name `token` misleads users into thinking it accepts a Personal Access Token string, which causes confusing parse errors when they pass a PAT file path. Deprecate `token` with a message directing users to `jwt_profile_file` for key files or `access_token` for PATs.

Closes #391

### Definition of Ready

- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] All non-functional requirements are met
- [x] The generic lifecycle acceptance test passes for affected resources.
- [x] Examples are up-to-date and meaningful. The provider version is incremented.
- [x] Docs are generated.
- [x] Code is generated where possible.
