### PR TITLE
docs: add version compatibility and deprecation notices to resource descriptions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ provider "zitadel" {
 - `jwt_profile_json` (String) JSON value of credentials to connect to ZITADEL. Either 'access_token', 'jwt_file', 'jwt_profile_file', 'jwt_profile_json' or 'system_api' is required
 - `port` (String) Used port if not the default ports 80 or 443 are configured
 - `system_api` (Block List) Configuration block for authenticating with the ZITADEL System API using a PEM encoded key. (see [below for nested schema](#nestedblock--system_api))
-- `token` (String, Deprecated) Deprecated: Use `access_token` for Personal Access Tokens or `jwt_profile_file` for JWT profile credentials instead. Path to the file containing a JWT Profile key to connect to ZITADEL.
+- `token` (String, Deprecated) Deprecated: Use 'access_token' for Personal Access Tokens or 'jwt_profile_file' for JWT Profile credentials instead. Path to the file containing a JWT Profile key to connect to ZITADEL.
 - `transport_headers` (Map of String) Custom headers to add to both HTTP (authentication) and gRPC (API) requests. Useful for proxy authentication (e.g., GCP IAP with Proxy-Authorization header).
 
 <a id="nestedblock--system_api"></a>

--- a/docs/resources/default_domain_claimed_message_text.md
+++ b/docs/resources/default_domain_claimed_message_text.md
@@ -2,12 +2,12 @@
 page_title: "zitadel_default_domain_claimed_message_text Resource - terraform-provider-zitadel"
 subcategory: ""
 description: |-
-  
+  Instance-level default template for the domain claimed notification email. Org-level overrides are managed by zitadel_domain_claimed_message_text.
 ---
 
 # zitadel_default_domain_claimed_message_text (Resource)
 
-
+Instance-level default template for the domain claimed notification email. Org-level overrides are managed by `zitadel_domain_claimed_message_text`.
 
 ## Example Usage
 

--- a/docs/resources/default_init_message_text.md
+++ b/docs/resources/default_init_message_text.md
@@ -2,12 +2,12 @@
 page_title: "zitadel_default_init_message_text Resource - terraform-provider-zitadel"
 subcategory: ""
 description: |-
-  
+  Instance-level default template for the account initialization email sent to newly created users. Org-level overrides are managed by zitadel_init_message_text.
 ---
 
 # zitadel_default_init_message_text (Resource)
 
-
+Instance-level default template for the account initialization email sent to newly created users. Org-level overrides are managed by `zitadel_init_message_text`.
 
 ## Example Usage
 

--- a/docs/resources/default_invite_user_message_text.md
+++ b/docs/resources/default_invite_user_message_text.md
@@ -2,12 +2,12 @@
 page_title: "zitadel_default_invite_user_message_text Resource - terraform-provider-zitadel"
 subcategory: ""
 description: |-
-  
+  Instance-level default template for the user invitation email. There is no org-level override for this message type.
 ---
 
 # zitadel_default_invite_user_message_text (Resource)
 
-
+Instance-level default template for the user invitation email. There is no org-level override for this message type.
 
 ## Example Usage
 

--- a/docs/resources/default_login_texts.md
+++ b/docs/resources/default_login_texts.md
@@ -2,12 +2,12 @@
 page_title: "zitadel_default_login_texts Resource - terraform-provider-zitadel"
 subcategory: ""
 description: |-
-  
+  Instance-level default text customizations for the legacy login UI (v1) at /ui/login. These settings have no effect on the new hosted login v2 (/ui/v2/login). Org-level overrides are managed by zitadel_login_texts.
 ---
 
 # zitadel_default_login_texts (Resource)
 
-
+Instance-level default text customizations for the **legacy login UI (v1)** at `/ui/login`. These settings have **no effect on the new hosted login v2** (`/ui/v2/login`). Org-level overrides are managed by `zitadel_login_texts`.
 
 ## Example Usage
 

--- a/docs/resources/default_password_change_message_text.md
+++ b/docs/resources/default_password_change_message_text.md
@@ -2,12 +2,12 @@
 page_title: "zitadel_default_password_change_message_text Resource - terraform-provider-zitadel"
 subcategory: ""
 description: |-
-  
+  Instance-level default template for the notification email sent when a user's password changes. Org-level overrides are managed by zitadel_password_change_message_text.
 ---
 
 # zitadel_default_password_change_message_text (Resource)
 
-
+Instance-level default template for the notification email sent when a user's password changes. Org-level overrides are managed by `zitadel_password_change_message_text`.
 
 ## Example Usage
 

--- a/docs/resources/default_password_reset_message_text.md
+++ b/docs/resources/default_password_reset_message_text.md
@@ -2,12 +2,12 @@
 page_title: "zitadel_default_password_reset_message_text Resource - terraform-provider-zitadel"
 subcategory: ""
 description: |-
-  
+  Instance-level default template for the password reset notification email. Org-level overrides are managed by zitadel_password_reset_message_text.
 ---
 
 # zitadel_default_password_reset_message_text (Resource)
 
-
+Instance-level default template for the password reset notification email. Org-level overrides are managed by `zitadel_password_reset_message_text`.
 
 ## Example Usage
 

--- a/docs/resources/default_passwordless_registration_message_text.md
+++ b/docs/resources/default_passwordless_registration_message_text.md
@@ -2,12 +2,12 @@
 page_title: "zitadel_default_passwordless_registration_message_text Resource - terraform-provider-zitadel"
 subcategory: ""
 description: |-
-  
+  Instance-level default template for the passkey/passwordless registration invitation email. Org-level overrides are managed by zitadel_passwordless_registration_message_text.
 ---
 
 # zitadel_default_passwordless_registration_message_text (Resource)
 
-
+Instance-level default template for the passkey/passwordless registration invitation email. Org-level overrides are managed by `zitadel_passwordless_registration_message_text`.
 
 ## Example Usage
 

--- a/docs/resources/default_verify_email_message_text.md
+++ b/docs/resources/default_verify_email_message_text.md
@@ -2,12 +2,12 @@
 page_title: "zitadel_default_verify_email_message_text Resource - terraform-provider-zitadel"
 subcategory: ""
 description: |-
-  
+  Instance-level default template for the email address verification email. Org-level overrides are managed by zitadel_verify_email_message_text.
 ---
 
 # zitadel_default_verify_email_message_text (Resource)
 
-
+Instance-level default template for the email address verification email. Org-level overrides are managed by `zitadel_verify_email_message_text`.
 
 ## Example Usage
 

--- a/docs/resources/default_verify_email_otp_message_text.md
+++ b/docs/resources/default_verify_email_otp_message_text.md
@@ -2,12 +2,12 @@
 page_title: "zitadel_default_verify_email_otp_message_text Resource - terraform-provider-zitadel"
 subcategory: ""
 description: |-
-  
+  Instance-level default template for the OTP verification email. Org-level overrides are managed by zitadel_verify_email_otp_message_text.
 ---
 
 # zitadel_default_verify_email_otp_message_text (Resource)
 
-
+Instance-level default template for the OTP verification email. Org-level overrides are managed by `zitadel_verify_email_otp_message_text`.
 
 ## Example Usage
 

--- a/docs/resources/default_verify_phone_message_text.md
+++ b/docs/resources/default_verify_phone_message_text.md
@@ -2,12 +2,12 @@
 page_title: "zitadel_default_verify_phone_message_text Resource - terraform-provider-zitadel"
 subcategory: ""
 description: |-
-  
+  Instance-level default template for the phone number verification SMS. Org-level overrides are managed by zitadel_verify_phone_message_text.
 ---
 
 # zitadel_default_verify_phone_message_text (Resource)
 
-
+Instance-level default template for the phone number verification SMS. Org-level overrides are managed by `zitadel_verify_phone_message_text`.
 
 ## Example Usage
 

--- a/docs/resources/default_verify_sms_otp_message_text.md
+++ b/docs/resources/default_verify_sms_otp_message_text.md
@@ -2,12 +2,12 @@
 page_title: "zitadel_default_verify_sms_otp_message_text Resource - terraform-provider-zitadel"
 subcategory: ""
 description: |-
-  
+  Instance-level default template for the OTP verification SMS. Org-level overrides are managed by zitadel_verify_sms_otp_message_text.
 ---
 
 # zitadel_default_verify_sms_otp_message_text (Resource)
 
-
+Instance-level default template for the OTP verification SMS. Org-level overrides are managed by `zitadel_verify_sms_otp_message_text`.
 
 ## Example Usage
 

--- a/docs/resources/domain.md
+++ b/docs/resources/domain.md
@@ -2,12 +2,12 @@
 page_title: "zitadel_domain Resource - terraform-provider-zitadel"
 subcategory: ""
 description: |-
-  Resource representing a domain of the organization.
+  Domain of an organization. Deprecated: use zitadel_organization_domain which uses the org/v2 API (requires ZITADEL 4.x).
 ---
 
 # zitadel_domain (Resource)
 
-Resource representing a domain of the organization.
+Domain of an organization. **Deprecated:** use `zitadel_organization_domain` which uses the org/v2 API (requires ZITADEL 4.x).
 
 ## Example Usage
 

--- a/docs/resources/domain_claimed_message_text.md
+++ b/docs/resources/domain_claimed_message_text.md
@@ -2,12 +2,12 @@
 page_title: "zitadel_domain_claimed_message_text Resource - terraform-provider-zitadel"
 subcategory: ""
 description: |-
-  
+  Customizes the notification email sent to users when a domain is claimed (org-scoped). Instance-level defaults are managed by zitadel_default_domain_claimed_message_text.
 ---
 
 # zitadel_domain_claimed_message_text (Resource)
 
-
+Customizes the notification email sent to users when a domain is claimed (org-scoped). Instance-level defaults are managed by `zitadel_default_domain_claimed_message_text`.
 
 ## Example Usage
 

--- a/docs/resources/email_provider_smtp.md
+++ b/docs/resources/email_provider_smtp.md
@@ -2,12 +2,12 @@
 page_title: "zitadel_email_provider_smtp Resource - terraform-provider-zitadel"
 subcategory: ""
 description: |-
-  Resource representing the SMTP email provider configuration of an instance.
+  SMTP email provider configuration for an instance. This is the current API for configuring SMTP (replaces the deprecated zitadel_smtp_config).
 ---
 
 # zitadel_email_provider_smtp (Resource)
 
-Resource representing the SMTP email provider configuration of an instance.
+SMTP email provider configuration for an instance. This is the current API for configuring SMTP (replaces the deprecated `zitadel_smtp_config`).
 
 ## Example Usage
 

--- a/docs/resources/human_user.md
+++ b/docs/resources/human_user.md
@@ -2,12 +2,12 @@
 page_title: "zitadel_human_user Resource - terraform-provider-zitadel"
 subcategory: ""
 description: |-
-  Resource representing a human user situated under an organization, which then can be authorized through memberships or direct grants on other resources.
+  Human user under an organization, using the user/v2 API. Requires ZITADEL 4.x.
 ---
 
 # zitadel_human_user (Resource)
 
-Resource representing a human user situated under an organization, which then can be authorized through memberships or direct grants on other resources.
+Human user under an organization, using the user/v2 API. **Requires ZITADEL 4.x.**
 
 ## Example Usage
 

--- a/docs/resources/init_message_text.md
+++ b/docs/resources/init_message_text.md
@@ -2,12 +2,12 @@
 page_title: "zitadel_init_message_text Resource - terraform-provider-zitadel"
 subcategory: ""
 description: |-
-  
+  Customizes the account initialization email sent to newly created users (org-scoped). Instance-level defaults are managed by zitadel_default_init_message_text.
 ---
 
 # zitadel_init_message_text (Resource)
 
-
+Customizes the account initialization email sent to newly created users (org-scoped). Instance-level defaults are managed by `zitadel_default_init_message_text`.
 
 ## Example Usage
 

--- a/docs/resources/login_texts.md
+++ b/docs/resources/login_texts.md
@@ -2,12 +2,12 @@
 page_title: "zitadel_login_texts Resource - terraform-provider-zitadel"
 subcategory: ""
 description: |-
-  
+  Customizes the text displayed in the legacy login UI (v1) at /ui/login. These settings have no effect on the new hosted login v2 (/ui/v2/login). For hosted login v2 translations, use the ZITADEL SettingsService v2beta SetHostedLoginTranslation API directly. Instance-level defaults are managed by zitadel_default_login_texts.
 ---
 
 # zitadel_login_texts (Resource)
 
-
+Customizes the text displayed in the **legacy login UI (v1)** at `/ui/login`. These settings have **no effect on the new hosted login v2** (`/ui/v2/login`). For hosted login v2 translations, use the ZITADEL SettingsService v2beta `SetHostedLoginTranslation` API directly. Instance-level defaults are managed by `zitadel_default_login_texts`.
 
 ## Example Usage
 

--- a/docs/resources/machine_user.md
+++ b/docs/resources/machine_user.md
@@ -2,12 +2,12 @@
 page_title: "zitadel_machine_user Resource - terraform-provider-zitadel"
 subcategory: ""
 description: |-
-  Resource representing a serviceaccount situated under an organization, which then can be authorized through memberships or direct grants on other resources.
+  Machine user (service account) under an organization. Backward-compatible: tries the user/v2 API first and falls back to the management API, so it works with both ZITADEL 3.x and 4.x.
 ---
 
 # zitadel_machine_user (Resource)
 
-Resource representing a serviceaccount situated under an organization, which then can be authorized through memberships or direct grants on other resources.
+Machine user (service account) under an organization. Backward-compatible: tries the user/v2 API first and falls back to the management API, so it works with both ZITADEL 3.x and 4.x.
 
 ## Example Usage
 

--- a/docs/resources/org.md
+++ b/docs/resources/org.md
@@ -2,12 +2,12 @@
 page_title: "zitadel_org Resource - terraform-provider-zitadel"
 subcategory: ""
 description: |-
-  Resource representing an organization in ZITADEL, which is the highest level after the instance and contains several other resource including policies if the configuration differs to the default policies on the instance.
+  Organization resource that is backward-compatible with ZITADEL 3.x and 4.x: it tries the org/v2 API first and falls back to the management API automatically. For deployments that only target ZITADEL 4.x, prefer zitadel_organization.
 ---
 
 # zitadel_org (Resource)
 
-Resource representing an organization in ZITADEL, which is the highest level after the instance and contains several other resource including policies if the configuration differs to the default policies on the instance.
+Organization resource that is backward-compatible with ZITADEL 3.x and 4.x: it tries the org/v2 API first and falls back to the management API automatically. For deployments that only target ZITADEL 4.x, prefer `zitadel_organization`.
 
 ## Example Usage
 

--- a/docs/resources/org_metadata.md
+++ b/docs/resources/org_metadata.md
@@ -2,12 +2,12 @@
 page_title: "zitadel_org_metadata Resource - terraform-provider-zitadel"
 subcategory: ""
 description: |-
-  Add a custom attribute to the organization like its location or an identifier in another system. You can use this information in your actions. This Terraform resource manages a single key-value pair.
+  Custom key-value metadata on an organization. Deprecated: use zitadel_organization_metadata which uses the metadata/v2 API (requires ZITADEL 4.x).
 ---
 
 # zitadel_org_metadata (Resource)
 
-Add a custom attribute to the organization like its location or an identifier in another system. You can use this information in your actions. This Terraform resource manages a single key-value pair.
+Custom key-value metadata on an organization. **Deprecated:** use `zitadel_organization_metadata` which uses the metadata/v2 API (requires ZITADEL 4.x).
 
 ## Example Usage
 

--- a/docs/resources/organization.md
+++ b/docs/resources/organization.md
@@ -2,12 +2,12 @@
 page_title: "zitadel_organization Resource - terraform-provider-zitadel"
 subcategory: ""
 description: |-
-  Resource representing an organization in ZITADEL, which is the highest level after the instance and contains several other resource including policies if the configuration differs to the default policies on the instance.
+  Resource representing an organization in ZITADEL. Uses the org/v2 API and requires ZITADEL 4.x. For deployments that must support ZITADEL 3.x, use zitadel_org instead (it automatically falls back to the management API).
 ---
 
 # zitadel_organization (Resource)
 
-Resource representing an organization in ZITADEL, which is the highest level after the instance and contains several other resource including policies if the configuration differs to the default policies on the instance.
+Resource representing an organization in ZITADEL. Uses the org/v2 API and **requires ZITADEL 4.x**. For deployments that must support ZITADEL 3.x, use `zitadel_org` instead (it automatically falls back to the management API).
 
 ## Example Usage
 

--- a/docs/resources/organization_domain.md
+++ b/docs/resources/organization_domain.md
@@ -2,12 +2,12 @@
 page_title: "zitadel_organization_domain Resource - terraform-provider-zitadel"
 subcategory: ""
 description: |-
-  Resource representing a domain of an organization in ZITADEL.
+  Domain of an organization, using the org/v2 API. Requires ZITADEL 4.x. For 3.x compatibility use zitadel_domain.
 ---
 
 # zitadel_organization_domain (Resource)
 
-Resource representing a domain of an organization in ZITADEL.
+Domain of an organization, using the org/v2 API. **Requires ZITADEL 4.x.** For 3.x compatibility use `zitadel_domain`.
 
 ## Example Usage
 

--- a/docs/resources/organization_metadata.md
+++ b/docs/resources/organization_metadata.md
@@ -2,12 +2,12 @@
 page_title: "zitadel_organization_metadata Resource - terraform-provider-zitadel"
 subcategory: ""
 description: |-
-  Resource representing metadata of an organization in ZITADEL. This resource manages a single key-value pair.
+  Custom key-value metadata on an organization, using the metadata/v2 API. Requires ZITADEL 4.x. For 3.x compatibility use zitadel_org_metadata.
 ---
 
 # zitadel_organization_metadata (Resource)
 
-Resource representing metadata of an organization in ZITADEL. This resource manages a single key-value pair.
+Custom key-value metadata on an organization, using the metadata/v2 API. **Requires ZITADEL 4.x.** For 3.x compatibility use `zitadel_org_metadata`.
 
 ## Example Usage
 

--- a/docs/resources/password_change_message_text.md
+++ b/docs/resources/password_change_message_text.md
@@ -2,12 +2,12 @@
 page_title: "zitadel_password_change_message_text Resource - terraform-provider-zitadel"
 subcategory: ""
 description: |-
-  
+  Customizes the notification email sent to users when their password is changed (org-scoped). Instance-level defaults are managed by zitadel_default_password_change_message_text.
 ---
 
 # zitadel_password_change_message_text (Resource)
 
-
+Customizes the notification email sent to users when their password is changed (org-scoped). Instance-level defaults are managed by `zitadel_default_password_change_message_text`.
 
 ## Example Usage
 

--- a/docs/resources/password_reset_message_text.md
+++ b/docs/resources/password_reset_message_text.md
@@ -2,12 +2,12 @@
 page_title: "zitadel_password_reset_message_text Resource - terraform-provider-zitadel"
 subcategory: ""
 description: |-
-  
+  Customizes the password reset notification email sent to users (org-scoped). Instance-level defaults are managed by zitadel_default_password_reset_message_text.
 ---
 
 # zitadel_password_reset_message_text (Resource)
 
-
+Customizes the password reset notification email sent to users (org-scoped). Instance-level defaults are managed by `zitadel_default_password_reset_message_text`.
 
 ## Example Usage
 

--- a/docs/resources/passwordless_registration_message_text.md
+++ b/docs/resources/passwordless_registration_message_text.md
@@ -2,12 +2,12 @@
 page_title: "zitadel_passwordless_registration_message_text Resource - terraform-provider-zitadel"
 subcategory: ""
 description: |-
-  
+  Customizes the passkey/passwordless registration invitation email sent to users (org-scoped). Instance-level defaults are managed by zitadel_default_passwordless_registration_message_text.
 ---
 
 # zitadel_passwordless_registration_message_text (Resource)
 
-
+Customizes the passkey/passwordless registration invitation email sent to users (org-scoped). Instance-level defaults are managed by `zitadel_default_passwordless_registration_message_text`.
 
 ## Example Usage
 

--- a/docs/resources/smtp_config.md
+++ b/docs/resources/smtp_config.md
@@ -2,12 +2,12 @@
 page_title: "zitadel_smtp_config Resource - terraform-provider-zitadel"
 subcategory: ""
 description: |-
-  Resource representing the SMTP configuration of an instance.
+  Instance SMTP configuration. Deprecated: the underlying SMTP config API is marked deprecated in ZITADEL. Use zitadel_email_provider_smtp instead.
 ---
 
 # zitadel_smtp_config (Resource)
 
-Resource representing the SMTP configuration of an instance.
+Instance SMTP configuration. **Deprecated:** the underlying SMTP config API is marked deprecated in ZITADEL. Use `zitadel_email_provider_smtp` instead.
 
 ## Example Usage
 

--- a/docs/resources/verify_email_message_text.md
+++ b/docs/resources/verify_email_message_text.md
@@ -2,12 +2,12 @@
 page_title: "zitadel_verify_email_message_text Resource - terraform-provider-zitadel"
 subcategory: ""
 description: |-
-  
+  Customizes the email address verification email sent to users (org-scoped). Instance-level defaults are managed by zitadel_default_verify_email_message_text.
 ---
 
 # zitadel_verify_email_message_text (Resource)
 
-
+Customizes the email address verification email sent to users (org-scoped). Instance-level defaults are managed by `zitadel_default_verify_email_message_text`.
 
 ## Example Usage
 

--- a/docs/resources/verify_email_otp_message_text.md
+++ b/docs/resources/verify_email_otp_message_text.md
@@ -2,12 +2,12 @@
 page_title: "zitadel_verify_email_otp_message_text Resource - terraform-provider-zitadel"
 subcategory: ""
 description: |-
-  
+  Customizes the one-time password (OTP) verification email sent to users (org-scoped). Instance-level defaults are managed by zitadel_default_verify_email_otp_message_text.
 ---
 
 # zitadel_verify_email_otp_message_text (Resource)
 
-
+Customizes the one-time password (OTP) verification email sent to users (org-scoped). Instance-level defaults are managed by `zitadel_default_verify_email_otp_message_text`.
 
 ## Example Usage
 

--- a/docs/resources/verify_phone_message_text.md
+++ b/docs/resources/verify_phone_message_text.md
@@ -2,12 +2,12 @@
 page_title: "zitadel_verify_phone_message_text Resource - terraform-provider-zitadel"
 subcategory: ""
 description: |-
-  
+  Customizes the phone number verification SMS sent to users (org-scoped). Instance-level defaults are managed by zitadel_default_verify_phone_message_text.
 ---
 
 # zitadel_verify_phone_message_text (Resource)
 
-
+Customizes the phone number verification SMS sent to users (org-scoped). Instance-level defaults are managed by `zitadel_default_verify_phone_message_text`.
 
 ## Example Usage
 

--- a/docs/resources/verify_sms_otp_message_text.md
+++ b/docs/resources/verify_sms_otp_message_text.md
@@ -2,12 +2,12 @@
 page_title: "zitadel_verify_sms_otp_message_text Resource - terraform-provider-zitadel"
 subcategory: ""
 description: |-
-  
+  Customizes the one-time password (OTP) verification SMS sent to users (org-scoped). Instance-level defaults are managed by zitadel_default_verify_sms_otp_message_text.
 ---
 
 # zitadel_verify_sms_otp_message_text (Resource)
 
-
+Customizes the one-time password (OTP) verification SMS sent to users (org-scoped). Instance-level defaults are managed by `zitadel_default_verify_sms_otp_message_text`.
 
 ## Example Usage
 

--- a/gen/github.com/zitadel/zitadel/pkg/grpc/text/text_terraform.go
+++ b/gen/github.com/zitadel/zitadel/pkg/grpc/text/text_terraform.go
@@ -7,6 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	textpb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/text"
@@ -120,7 +122,12 @@ func buildSchemaForMessage(desc protoreflect.MessageDescriptor, prefix string) (
 }
 
 func augmentRootAttributes(attrs map[string]resourceschema.Attribute, attrTypes map[string]attr.Type) {
-	attrs[idAttr] = resourceschema.StringAttribute{Computed: true}
+	attrs[idAttr] = resourceschema.StringAttribute{
+		Computed: true,
+		PlanModifiers: []planmodifier.String{
+			stringplanmodifier.UseStateForUnknown(),
+		},
+	}
 	attrs[orgIDAttr] = resourceschema.StringAttribute{Required: true}
 	attrs[languageAttr] = resourceschema.StringAttribute{Required: true}
 

--- a/zitadel/default_domain_claimed_message_text/resource.go
+++ b/zitadel/default_domain_claimed_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *defaultDomainClaimedMessageTextResource) Read(ctx context.Context, req 
 
 	zResp, err := client.GetCustomDomainClaimedMessageText(ctx, &admin.GetCustomDomainClaimedMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, language)...)

--- a/zitadel/default_domain_claimed_message_text/resource.go
+++ b/zitadel/default_domain_claimed_message_text/resource.go
@@ -41,6 +41,8 @@ func (r *defaultDomainClaimedMessageTextResource) Schema(ctx context.Context, _ 
 	s, diags := text.GenSchemaMessageCustomText(ctx)
 	resp.Diagnostics.Append(diags...)
 	delete(s.Attributes, "org_id")
+	s.MarkdownDescription = "Instance-level default template for the domain claimed notification email. " +
+		"Org-level overrides are managed by `zitadel_domain_claimed_message_text`."
 	resp.Schema = s
 }
 

--- a/zitadel/default_init_message_text/resource.go
+++ b/zitadel/default_init_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *defaultInitMessageTextResource) Read(ctx context.Context, req resource.
 
 	zResp, err := client.GetCustomInitMessageText(ctx, &admin.GetCustomInitMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, language)...)

--- a/zitadel/default_init_message_text/resource.go
+++ b/zitadel/default_init_message_text/resource.go
@@ -41,6 +41,8 @@ func (r *defaultInitMessageTextResource) Schema(ctx context.Context, _ resource.
 	s, diags := text.GenSchemaMessageCustomText(ctx)
 	resp.Diagnostics.Append(diags...)
 	delete(s.Attributes, "org_id")
+	s.MarkdownDescription = "Instance-level default template for the account initialization email sent to newly created users. " +
+		"Org-level overrides are managed by `zitadel_init_message_text`."
 	resp.Schema = s
 }
 

--- a/zitadel/default_invite_user_message_text/resource.go
+++ b/zitadel/default_invite_user_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *defaultInviteUserMessageTextResource) Read(ctx context.Context, req res
 
 	zResp, err := client.GetCustomInviteUserMessageText(ctx, &admin.GetCustomInviteUserMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, language)...)

--- a/zitadel/default_invite_user_message_text/resource.go
+++ b/zitadel/default_invite_user_message_text/resource.go
@@ -41,6 +41,8 @@ func (r *defaultInviteUserMessageTextResource) Schema(ctx context.Context, _ res
 	s, diags := text.GenSchemaMessageCustomText(ctx)
 	resp.Diagnostics.Append(diags...)
 	delete(s.Attributes, "org_id")
+	s.MarkdownDescription = "Instance-level default template for the user invitation email. " +
+		"There is no org-level override for this message type."
 	resp.Schema = s
 }
 

--- a/zitadel/default_login_texts/resource.go
+++ b/zitadel/default_login_texts/resource.go
@@ -41,6 +41,9 @@ func (r *defaultLoginTextsResource) Schema(ctx context.Context, _ resource.Schem
 	s, diags := text.GenSchemaLoginCustomText(ctx)
 	resp.Diagnostics.Append(diags...)
 	delete(s.Attributes, "org_id")
+	s.MarkdownDescription = "Instance-level default text customizations for the **legacy login UI (v1)** at `/ui/login`. " +
+		"These settings have **no effect on the new hosted login v2** (`/ui/v2/login`). " +
+		"Org-level overrides are managed by `zitadel_login_texts`."
 	resp.Schema = s
 }
 

--- a/zitadel/default_login_texts/resource.go
+++ b/zitadel/default_login_texts/resource.go
@@ -121,15 +121,15 @@ func (r *defaultLoginTextsResource) Read(ctx context.Context, req resource.ReadR
 
 	zResp, err := client.GetCustomLoginTexts(ctx, &admin.GetCustomLoginTextsRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyLoginCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyLoginCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, language)...)

--- a/zitadel/default_password_change_message_text/resource.go
+++ b/zitadel/default_password_change_message_text/resource.go
@@ -41,6 +41,8 @@ func (r *defaultPasswordChangeMessageTextResource) Schema(ctx context.Context, _
 	s, diags := text.GenSchemaMessageCustomText(ctx)
 	resp.Diagnostics.Append(diags...)
 	delete(s.Attributes, "org_id")
+	s.MarkdownDescription = "Instance-level default template for the notification email sent when a user's password changes. " +
+		"Org-level overrides are managed by `zitadel_password_change_message_text`."
 	resp.Schema = s
 }
 

--- a/zitadel/default_password_change_message_text/resource.go
+++ b/zitadel/default_password_change_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *defaultPasswordChangeMessageTextResource) Read(ctx context.Context, req
 
 	zResp, err := client.GetCustomPasswordChangeMessageText(ctx, &admin.GetCustomPasswordChangeMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, language)...)

