### PR TITLE
fix: stop perpetual id diff on message_text and login_texts resources

### DIFF
--- a/gen/github.com/zitadel/zitadel/pkg/grpc/text/text_terraform.go
+++ b/gen/github.com/zitadel/zitadel/pkg/grpc/text/text_terraform.go
@@ -7,6 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	textpb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/text"
@@ -120,7 +122,12 @@ func buildSchemaForMessage(desc protoreflect.MessageDescriptor, prefix string) (
 }
 
 func augmentRootAttributes(attrs map[string]resourceschema.Attribute, attrTypes map[string]attr.Type) {
-	attrs[idAttr] = resourceschema.StringAttribute{Computed: true}
+	attrs[idAttr] = resourceschema.StringAttribute{
+		Computed: true,
+		PlanModifiers: []planmodifier.String{
+			stringplanmodifier.UseStateForUnknown(),
+		},
+	}
 	attrs[orgIDAttr] = resourceschema.StringAttribute{Required: true}
 	attrs[languageAttr] = resourceschema.StringAttribute{Required: true}
 

--- a/zitadel/default_domain_claimed_message_text/resource.go
+++ b/zitadel/default_domain_claimed_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *defaultDomainClaimedMessageTextResource) Read(ctx context.Context, req 
 
 	zResp, err := client.GetCustomDomainClaimedMessageText(ctx, &admin.GetCustomDomainClaimedMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, language)...)

--- a/zitadel/default_init_message_text/resource.go
+++ b/zitadel/default_init_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *defaultInitMessageTextResource) Read(ctx context.Context, req resource.
 
 	zResp, err := client.GetCustomInitMessageText(ctx, &admin.GetCustomInitMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, language)...)

--- a/zitadel/default_invite_user_message_text/resource.go
+++ b/zitadel/default_invite_user_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *defaultInviteUserMessageTextResource) Read(ctx context.Context, req res
 
 	zResp, err := client.GetCustomInviteUserMessageText(ctx, &admin.GetCustomInviteUserMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, language)...)

--- a/zitadel/default_login_texts/resource.go
+++ b/zitadel/default_login_texts/resource.go
@@ -121,15 +121,15 @@ func (r *defaultLoginTextsResource) Read(ctx context.Context, req resource.ReadR
 
 	zResp, err := client.GetCustomLoginTexts(ctx, &admin.GetCustomLoginTextsRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyLoginCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyLoginCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, language)...)

--- a/zitadel/default_password_change_message_text/resource.go
+++ b/zitadel/default_password_change_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *defaultPasswordChangeMessageTextResource) Read(ctx context.Context, req
 
 	zResp, err := client.GetCustomPasswordChangeMessageText(ctx, &admin.GetCustomPasswordChangeMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, language)...)

--- a/zitadel/default_password_reset_message_text/resource.go
+++ b/zitadel/default_password_reset_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *defaultPasswordResetMessageTextResource) Read(ctx context.Context, req 
 
 	zResp, err := client.GetCustomPasswordResetMessageText(ctx, &admin.GetCustomPasswordResetMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, language)...)

--- a/zitadel/default_passwordless_registration_message_text/resource.go
+++ b/zitadel/default_passwordless_registration_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *defaultPasswordlessRegistrationMessageTextResource) Read(ctx context.Co
 
 	zResp, err := client.GetCustomPasswordlessRegistrationMessageText(ctx, &admin.GetCustomPasswordlessRegistrationMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, language)...)

--- a/zitadel/default_verify_email_message_text/resource.go
+++ b/zitadel/default_verify_email_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *defaultVerifyEmailMessageTextResource) Read(ctx context.Context, req re
 
 	zResp, err := client.GetCustomVerifyEmailMessageText(ctx, &admin.GetCustomVerifyEmailMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, language)...)

--- a/zitadel/default_verify_email_otp_message_text/resource.go
+++ b/zitadel/default_verify_email_otp_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *defaultVerifyEmailOTPMessageTextResource) Read(ctx context.Context, req
 
 	zResp, err := client.GetCustomVerifyEmailOTPMessageText(ctx, &admin.GetCustomVerifyEmailOTPMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, language)...)

--- a/zitadel/default_verify_phone_message_text/resource.go
+++ b/zitadel/default_verify_phone_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *defaultVerifyPhoneMessageTextResource) Read(ctx context.Context, req re
 
 	zResp, err := client.GetCustomVerifyPhoneMessageText(ctx, &admin.GetCustomVerifyPhoneMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, language)...)

--- a/zitadel/default_verify_sms_otp_message_text/resource.go
+++ b/zitadel/default_verify_sms_otp_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *defaultVerifySMSOTPMessageTextResource) Read(ctx context.Context, req r
 
 	zResp, err := client.GetCustomVerifySMSOTPMessageText(ctx, &admin.GetCustomVerifySMSOTPMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, language)...)

