### PR TITLE
docs: fix login_v2 nested-block syntax in instance_features example

### DIFF
--- a/docs/resources/instance_features.md
+++ b/docs/resources/instance_features.md
@@ -23,7 +23,7 @@ resource "zitadel_instance_features" "default" {
   debug_oidc_parent_error            = false
   oidc_single_v1_session_termination = true
   enable_back_channel_logout         = true
-  login_v2 = {
+  login_v2 {
     required = true
     base_uri = "https://login.example.com"
   }

--- a/examples/provider/resources/instance_features.tf
+++ b/examples/provider/resources/instance_features.tf
@@ -9,7 +9,7 @@ resource "zitadel_instance_features" "default" {
   debug_oidc_parent_error            = false
   oidc_single_v1_session_termination = true
   enable_back_channel_logout         = true
-  login_v2 = {
+  login_v2 {
     required = true
     base_uri = "https://login.example.com"
   }


### PR DESCRIPTION
The `zitadel_instance_features` example showed `login_v2 = { ... }` (attribute-assignment syntax), but the schema declares `login_v2` as a `TypeList` block with `MaxItems: 1` so the schema section of the same docs page already lists it as "Block List, Max: 1". Users copying the sample get a parse error.

Switched the example to nested-block syntax (`login_v2 { ... }`) and regenerated the docs.

Closes #398

### Definition of Ready

- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] All non-functional requirements are met
- [x] The generic lifecycle acceptance test passes for affected resources.
- [x] Examples are up-to-date and meaningful. The provider version is incremented.
- [x] Docs are generated.
- [x] Code is generated where possible.