--- a/zitadel/default_password_reset_message_text/resource.go
+++ b/zitadel/default_password_reset_message_text/resource.go
@@ -41,6 +41,8 @@ func (r *defaultPasswordResetMessageTextResource) Schema(ctx context.Context, _ 
 	s, diags := text.GenSchemaMessageCustomText(ctx)
 	resp.Diagnostics.Append(diags...)
 	delete(s.Attributes, "org_id")
+	s.MarkdownDescription = "Instance-level default template for the password reset notification email. " +
+		"Org-level overrides are managed by `zitadel_password_reset_message_text`."
 	resp.Schema = s
 }
 

--- a/zitadel/default_password_reset_message_text/resource.go
+++ b/zitadel/default_password_reset_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *defaultPasswordResetMessageTextResource) Read(ctx context.Context, req 
 
 	zResp, err := client.GetCustomPasswordResetMessageText(ctx, &admin.GetCustomPasswordResetMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, language)...)

--- a/zitadel/default_passwordless_registration_message_text/resource.go
+++ b/zitadel/default_passwordless_registration_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *defaultPasswordlessRegistrationMessageTextResource) Read(ctx context.Co
 
 	zResp, err := client.GetCustomPasswordlessRegistrationMessageText(ctx, &admin.GetCustomPasswordlessRegistrationMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, language)...)