--- a/zitadel/domain_claimed_message_text/resource.go
+++ b/zitadel/domain_claimed_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *domainClaimedMessageTextResource) Read(ctx context.Context, req resourc
 
 	zResp, err := client.GetCustomDomainClaimedMessageText(helper.CtxSetOrgID(ctx, orgID), &management.GetCustomDomainClaimedMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, orgID, language)...)

--- a/zitadel/init_message_text/resource.go
+++ b/zitadel/init_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *initMessageTextResource) Read(ctx context.Context, req resource.ReadReq
 
 	zResp, err := client.GetCustomInitMessageText(helper.CtxSetOrgID(ctx, orgID), &management.GetCustomInitMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, orgID, language)...)

--- a/zitadel/login_texts/resource.go
+++ b/zitadel/login_texts/resource.go
@@ -121,15 +121,15 @@ func (r *loginTextsResource) Read(ctx context.Context, req resource.ReadRequest,
 
 	zResp, err := client.GetCustomLoginTexts(helper.CtxSetOrgID(ctx, orgID), &management.GetCustomLoginTextsRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyLoginCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyLoginCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, orgID, language)...)

--- a/zitadel/password_change_message_text/resource.go
+++ b/zitadel/password_change_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *passwordChangeMessageTextResource) Read(ctx context.Context, req resour
 
 	zResp, err := client.GetCustomPasswordChangeMessageText(helper.CtxSetOrgID(ctx, orgID), &management.GetCustomPasswordChangeMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, orgID, language)...)

--- a/zitadel/password_reset_message_text/resource.go
+++ b/zitadel/password_reset_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *passwordResetMessageTextResource) Read(ctx context.Context, req resourc
 
 	zResp, err := client.GetCustomPasswordResetMessageText(helper.CtxSetOrgID(ctx, orgID), &management.GetCustomPasswordResetMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, orgID, language)...)

--- a/zitadel/passwordless_registration_message_text/resource.go
+++ b/zitadel/passwordless_registration_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *passwordlessRegistrationMessageTextResource) Read(ctx context.Context, 
 
 	zResp, err := client.GetCustomPasswordlessRegistrationMessageText(helper.CtxSetOrgID(ctx, orgID), &management.GetCustomPasswordlessRegistrationMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, orgID, language)...)

--- a/zitadel/verify_email_message_text/resource.go
+++ b/zitadel/verify_email_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *verifyEmailMessageTextResource) Read(ctx context.Context, req resource.
 
 	zResp, err := client.GetCustomVerifyEmailMessageText(helper.CtxSetOrgID(ctx, orgID), &management.GetCustomVerifyEmailMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, orgID, language)...)

--- a/zitadel/verify_email_otp_message_text/resource.go
+++ b/zitadel/verify_email_otp_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *verifyEmailOTPMessageTextResource) Read(ctx context.Context, req resour
 
 	zResp, err := client.GetCustomVerifyEmailOTPMessageText(helper.CtxSetOrgID(ctx, orgID), &management.GetCustomVerifyEmailOTPMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, orgID, language)...)

--- a/zitadel/verify_phone_message_text/resource.go
+++ b/zitadel/verify_phone_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *verifyPhoneMessageTextResource) Read(ctx context.Context, req resource.
 
 	zResp, err := client.GetCustomVerifyPhoneMessageText(helper.CtxSetOrgID(ctx, orgID), &management.GetCustomVerifyPhoneMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, orgID, language)...)

--- a/zitadel/verify_sms_otp_message_text/resource.go
+++ b/zitadel/verify_sms_otp_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *verifySMSOTPMessageTextResource) Read(ctx context.Context, req resource
 
 	zResp, err := client.GetCustomVerifySMSOTPMessageText(helper.CtxSetOrgID(ctx, orgID), &management.GetCustomVerifySMSOTPMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, orgID, language)...)


### PR DESCRIPTION
After the v2.4.0 framework migration, every `terraform plan` on the message-text and login-texts resources (`zitadel_init_message_text`, `zitadel_login_texts`, `zitadel_password_reset_message_text`, `zitadel_verify_email_message_text`, plus all the sibling `*_message_text` and `default_*` variants) showed `id = "…_fr" -> (known after apply)` and `apply` never persisted it, leaving a permanent diff. Root cause: the shared schema in `gen/.../text_terraform.go` declared `id` as `Computed: true` with no plan modifier, and every Read function returned early without calling `resp.State.Set` whenever the API returned `IsDefault=true` or an error, so the state never reconciled.

Added `stringplanmodifier.UseStateForUnknown()` to the `id` attribute in the shared schema and reshaped Read across all 21 affected resources to surface API errors as diagnostics and always persist `id`/`org_id`/`language` (skipping the body-text copy only when the server reports defaults).

Closes #397

### Definition of Ready

- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] All non-functional requirements are met
- [x] The generic lifecycle acceptance test passes for affected resources.
- [x] Examples are up-to-date and meaningful. The provider version is incremented.
- [x] Docs are generated.
- [x] Code is generated where possible.