### PR TITLE
fix: add v3 server backward compatibility fallback for user and org resources

### DIFF
--- a/zitadel/helper/fallback.go
+++ b/zitadel/helper/fallback.go
@@ -1,0 +1,13 @@
+package helper
+
+import (
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// IsUnimplemented returns true if the error is a gRPC Unimplemented status code.
+// This is used to detect when a V2 API is not available (e.g. on Zitadel server v3.x)
+// and fallback to the legacy Management/Admin API should be attempted.
+func IsUnimplemented(err error) bool {
+	return status.Code(err) == codes.Unimplemented
+}

--- a/zitadel/human_user/funcs.go
+++ b/zitadel/human_user/funcs.go
@@ -29,6 +29,9 @@ func delete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 		UserId: d.Id(),
 	})
 	if err != nil {
+		if helper.IsUnimplemented(err) {
+			return legacyDeleteUser(ctx, d, clientinfo)
+		}
 		return diag.Errorf("failed to delete user: %v", err)
 	}
 	return nil
@@ -172,6 +175,25 @@ func create(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 
 	respUser, err := client.CreateUser(helper.CtxWithOrgID(ctx, d), req)
 	if err != nil {
+		if helper.IsUnimplemented(err) {
+			if req.UserId != nil {
+				return diag.Errorf("custom user_id requires Zitadel server v4+")
+			}
+			if humanUser.IdpLinks != nil {
+				return diag.Errorf("idp_links on create requires Zitadel server v4+")
+			}
+			if humanUser.TotpSecret != nil {
+				return diag.Errorf("totp_secret on create requires Zitadel server v4+")
+			}
+			if humanUser.Metadata != nil {
+				return diag.Errorf("metadata on create requires Zitadel server v4+")
+			}
+			diags := legacyCreateHumanUser(ctx, d, clientinfo)
+			if diags.HasError() {
+				return diags
+			}
+			return readFunc(false)(ctx, d, m)
+		}
 		return diag.Errorf("failed to create human user: %v", err)
 	}
 	d.SetId(respUser.Id)
@@ -292,6 +314,9 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 	if req.Username != nil || req.UserType != nil {
 		_, err = client.UpdateUser(helper.CtxWithOrgID(ctx, d), req)
 		if err != nil {
+			if helper.IsUnimplemented(err) {
+				return legacyUpdateHumanUser(ctx, d, clientinfo)
+			}
 			return diag.Errorf("failed to update human user: %v", err)
 		}
 	}
@@ -316,11 +341,14 @@ func readFunc(forDatasource bool) func(ctx context.Context, d *schema.ResourceDa
 		respUser, err := client.GetUserByID(helper.CtxWithOrgID(ctx, d), &userv2.GetUserByIDRequest{
 			UserId: helper.GetID(d, UserIDVar),
 		})
-		if err != nil && helper.IgnoreIfNotFoundError(err) == nil {
-			d.SetId("")
-			return nil
-		}
 		if err != nil {
+			if helper.IsUnimplemented(err) {
+				return legacyReadHumanUser(ctx, d, clientinfo, forDatasource)
+			}
+			if helper.IgnoreIfNotFoundError(err) == nil {
+				d.SetId("")
+				return nil
+			}
 			return diag.Errorf("failed to get user: %v", err)
 		}
 
@@ -484,6 +512,9 @@ func list(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagn
 
 	resp, err := client.ListUsers(helper.CtxWithOrgID(ctx, d), req)
 	if err != nil {
+		if helper.IsUnimplemented(err) {
+			return legacyListHumanUsers(ctx, d, clientinfo)
+		}
 		return diag.Errorf("error while listing users: %v", err)
 	}
 

--- a/zitadel/human_user/funcs_legacy.go
+++ b/zitadel/human_user/funcs_legacy.go
@@ -1,0 +1,349 @@
+package human_user
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/management"
+	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/object"
+	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/user"
+
+	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/helper"
+)
+
+func legacyCreateHumanUser(ctx context.Context, d *schema.ResourceData, clientinfo *helper.ClientInfo) diag.Diagnostics {
+	tflog.Info(ctx, "falling back to legacy management API for create")
+
+	client, err := helper.GetManagementClient(ctx, clientinfo)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	firstName := d.Get(firstNameVar).(string)
+	lastName := d.Get(lastNameVar).(string)
+	email := d.Get(emailVar).(string)
+	username := d.Get(UserNameVar).(string)
+
+	profile := &management.ImportHumanUserRequest_Profile{
+		FirstName:         firstName,
+		LastName:          lastName,
+		PreferredLanguage: d.Get(preferredLanguageVar).(string),
+	}
+
+	if nickName, ok := d.GetOk(nickNameVar); ok && nickName.(string) != "" {
+		profile.NickName = nickName.(string)
+	}
+
+	if dn, ok := d.GetOk(DisplayNameVar); ok {
+		profile.DisplayName = dn.(string)
+	} else {
+		profile.DisplayName = defaultDisplayName(firstName, lastName)
+	}
+
+	genderVal := user.Gender(user.Gender_value[d.Get(genderVar).(string)])
+	profile.Gender = genderVal
+
+	humanEmail := &management.ImportHumanUserRequest_Email{
+		Email: email,
+	}
+	if isVerified, ok := d.GetOk(isEmailVerifiedVar); ok && isVerified.(bool) {
+		humanEmail.IsEmailVerified = true
+	}
+
+	req := &management.ImportHumanUserRequest{
+		UserName: username,
+		Profile:  profile,
+		Email:    humanEmail,
+	}
+
+	if phone, ok := d.GetOk(phoneVar); ok {
+		phoneReq := &management.ImportHumanUserRequest_Phone{
+			Phone: phone.(string),
+		}
+		if isVerified, ok := d.GetOk(isPhoneVerifiedVar); ok && isVerified.(bool) {
+			phoneReq.IsPhoneVerified = true
+		}
+		req.Phone = phoneReq
+	}
+
+	if password, ok := d.GetOk(InitialPasswordVar); ok {
+		req.Password = password.(string)
+		req.PasswordChangeRequired = !d.Get(initialSkipPasswordChange).(bool)
+	} else if hashedPassword, ok := d.GetOk(initialHashedPasswordVar); ok {
+		req.HashedPassword = &management.ImportHumanUserRequest_HashedPassword{
+			Value: hashedPassword.(string),
+		}
+	}
+
+	resp, err := client.ImportHumanUser(helper.CtxWithOrgID(ctx, d), req)
+	if err != nil {
+		return diag.Errorf("failed to create human user: %v", err)
+	}
+	d.SetId(resp.GetUserId())
+
+	return nil
+}
+
+func legacyDeleteUser(ctx context.Context, d *schema.ResourceData, clientinfo *helper.ClientInfo) diag.Diagnostics {
+	tflog.Info(ctx, "falling back to legacy management API for delete")
+
+	client, err := helper.GetManagementClient(ctx, clientinfo)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	_, err = client.RemoveUser(helper.CtxWithOrgID(ctx, d), &management.RemoveUserRequest{
+		Id: d.Id(),
+	})
+	if err != nil {
+		return diag.Errorf("failed to delete user: %v", err)
+	}
+	return nil
+}
+
+func legacyReadHumanUser(ctx context.Context, d *schema.ResourceData, clientinfo *helper.ClientInfo, forDatasource bool) diag.Diagnostics {
+	tflog.Info(ctx, "falling back to legacy management API for read")
+
+	client, err := helper.GetManagementClient(ctx, clientinfo)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	resp, err := client.GetUserByID(helper.CtxWithOrgID(ctx, d), &management.GetUserByIDRequest{
+		Id: helper.GetID(d, UserIDVar),
+	})
+	if err != nil && helper.IgnoreIfNotFoundError(err) == nil {
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return diag.Errorf("failed to get user: %v", err)
+	}
+
+	u := resp.GetUser()
+	set := map[string]interface{}{
+		helper.OrgIDVar:       u.GetDetails().GetResourceOwner(),
+		userStateVar:          u.GetState().String(),
+		UserNameVar:           u.GetUserName(),
+		loginNamesVar:         u.GetLoginNames(),
+		preferredLoginNameVar: u.GetPreferredLoginName(),
+	}
+	if !forDatasource {
+		set[initialSkipPasswordChange] = false
+	}
+
+	if human := u.GetHuman(); human != nil {
+		if profile := human.GetProfile(); profile != nil {
+			set[firstNameVar] = profile.GetFirstName()
+			set[lastNameVar] = profile.GetLastName()
+			set[DisplayNameVar] = profile.GetDisplayName()
+			set[nickNameVar] = profile.GetNickName()
+			set[preferredLanguageVar] = profile.GetPreferredLanguage()
+			set[genderVar] = profile.GetGender().String()
+		}
+		if email := human.GetEmail(); email != nil {
+			set[emailVar] = email.GetEmail()
+			set[isEmailVerifiedVar] = email.GetIsEmailVerified()
+		}
+		if phone := human.GetPhone(); phone != nil {
+			set[phoneVar] = phone.GetPhone()
+			set[isPhoneVerifiedVar] = phone.GetIsPhoneVerified()
+		}
+	}
+	for k, v := range set {
+		if err := d.Set(k, v); err != nil {
+			return diag.Errorf("failed to set %s of user: %v", k, err)
+		}
+	}
+	d.SetId(u.GetId())
+	return nil
+}
+
+func legacyUpdateHumanUser(ctx context.Context, d *schema.ResourceData, clientinfo *helper.ClientInfo) diag.Diagnostics {
+	tflog.Info(ctx, "falling back to legacy management API for update")
+
+	client, err := helper.GetManagementClient(ctx, clientinfo)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if d.HasChange(UserNameVar) {
+		_, err = client.UpdateUserName(helper.CtxWithOrgID(ctx, d), &management.UpdateUserNameRequest{
+			UserId:   d.Id(),
+			UserName: d.Get(UserNameVar).(string),
+		})
+		if err != nil {
+			return diag.Errorf("failed to update human user username: %v", err)
+		}
+	}
+
+	if d.HasChanges(firstNameVar, lastNameVar, nickNameVar, DisplayNameVar, preferredLanguageVar, genderVar) {
+		_, err = client.UpdateHumanProfile(helper.CtxWithOrgID(ctx, d), &management.UpdateHumanProfileRequest{
+			UserId:            d.Id(),
+			FirstName:         d.Get(firstNameVar).(string),
+			LastName:          d.Get(lastNameVar).(string),
+			NickName:          d.Get(nickNameVar).(string),
+			DisplayName:       d.Get(DisplayNameVar).(string),
+			PreferredLanguage: d.Get(preferredLanguageVar).(string),
+			Gender:            user.Gender(user.Gender_value[d.Get(genderVar).(string)]),
+		})
+		if err != nil {
+			return diag.Errorf("failed to update human user profile: %v", err)
+		}
+	}
+
+	if d.HasChanges(emailVar, isEmailVerifiedVar) {
+		oldEmail, newEmail := d.GetChange(emailVar)
+		_, isVerifiedInConfig := d.GetOk(isEmailVerifiedVar)
+
+		if oldEmail != newEmail || isVerifiedInConfig {
+			_, err = client.UpdateHumanEmail(helper.CtxWithOrgID(ctx, d), &management.UpdateHumanEmailRequest{
+				UserId:          d.Id(),
+				Email:           d.Get(emailVar).(string),
+				IsEmailVerified: d.Get(isEmailVerifiedVar).(bool),
+			})
+			if err != nil {
+				return diag.Errorf("failed to update human user email: %v", err)
+			}
+		}
+	}
+
+	if d.HasChanges(phoneVar, isPhoneVerifiedVar) {
+		oldPhone, newPhone := d.GetChange(phoneVar)
+		_, isVerifiedInConfig := d.GetOk(isPhoneVerifiedVar)
+
+		if oldPhone != newPhone || isVerifiedInConfig {
+			_, err = client.UpdateHumanPhone(helper.CtxWithOrgID(ctx, d), &management.UpdateHumanPhoneRequest{
+				UserId:          d.Id(),
+				Phone:           d.Get(phoneVar).(string),
+				IsPhoneVerified: d.Get(isPhoneVerifiedVar).(bool),
+			})
+			if err != nil {
+				return diag.Errorf("failed to update human user phone: %v", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func legacyListHumanUsers(ctx context.Context, d *schema.ResourceData, clientinfo *helper.ClientInfo) diag.Diagnostics {
+	tflog.Info(ctx, "falling back to legacy management API for list")
+
+	client, err := helper.GetManagementClient(ctx, clientinfo)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	req := &management.ListUsersRequest{}
+	var queries []*user.SearchQuery
+
+	queries = append(queries, &user.SearchQuery{
+		Query: &user.SearchQuery_TypeQuery{
+			TypeQuery: &user.TypeQuery{
+				Type: user.Type_TYPE_HUMAN,
+			},
+		},
+	})
+
+	if userName, ok := d.GetOk(UserNameVar); ok {
+		userNameMethod := d.Get(userNameMethodVar).(string)
+		queries = append(queries, &user.SearchQuery{
+			Query: &user.SearchQuery_UserNameQuery{
+				UserNameQuery: &user.UserNameQuery{
+					UserName: userName.(string),
+					Method:   object.TextQueryMethod(object.TextQueryMethod_value[userNameMethod]),
+				},
+			},
+		})
+	}
+
+	if firstName, ok := d.GetOk(firstNameVar); ok {
+		firstNameMethod := d.Get(firstNameMethodVar).(string)
+		queries = append(queries, &user.SearchQuery{
+			Query: &user.SearchQuery_FirstNameQuery{
+				FirstNameQuery: &user.FirstNameQuery{
+					FirstName: firstName.(string),
+					Method:    object.TextQueryMethod(object.TextQueryMethod_value[firstNameMethod]),
+				},
+			},
+		})
+	}
+
+	if lastName, ok := d.GetOk(lastNameVar); ok {
+		lastNameMethod := d.Get(lastNameMethodVar).(string)
+		queries = append(queries, &user.SearchQuery{
+			Query: &user.SearchQuery_LastNameQuery{
+				LastNameQuery: &user.LastNameQuery{
+					LastName: lastName.(string),
+					Method:   object.TextQueryMethod(object.TextQueryMethod_value[lastNameMethod]),
+				},
+			},
+		})
+	}
+
+	if nickName, ok := d.GetOk(nickNameVar); ok {
+		nickNameMethod := d.Get(nickNameMethodVar).(string)
+		queries = append(queries, &user.SearchQuery{
+			Query: &user.SearchQuery_NickNameQuery{
+				NickNameQuery: &user.NickNameQuery{
+					NickName: nickName.(string),
+					Method:   object.TextQueryMethod(object.TextQueryMethod_value[nickNameMethod]),
+				},
+			},
+		})
+	}
+
+	if displayName, ok := d.GetOk(DisplayNameVar); ok {
+		displayNameMethod := d.Get(displayNameMethodVar).(string)
+		queries = append(queries, &user.SearchQuery{
+			Query: &user.SearchQuery_DisplayNameQuery{
+				DisplayNameQuery: &user.DisplayNameQuery{
+					DisplayName: displayName.(string),
+					Method:      object.TextQueryMethod(object.TextQueryMethod_value[displayNameMethod]),
+				},
+			},
+		})
+	}
+
+	if email, ok := d.GetOk(emailVar); ok {
+		emailMethod := d.Get(emailMethodVar).(string)
+		queries = append(queries, &user.SearchQuery{
+			Query: &user.SearchQuery_EmailQuery{
+				EmailQuery: &user.EmailQuery{
+					EmailAddress: email.(string),
+					Method:       object.TextQueryMethod(object.TextQueryMethod_value[emailMethod]),
+				},
+			},
+		})
+	}
+
+	if loginName, ok := d.GetOk(loginNameVar); ok {
+		loginNameMethod := d.Get(loginNameMethodVar).(string)
+		queries = append(queries, &user.SearchQuery{
+			Query: &user.SearchQuery_LoginNameQuery{
+				LoginNameQuery: &user.LoginNameQuery{
+					LoginName: loginName.(string),
+					Method:    object.TextQueryMethod(object.TextQueryMethod_value[loginNameMethod]),
+				},
+			},
+		})
+	}
+
+	req.Queries = queries
+
+	resp, err := client.ListUsers(helper.CtxWithOrgID(ctx, d), req)
+	if err != nil {
+		return diag.Errorf("error while listing users: %v", err)
+	}
+
+	ids := make([]string, len(resp.Result))
+	for i, res := range resp.Result {
+		ids[i] = res.GetId()
+	}
+
+	d.SetId("-")
+	return diag.FromErr(d.Set(userIDsVar, ids))
+}

--- a/zitadel/machine_user/funcs.go
+++ b/zitadel/machine_user/funcs.go
@@ -31,6 +31,9 @@ func delete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 		UserId: d.Id(),
 	})
 	if err != nil {
+		if helper.IsUnimplemented(err) {
+			return legacyDeleteUser(ctx, d, clientinfo)
+		}
 		return diag.Errorf("failed to delete user: %v", err)
 	}
 	return nil
@@ -77,6 +80,16 @@ func create(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 
 	respUser, err := client.CreateUser(helper.CtxWithOrgID(ctx, d), req)
 	if err != nil {
+		if helper.IsUnimplemented(err) {
+			if req.UserId != nil {
+				return diag.Errorf("custom user_id requires Zitadel server v4+")
+			}
+			diags := legacyCreateMachineUser(ctx, d, clientinfo)
+			if diags.HasError() {
+				return diags
+			}
+			return read(ctx, d, m)
+		}
 		return diag.Errorf("failed to create machine user: %v", err)
 	}
 	d.SetId(respUser.Id)
@@ -158,7 +171,16 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 	if req.Username != nil || req.UserType != nil {
 		_, err = client.UpdateUser(helper.CtxWithOrgID(ctx, d), req)
 		if err != nil {
-			return diag.Errorf("failed to update machine user: %v", err)
+			if helper.IsUnimplemented(err) {
+				if d.HasChange(UserNameVar) {
+					diags := legacyUpdateMachineUsername(ctx, d, clientinfo)
+					if diags.HasError() {
+						return diags
+					}
+				}
+			} else {
+				return diag.Errorf("failed to update machine user: %v", err)
+			}
 		}
 	}
 
@@ -232,11 +254,14 @@ func read(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagn
 	respUser, err := client.GetUserByID(helper.CtxWithOrgID(ctx, d), &userv2.GetUserByIDRequest{
 		UserId: helper.GetID(d, UserIDVar),
 	})
-	if err != nil && helper.IgnoreIfNotFoundError(err) == nil {
-		d.SetId("")
-		return nil
-	}
 	if err != nil {
+		if helper.IsUnimplemented(err) {
+			return legacyReadMachineUser(ctx, d, clientinfo)
+		}
+		if helper.IgnoreIfNotFoundError(err) == nil {
+			d.SetId("")
+			return nil
+		}
 		return diag.Errorf("failed to get user: %v", err)
 	}
 
@@ -314,6 +339,9 @@ func list(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagn
 
 	resp, err := client.ListUsers(helper.CtxWithOrgID(ctx, d), req)
 	if err != nil {
+		if helper.IsUnimplemented(err) {
+			return legacyListMachineUsers(ctx, d, clientinfo)
+		}
 		return diag.Errorf("error while listing users: %v", err)
 	}
 

--- a/zitadel/machine_user/funcs_legacy.go
+++ b/zitadel/machine_user/funcs_legacy.go
@@ -1,0 +1,194 @@
+package machine_user
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/management"
+	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/object"
+	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/user"
+
+	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/helper"
+)
+
+func legacyCreateMachineUser(ctx context.Context, d *schema.ResourceData, clientinfo *helper.ClientInfo) diag.Diagnostics {
+	tflog.Info(ctx, "falling back to legacy management API for create")
+
+	client, err := helper.GetManagementClient(ctx, clientinfo)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	name := d.Get(nameVar).(string)
+	username := d.Get(UserNameVar).(string)
+
+	req := &management.AddMachineUserRequest{
+		UserName:    username,
+		Name:        name,
+		Description: d.Get(DescriptionVar).(string),
+	}
+
+	if desiredType := d.Get(accessTokenTypeVar).(string); desiredType != defaultAccessTokenType {
+		req.AccessTokenType = user.AccessTokenType(user.AccessTokenType_value[desiredType])
+	}
+
+	resp, err := client.AddMachineUser(helper.CtxWithOrgID(ctx, d), req)
+	if err != nil {
+		return diag.Errorf("failed to create machine user: %v", err)
+	}
+	d.SetId(resp.GetUserId())
+
+	if d.Get(WithSecretVar).(bool) {
+		secretResp, err := client.GenerateMachineSecret(helper.CtxWithOrgID(ctx, d), &management.GenerateMachineSecretRequest{
+			UserId: resp.GetUserId(),
+		})
+		if err != nil {
+			return diag.Errorf("failed to generate machine user secret: %v", err)
+		}
+		if err := d.Set(clientIDVar, secretResp.GetClientId()); err != nil {
+			return diag.Errorf("failed to set %s of user: %v", clientIDVar, err)
+		}
+		if err := d.Set(clientSecretVar, secretResp.GetClientSecret()); err != nil {
+			return diag.Errorf("failed to set %s of user: %v", clientSecretVar, err)
+		}
+	}
+
+	return nil
+}
+
+func legacyDeleteUser(ctx context.Context, d *schema.ResourceData, clientinfo *helper.ClientInfo) diag.Diagnostics {
+	tflog.Info(ctx, "falling back to legacy management API for delete")
+
+	client, err := helper.GetManagementClient(ctx, clientinfo)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	_, err = client.RemoveUser(helper.CtxWithOrgID(ctx, d), &management.RemoveUserRequest{
+		Id: d.Id(),
+	})
+	if err != nil {
+		return diag.Errorf("failed to delete user: %v", err)
+	}
+	return nil
+}
+
+func legacyReadMachineUser(ctx context.Context, d *schema.ResourceData, clientinfo *helper.ClientInfo) diag.Diagnostics {
+	tflog.Info(ctx, "falling back to legacy management API for read")
+
+	client, err := helper.GetManagementClient(ctx, clientinfo)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	resp, err := client.GetUserByID(helper.CtxWithOrgID(ctx, d), &management.GetUserByIDRequest{
+		Id: helper.GetID(d, UserIDVar),
+	})
+	if err != nil && helper.IgnoreIfNotFoundError(err) == nil {
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return diag.Errorf("failed to get user: %v", err)
+	}
+
+	u := resp.GetUser()
+	set := map[string]interface{}{
+		helper.OrgIDVar:       u.GetDetails().GetResourceOwner(),
+		userStateVar:          u.GetState().String(),
+		UserNameVar:           u.GetUserName(),
+		loginNamesVar:         u.GetLoginNames(),
+		preferredLoginNameVar: u.GetPreferredLoginName(),
+	}
+	if machine := u.GetMachine(); machine != nil {
+		set[nameVar] = machine.GetName()
+		set[DescriptionVar] = machine.GetDescription()
+		set[accessTokenTypeVar] = machine.GetAccessTokenType().String()
+	}
+	for k, v := range set {
+		if err := d.Set(k, v); err != nil {
+			return diag.Errorf("failed to set %s of user: %v", k, err)
+		}
+	}
+	d.SetId(u.GetId())
+	return nil
+}
+
+func legacyUpdateMachineUsername(ctx context.Context, d *schema.ResourceData, clientinfo *helper.ClientInfo) diag.Diagnostics {
+	tflog.Info(ctx, "falling back to legacy management API for update username")
+
+	client, err := helper.GetManagementClient(ctx, clientinfo)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	_, err = client.UpdateUserName(helper.CtxWithOrgID(ctx, d), &management.UpdateUserNameRequest{
+		UserId:   d.Id(),
+		UserName: d.Get(UserNameVar).(string),
+	})
+	if err != nil {
+		return diag.Errorf("failed to update machine user: %v", err)
+	}
+	return nil
+}
+
+func legacyListMachineUsers(ctx context.Context, d *schema.ResourceData, clientinfo *helper.ClientInfo) diag.Diagnostics {
+	tflog.Info(ctx, "falling back to legacy management API for list")
+
+	client, err := helper.GetManagementClient(ctx, clientinfo)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	req := &management.ListUsersRequest{}
+	var queries []*user.SearchQuery
+
+	queries = append(queries, &user.SearchQuery{
+		Query: &user.SearchQuery_TypeQuery{
+			TypeQuery: &user.TypeQuery{
+				Type: user.Type_TYPE_MACHINE,
+			},
+		},
+	})
+
+	if userName, ok := d.GetOk(UserNameVar); ok {
+		userNameMethod := d.Get(userNameMethodVar).(string)
+		queries = append(queries, &user.SearchQuery{
+			Query: &user.SearchQuery_UserNameQuery{
+				UserNameQuery: &user.UserNameQuery{
+					UserName: userName.(string),
+					Method:   object.TextQueryMethod(object.TextQueryMethod_value[userNameMethod]),
+				},
+			},
+		})
+	}
+
+	if loginName, ok := d.GetOk(loginNameVar); ok {
+		loginNameMethod := d.Get(loginNameMethodVar).(string)
+		queries = append(queries, &user.SearchQuery{
+			Query: &user.SearchQuery_LoginNameQuery{
+				LoginNameQuery: &user.LoginNameQuery{
+					LoginName: loginName.(string),
+					Method:    object.TextQueryMethod(object.TextQueryMethod_value[loginNameMethod]),
+				},
+			},
+		})
+	}
+
+	req.Queries = queries
+
+	resp, err := client.ListUsers(helper.CtxWithOrgID(ctx, d), req)
+	if err != nil {
+		return diag.Errorf("error while listing users: %v", err)
+	}
+
+	ids := make([]string, len(resp.Result))
+	for i, res := range resp.Result {
+		ids[i] = res.GetId()
+	}
+
+	d.SetId("-")
+	return diag.FromErr(d.Set(userIDsVar, ids))
+}

--- a/zitadel/org/funcs.go
+++ b/zitadel/org/funcs.go
@@ -29,6 +29,9 @@ func delete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 		OrganizationId: d.Id(),
 	})
 	if err != nil {
+		if helper.IsUnimplemented(err) {
+			return legacyDeleteOrg(ctx, d, clientinfo)
+		}
 		return diag.FromErr(err)
 	}
 	d.SetId("")
@@ -120,7 +123,14 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 			Name:           d.Get(NameVar).(string),
 		})
 		if err != nil {
-			return diag.Errorf("failed to update org: %v", err)
+			if helper.IsUnimplemented(err) {
+				diags := legacyUpdateOrg(ctx, d, clientinfo)
+				if diags.HasError() {
+					return diags
+				}
+			} else {
+				return diag.Errorf("failed to update org: %v", err)
+			}
 		}
 	}
 

--- a/zitadel/org/funcs_legacy.go
+++ b/zitadel/org/funcs_legacy.go
@@ -1,0 +1,48 @@
+package org
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/admin"
+	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/management"
+
+	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/helper"
+)
+
+func legacyDeleteOrg(ctx context.Context, d *schema.ResourceData, clientinfo *helper.ClientInfo) diag.Diagnostics {
+	tflog.Info(ctx, "falling back to legacy admin API for delete")
+
+	client, err := helper.GetAdminClient(ctx, clientinfo)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	_, err = client.RemoveOrg(ctx, &admin.RemoveOrgRequest{
+		OrgId: d.Id(),
+	})
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId("")
+	return nil
+}
+
+func legacyUpdateOrg(ctx context.Context, d *schema.ResourceData, clientinfo *helper.ClientInfo) diag.Diagnostics {
+	tflog.Info(ctx, "falling back to legacy management API for update")
+
+	client, err := helper.GetManagementClient(ctx, clientinfo)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	_, err = client.UpdateOrg(helper.CtxSetOrgID(ctx, d.Id()), &management.UpdateOrgRequest{
+		Name: d.Get(NameVar).(string),
+	})
+	if err != nil {
+		return diag.Errorf("failed to update org: %v", err)
+	}
+	return nil
+}


### PR DESCRIPTION
Release v2.4.0 (January 2026, PR #305) migrated `zitadel_machine_user`, `zitadel_human_user`, and `zitadel_org` from the Management/Admin APIs to the User V2 and Organization V2 APIs. These V2 APIs were introduced in Zitadel server v4.x and do not exist on v3.x. Any user running the provider v2.4.0+ against a Zitadel v3.x server gets `codes.Unimplemented` errors on every CRUD operation for these three resources.

This adds per-call inline fallback: each V2 call checks for `codes.Unimplemented` and, when detected, transparently retries against the legacy Management or Admin API. V2-only features that have no legacy equivalent (`user_id`, `idp_links`, `totp_secret`, `metadata`) return a clear error directing the user to upgrade to Zitadel v4+.

### Definition of Ready

- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] All non-functional requirements are met
- [x] The generic lifecycle acceptance test passes for affected resources.
- [x] Examples are up-to-date and meaningful. The provider version is incremented.
- [x] Docs are generated.
- [x] Code is generated where possible.