--- a/zitadel/default_passwordless_registration_message_text/resource.go
+++ b/zitadel/default_passwordless_registration_message_text/resource.go
@@ -41,6 +41,8 @@ func (r *defaultPasswordlessRegistrationMessageTextResource) Schema(ctx context.
 	s, diags := text.GenSchemaMessageCustomText(ctx)
 	resp.Diagnostics.Append(diags...)
 	delete(s.Attributes, "org_id")
+	s.MarkdownDescription = "Instance-level default template for the passkey/passwordless registration invitation email. " +
+		"Org-level overrides are managed by `zitadel_passwordless_registration_message_text`."
 	resp.Schema = s
 }
 

--- a/zitadel/default_verify_email_message_text/resource.go
+++ b/zitadel/default_verify_email_message_text/resource.go
@@ -41,6 +41,8 @@ func (r *defaultVerifyEmailMessageTextResource) Schema(ctx context.Context, _ re
 	s, diags := text.GenSchemaMessageCustomText(ctx)
 	resp.Diagnostics.Append(diags...)
 	delete(s.Attributes, "org_id")
+	s.MarkdownDescription = "Instance-level default template for the email address verification email. " +
+		"Org-level overrides are managed by `zitadel_verify_email_message_text`."
 	resp.Schema = s
 }
 

--- a/zitadel/default_verify_email_message_text/resource.go
+++ b/zitadel/default_verify_email_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *defaultVerifyEmailMessageTextResource) Read(ctx context.Context, req re
 
 	zResp, err := client.GetCustomVerifyEmailMessageText(ctx, &admin.GetCustomVerifyEmailMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, language)...)

--- a/zitadel/default_verify_email_otp_message_text/resource.go
+++ b/zitadel/default_verify_email_otp_message_text/resource.go
@@ -41,6 +41,8 @@ func (r *defaultVerifyEmailOTPMessageTextResource) Schema(ctx context.Context, _
 	s, diags := text.GenSchemaMessageCustomText(ctx)
 	resp.Diagnostics.Append(diags...)
 	delete(s.Attributes, "org_id")
+	s.MarkdownDescription = "Instance-level default template for the OTP verification email. " +
+		"Org-level overrides are managed by `zitadel_verify_email_otp_message_text`."
 	resp.Schema = s
 }
 

--- a/zitadel/default_verify_email_otp_message_text/resource.go
+++ b/zitadel/default_verify_email_otp_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *defaultVerifyEmailOTPMessageTextResource) Read(ctx context.Context, req
 
 	zResp, err := client.GetCustomVerifyEmailOTPMessageText(ctx, &admin.GetCustomVerifyEmailOTPMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, language)...)

--- a/zitadel/default_verify_phone_message_text/resource.go
+++ b/zitadel/default_verify_phone_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *defaultVerifyPhoneMessageTextResource) Read(ctx context.Context, req re
 
 	zResp, err := client.GetCustomVerifyPhoneMessageText(ctx, &admin.GetCustomVerifyPhoneMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, language)...)

--- a/zitadel/default_verify_phone_message_text/resource.go
+++ b/zitadel/default_verify_phone_message_text/resource.go
@@ -41,6 +41,8 @@ func (r *defaultVerifyPhoneMessageTextResource) Schema(ctx context.Context, _ re
 	s, diags := text.GenSchemaMessageCustomText(ctx)
 	resp.Diagnostics.Append(diags...)
 	delete(s.Attributes, "org_id")
+	s.MarkdownDescription = "Instance-level default template for the phone number verification SMS. " +
+		"Org-level overrides are managed by `zitadel_verify_phone_message_text`."
 	resp.Schema = s
 }
 

--- a/zitadel/default_verify_sms_otp_message_text/resource.go
+++ b/zitadel/default_verify_sms_otp_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *defaultVerifySMSOTPMessageTextResource) Read(ctx context.Context, req r
 
 	zResp, err := client.GetCustomVerifySMSOTPMessageText(ctx, &admin.GetCustomVerifySMSOTPMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, language)...)

--- a/zitadel/default_verify_sms_otp_message_text/resource.go
+++ b/zitadel/default_verify_sms_otp_message_text/resource.go
@@ -41,6 +41,8 @@ func (r *defaultVerifySMSOTPMessageTextResource) Schema(ctx context.Context, _ r
 	s, diags := text.GenSchemaMessageCustomText(ctx)
 	resp.Diagnostics.Append(diags...)
 	delete(s.Attributes, "org_id")
+	s.MarkdownDescription = "Instance-level default template for the OTP verification SMS. " +
+		"Org-level overrides are managed by `zitadel_verify_sms_otp_message_text`."
 	resp.Schema = s
 }
 

--- a/zitadel/domain/resource.go
+++ b/zitadel/domain/resource.go
@@ -8,7 +8,8 @@ import (
 
 func GetResource() *schema.Resource {
 	return &schema.Resource{
-		Description: "Resource representing a domain of the organization.",
+		Description:        "Domain of an organization. **Deprecated:** use `zitadel_organization_domain` which uses the org/v2 API (requires ZITADEL 4.x).",
+		DeprecationMessage: "Use zitadel_organization_domain instead (org/v2 API, requires ZITADEL 4.x).",
 		Schema: map[string]*schema.Schema{
 			helper.OrgIDVar: helper.OrgIDResourceField,
 			NameVar: {

--- a/zitadel/domain_claimed_message_text/resource.go
+++ b/zitadel/domain_claimed_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *domainClaimedMessageTextResource) Read(ctx context.Context, req resourc
 
 	zResp, err := client.GetCustomDomainClaimedMessageText(helper.CtxSetOrgID(ctx, orgID), &management.GetCustomDomainClaimedMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, orgID, language)...)

--- a/zitadel/domain_claimed_message_text/resource.go
+++ b/zitadel/domain_claimed_message_text/resource.go
@@ -41,6 +41,8 @@ func (r *domainClaimedMessageTextResource) Metadata(_ context.Context, req resou
 func (r *domainClaimedMessageTextResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	s, diags := text.GenSchemaMessageCustomText(ctx)
 	resp.Diagnostics.Append(diags...)
+	s.MarkdownDescription = "Customizes the notification email sent to users when a domain is claimed (org-scoped). " +
+		"Instance-level defaults are managed by `zitadel_default_domain_claimed_message_text`."
 	resp.Schema = s
 }
 

--- a/zitadel/email_provider_smtp/resource.go
+++ b/zitadel/email_provider_smtp/resource.go
@@ -8,7 +8,7 @@ import (
 
 func GetResource() *schema.Resource {
 	return &schema.Resource{
-		Description: "Resource representing the SMTP email provider configuration of an instance.",
+		Description: "SMTP email provider configuration for an instance. This is the current API for configuring SMTP (replaces the deprecated `zitadel_smtp_config`).",
 		Schema: map[string]*schema.Schema{
 			SenderAddressVar: {
 				Type:        schema.TypeString,

--- a/zitadel/human_user/resource.go
+++ b/zitadel/human_user/resource.go
@@ -14,7 +14,7 @@ import (
 
 func GetResource() *schema.Resource {
 	return &schema.Resource{
-		Description: "Resource representing a human user situated under an organization, which then can be authorized through memberships or direct grants on other resources.",
+		Description: "Human user under an organization, using the user/v2 API. **Requires ZITADEL 4.x.**",
 		Schema: map[string]*schema.Schema{
 			helper.OrgIDVar: helper.OrgIDResourceField,
 			UserIDVar: {

--- a/zitadel/init_message_text/resource.go
+++ b/zitadel/init_message_text/resource.go
@@ -41,6 +41,8 @@ func (r *initMessageTextResource) Metadata(_ context.Context, req resource.Metad
 func (r *initMessageTextResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	s, diags := text.GenSchemaMessageCustomText(ctx)
 	resp.Diagnostics.Append(diags...)
+	s.MarkdownDescription = "Customizes the account initialization email sent to newly created users (org-scoped). " +
+		"Instance-level defaults are managed by `zitadel_default_init_message_text`."
 	resp.Schema = s
 }
 

--- a/zitadel/init_message_text/resource.go
+++ b/zitadel/init_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *initMessageTextResource) Read(ctx context.Context, req resource.ReadReq
 
 	zResp, err := client.GetCustomInitMessageText(helper.CtxSetOrgID(ctx, orgID), &management.GetCustomInitMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, orgID, language)...)

--- a/zitadel/login_texts/resource.go
+++ b/zitadel/login_texts/resource.go
@@ -41,6 +41,10 @@ func (r *loginTextsResource) Metadata(_ context.Context, req resource.MetadataRe
 func (r *loginTextsResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	s, diags := text.GenSchemaLoginCustomText(ctx)
 	resp.Diagnostics.Append(diags...)
+	s.MarkdownDescription = "Customizes the text displayed in the **legacy login UI (v1)** at `/ui/login`. " +
+		"These settings have **no effect on the new hosted login v2** (`/ui/v2/login`). " +
+		"For hosted login v2 translations, use the ZITADEL SettingsService v2beta `SetHostedLoginTranslation` API directly. " +
+		"Instance-level defaults are managed by `zitadel_default_login_texts`."
 	resp.Schema = s
 }
 

--- a/zitadel/login_texts/resource.go
+++ b/zitadel/login_texts/resource.go
@@ -121,15 +121,15 @@ func (r *loginTextsResource) Read(ctx context.Context, req resource.ReadRequest,
 
 	zResp, err := client.GetCustomLoginTexts(helper.CtxSetOrgID(ctx, orgID), &management.GetCustomLoginTextsRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyLoginCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyLoginCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, orgID, language)...)

--- a/zitadel/machine_user/resource.go
+++ b/zitadel/machine_user/resource.go
@@ -11,7 +11,7 @@ import (
 
 func GetResource() *schema.Resource {
 	return &schema.Resource{
-		Description: "Resource representing a serviceaccount situated under an organization, which then can be authorized through memberships or direct grants on other resources.",
+		Description: "Machine user (service account) under an organization. Backward-compatible: tries the user/v2 API first and falls back to the management API, so it works with both ZITADEL 3.x and 4.x.",
 		Schema: map[string]*schema.Schema{
 			helper.OrgIDVar: helper.OrgIDResourceField,
 			UserIDVar: {

--- a/zitadel/org/resource.go
+++ b/zitadel/org/resource.go
@@ -8,7 +8,7 @@ import (
 
 func GetResource() *schema.Resource {
 	return &schema.Resource{
-		Description: "Resource representing an organization in ZITADEL, which is the highest level after the instance and contains several other resource including policies if the configuration differs to the default policies on the instance.",
+		Description: "Organization resource that is backward-compatible with ZITADEL 3.x and 4.x: it tries the org/v2 API first and falls back to the management API automatically. For deployments that only target ZITADEL 4.x, prefer `zitadel_organization`.",
 		Schema: map[string]*schema.Schema{
 			NameVar: {
 				Type:        schema.TypeString,

--- a/zitadel/org_metadata/resource.go
+++ b/zitadel/org_metadata/resource.go
@@ -8,7 +8,8 @@ import (
 
 func GetResource() *schema.Resource {
 	return &schema.Resource{
-		Description: "Add a custom attribute to the organization like its location or an identifier in another system. You can use this information in your actions. This Terraform resource manages a single key-value pair.",
+		Description:        "Custom key-value metadata on an organization. **Deprecated:** use `zitadel_organization_metadata` which uses the metadata/v2 API (requires ZITADEL 4.x).",
+		DeprecationMessage: "Use zitadel_organization_metadata instead (metadata/v2 API, requires ZITADEL 4.x).",
 		Schema: map[string]*schema.Schema{
 			helper.OrgIDVar: helper.OrgIDResourceField,
 			KeyVar: {

--- a/zitadel/organization/resource.go
+++ b/zitadel/organization/resource.go
@@ -8,7 +8,7 @@ import (
 
 func GetResource() *schema.Resource {
 	return &schema.Resource{
-		Description: "Resource representing an organization in ZITADEL, which is the highest level after the instance and contains several other resource including policies if the configuration differs to the default policies on the instance.",
+		Description: "Resource representing an organization in ZITADEL. Uses the org/v2 API and **requires ZITADEL 4.x**. For deployments that must support ZITADEL 3.x, use `zitadel_org` instead (it automatically falls back to the management API).",
 		Schema: map[string]*schema.Schema{
 			NameVar: {
 				Type:        schema.TypeString,

--- a/zitadel/organization_domain/resource.go
+++ b/zitadel/organization_domain/resource.go
@@ -11,7 +11,7 @@ import (
 
 func GetResource() *schema.Resource {
 	return &schema.Resource{
-		Description: "Resource representing a domain of an organization in ZITADEL.",
+		Description: "Domain of an organization, using the org/v2 API. **Requires ZITADEL 4.x.** For 3.x compatibility use `zitadel_domain`.",
 		Schema: map[string]*schema.Schema{
 			OrganizationIDVar: {
 				Type:        schema.TypeString,

--- a/zitadel/organization_metadata/resource.go
+++ b/zitadel/organization_metadata/resource.go
@@ -8,7 +8,7 @@ import (
 
 func GetResource() *schema.Resource {
 	return &schema.Resource{
-		Description: "Resource representing metadata of an organization in ZITADEL. This resource manages a single key-value pair.",
+		Description: "Custom key-value metadata on an organization, using the metadata/v2 API. **Requires ZITADEL 4.x.** For 3.x compatibility use `zitadel_org_metadata`.",
 		Schema: map[string]*schema.Schema{
 			OrganizationIDVar: {
 				Type:        schema.TypeString,

--- a/zitadel/password_change_message_text/resource.go
+++ b/zitadel/password_change_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *passwordChangeMessageTextResource) Read(ctx context.Context, req resour
 
 	zResp, err := client.GetCustomPasswordChangeMessageText(helper.CtxSetOrgID(ctx, orgID), &management.GetCustomPasswordChangeMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, orgID, language)...)

--- a/zitadel/password_change_message_text/resource.go
+++ b/zitadel/password_change_message_text/resource.go
@@ -41,6 +41,8 @@ func (r *passwordChangeMessageTextResource) Metadata(_ context.Context, req reso
 func (r *passwordChangeMessageTextResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	s, diags := text.GenSchemaMessageCustomText(ctx)
 	resp.Diagnostics.Append(diags...)
+	s.MarkdownDescription = "Customizes the notification email sent to users when their password is changed (org-scoped). " +
+		"Instance-level defaults are managed by `zitadel_default_password_change_message_text`."
 	resp.Schema = s
 }
 

--- a/zitadel/password_reset_message_text/resource.go
+++ b/zitadel/password_reset_message_text/resource.go
@@ -41,6 +41,8 @@ func (r *passwordResetMessageTextResource) Metadata(_ context.Context, req resou
 func (r *passwordResetMessageTextResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	s, diags := text.GenSchemaMessageCustomText(ctx)
 	resp.Diagnostics.Append(diags...)
+	s.MarkdownDescription = "Customizes the password reset notification email sent to users (org-scoped). " +
+		"Instance-level defaults are managed by `zitadel_default_password_reset_message_text`."
 	resp.Schema = s
 }
 

--- a/zitadel/password_reset_message_text/resource.go
+++ b/zitadel/password_reset_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *passwordResetMessageTextResource) Read(ctx context.Context, req resourc
 
 	zResp, err := client.GetCustomPasswordResetMessageText(helper.CtxSetOrgID(ctx, orgID), &management.GetCustomPasswordResetMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, orgID, language)...)

--- a/zitadel/passwordless_registration_message_text/resource.go
+++ b/zitadel/passwordless_registration_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *passwordlessRegistrationMessageTextResource) Read(ctx context.Context, 
 
 	zResp, err := client.GetCustomPasswordlessRegistrationMessageText(helper.CtxSetOrgID(ctx, orgID), &management.GetCustomPasswordlessRegistrationMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, orgID, language)...)

--- a/zitadel/passwordless_registration_message_text/resource.go
+++ b/zitadel/passwordless_registration_message_text/resource.go
@@ -41,6 +41,8 @@ func (r *passwordlessRegistrationMessageTextResource) Metadata(_ context.Context
 func (r *passwordlessRegistrationMessageTextResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	s, diags := text.GenSchemaMessageCustomText(ctx)
 	resp.Diagnostics.Append(diags...)
+	s.MarkdownDescription = "Customizes the passkey/passwordless registration invitation email sent to users (org-scoped). " +
+		"Instance-level defaults are managed by `zitadel_default_passwordless_registration_message_text`."
 	resp.Schema = s
 }
 

--- a/zitadel/smtp_config/resource.go
+++ b/zitadel/smtp_config/resource.go
@@ -8,7 +8,8 @@ import (
 
 func GetResource() *schema.Resource {
 	return &schema.Resource{
-		Description: "Resource representing the SMTP configuration of an instance.",
+		Description:        "Instance SMTP configuration. **Deprecated:** the underlying SMTP config API is marked deprecated in ZITADEL. Use `zitadel_email_provider_smtp` instead.",
+		DeprecationMessage: "The underlying SMTP config API is marked deprecated in ZITADEL. Use zitadel_email_provider_smtp instead.",
 		Schema: map[string]*schema.Schema{
 			SenderAddressVar: {
 				Type:        schema.TypeString,

--- a/zitadel/verify_email_message_text/resource.go
+++ b/zitadel/verify_email_message_text/resource.go
@@ -41,6 +41,8 @@ func (r *verifyEmailMessageTextResource) Metadata(_ context.Context, req resourc
 func (r *verifyEmailMessageTextResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	s, diags := text.GenSchemaMessageCustomText(ctx)
 	resp.Diagnostics.Append(diags...)
+	s.MarkdownDescription = "Customizes the email address verification email sent to users (org-scoped). " +
+		"Instance-level defaults are managed by `zitadel_default_verify_email_message_text`."
 	resp.Schema = s
 }
 

--- a/zitadel/verify_email_message_text/resource.go
+++ b/zitadel/verify_email_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *verifyEmailMessageTextResource) Read(ctx context.Context, req resource.
 
 	zResp, err := client.GetCustomVerifyEmailMessageText(helper.CtxSetOrgID(ctx, orgID), &management.GetCustomVerifyEmailMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, orgID, language)...)

--- a/zitadel/verify_email_otp_message_text/resource.go
+++ b/zitadel/verify_email_otp_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *verifyEmailOTPMessageTextResource) Read(ctx context.Context, req resour
 
 	zResp, err := client.GetCustomVerifyEmailOTPMessageText(helper.CtxSetOrgID(ctx, orgID), &management.GetCustomVerifyEmailOTPMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, orgID, language)...)

--- a/zitadel/verify_email_otp_message_text/resource.go
+++ b/zitadel/verify_email_otp_message_text/resource.go
@@ -41,6 +41,8 @@ func (r *verifyEmailOTPMessageTextResource) Metadata(_ context.Context, req reso
 func (r *verifyEmailOTPMessageTextResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	s, diags := text.GenSchemaMessageCustomText(ctx)
 	resp.Diagnostics.Append(diags...)
+	s.MarkdownDescription = "Customizes the one-time password (OTP) verification email sent to users (org-scoped). " +
+		"Instance-level defaults are managed by `zitadel_default_verify_email_otp_message_text`."
 	resp.Schema = s
 }
 

--- a/zitadel/verify_phone_message_text/resource.go
+++ b/zitadel/verify_phone_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *verifyPhoneMessageTextResource) Read(ctx context.Context, req resource.
 
 	zResp, err := client.GetCustomVerifyPhoneMessageText(helper.CtxSetOrgID(ctx, orgID), &management.GetCustomVerifyPhoneMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, orgID, language)...)

--- a/zitadel/verify_phone_message_text/resource.go
+++ b/zitadel/verify_phone_message_text/resource.go
@@ -41,6 +41,8 @@ func (r *verifyPhoneMessageTextResource) Metadata(_ context.Context, req resourc
 func (r *verifyPhoneMessageTextResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	s, diags := text.GenSchemaMessageCustomText(ctx)
 	resp.Diagnostics.Append(diags...)
+	s.MarkdownDescription = "Customizes the phone number verification SMS sent to users (org-scoped). " +
+		"Instance-level defaults are managed by `zitadel_default_verify_phone_message_text`."
 	resp.Schema = s
 }
 

--- a/zitadel/verify_sms_otp_message_text/resource.go
+++ b/zitadel/verify_sms_otp_message_text/resource.go
@@ -41,6 +41,8 @@ func (r *verifySMSOTPMessageTextResource) Metadata(_ context.Context, req resour
 func (r *verifySMSOTPMessageTextResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	s, diags := text.GenSchemaMessageCustomText(ctx)
 	resp.Diagnostics.Append(diags...)
+	s.MarkdownDescription = "Customizes the one-time password (OTP) verification SMS sent to users (org-scoped). " +
+		"Instance-level defaults are managed by `zitadel_default_verify_sms_otp_message_text`."
 	resp.Schema = s
 }
 

--- a/zitadel/verify_sms_otp_message_text/resource.go
+++ b/zitadel/verify_sms_otp_message_text/resource.go
@@ -121,15 +121,15 @@ func (r *verifySMSOTPMessageTextResource) Read(ctx context.Context, req resource
 
 	zResp, err := client.GetCustomVerifySMSOTPMessageText(helper.CtxSetOrgID(ctx, orgID), &management.GetCustomVerifySMSOTPMessageTextRequest{Language: language})
 	if err != nil {
-		return
-	}
-	if zResp.CustomText.IsDefault {
+		resp.Diagnostics.AddError("failed to read", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
+	if !zResp.CustomText.IsDefault {
+		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	resp.Diagnostics.Append(setID(ctx, &state, orgID, language)...)


### PR DESCRIPTION
This pull-request adds descriptions to all 19 \`*_message_text\` resources (previously empty), notes that \`zitadel_login_texts\` and \`zitadel_default_login_texts\` only affect the legacy login UI and have no effect on hosted login v2, and clarifies which resources require ZITADEL 4.x vs work on both 3.x and 4.x. Resources whose underlying proto API is explicitly marked deprecated in ZITADEL (\`zitadel_smtp_config\`, \`zitadel_org_metadata\`, \`zitadel_domain\`) now also carry a Terraform \`DeprecationMessage\` pointing users to their v2 replacements.

Closes #401

### Definition of Ready

- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] All non-functional requirements are met
- [x] The generic lifecycle acceptance test passes for affected resources.
- [x] Examples are up-to-date and meaningful. The provider version is incremented.
- [x] Docs are generated.
- [x] Code is generated where possible.