### PR TITLE
feat: support activating public key on create

### DIFF
--- a/docs/resources/action_target_public_key.md
+++ b/docs/resources/action_target_public_key.md
@@ -28,11 +28,11 @@ resource "zitadel_action_target_public_key" "default" {
 
 ### Optional
 
+- `active` (Boolean) Whether the public key is active and used for payload encryption. If unset, the key is created in the state ZITADEL returns (inactive) and is not modified by this provider. Set to true to activate the key after creation, or to toggle activation on an existing key.
 - `expiration_date` (String) The expiration date of the public key in RFC3339 format.
 
 ### Read-Only
 
-- `active` (Boolean) Whether the public key is active and used for payload encryption.
 - `creation_date` (String) The date the public key was added.
 - `fingerprint` (String) The fingerprint of the public key.
 - `id` (String) The ID of this resource.

--- a/docs/resources/action_target_public_key.md
+++ b/docs/resources/action_target_public_key.md
@@ -28,7 +28,7 @@ resource "zitadel_action_target_public_key" "default" {
 
 ### Optional
 
-- `active` (Boolean) Whether the public key is active and used for payload encryption. If unset, the key is created in the state ZITADEL returns (inactive) and is not modified by this provider. Set to true to activate the key after creation, or to toggle activation on an existing key.
+- `active` (Boolean) Whether the public key is active and used for payload encryption. If unset, the key is created in ZITADEL's default (inactive) state and the provider does not modify its activation state. Set to true to activate the key after creation, or to toggle activation on an existing key.
 - `expiration_date` (String) The expiration date of the public key in RFC3339 format.
 
 ### Read-Only

--- a/zitadel/action_target_public_key/funcs.go
+++ b/zitadel/action_target_public_key/funcs.go
@@ -85,6 +85,57 @@ func create(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 		return diag.Errorf("failed to set key_id: %v", err)
 	}
 
+	// Only call ActivatePublicKey when the user explicitly opted in via active=true.
+	// An unset active leaves the key in ZITADEL's default (inactive) state to preserve
+	// pre-existing behavior for configs that don't set the field.
+	if v, ok := d.GetOkExists(activeVar); ok && v.(bool) {
+		if _, err := client.ActivatePublicKey(ctx, &actionv2.ActivatePublicKeyRequest{
+			TargetId: req.TargetId,
+			KeyId:    resp.GetKeyId(),
+		}); err != nil {
+			return diag.Errorf("failed to activate public key: %v", err)
+		}
+	}
+
+	return nil
+}
+
+func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	tflog.Info(ctx, "started update")
+
+	if !d.HasChange(activeVar) {
+		return nil
+	}
+
+	clientinfo, ok := m.(*helper.ClientInfo)
+	if !ok {
+		return diag.Errorf("failed to get client")
+	}
+
+	client, err := helper.GetActionClient(ctx, clientinfo)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	targetID := d.Get(targetIDVar).(string)
+	keyID := d.Id()
+
+	if d.Get(activeVar).(bool) {
+		if _, err := client.ActivatePublicKey(ctx, &actionv2.ActivatePublicKeyRequest{
+			TargetId: targetID,
+			KeyId:    keyID,
+		}); err != nil {
+			return diag.Errorf("failed to activate public key: %v", err)
+		}
+		return nil
+	}
+
+	if _, err := client.DeactivatePublicKey(ctx, &actionv2.DeactivatePublicKeyRequest{
+		TargetId: targetID,
+		KeyId:    keyID,
+	}); err != nil && helper.IgnorePreconditionError(err) != nil {
+		return diag.Errorf("failed to deactivate public key: %v", err)
+	}
 	return nil
 }
 

--- a/zitadel/action_target_public_key/funcs.go
+++ b/zitadel/action_target_public_key/funcs.go
@@ -14,6 +14,23 @@ import (
 	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/helper"
 )
 
+// configBool reports the practitioner-supplied value of a bool attribute from the
+// raw configuration, returning false when the attribute is absent or unknown.
+// Unlike d.Get / d.GetOkExists it does NOT fall back to state, which makes it
+// the right primitive for distinguishing "the user wrote `active = false`" from
+// "the user did not write `active` at all" on Optional+Computed attributes.
+func configBool(d *schema.ResourceData, attr string) bool {
+	raw := d.GetRawConfig()
+	if raw.IsNull() || !raw.IsKnown() {
+		return false
+	}
+	v := raw.GetAttr(attr)
+	if v.IsNull() || !v.IsKnown() {
+		return false
+	}
+	return v.True()
+}
+
 func delete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	tflog.Info(ctx, "started delete")
 
@@ -91,8 +108,11 @@ func create(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 	// d.SetId above ensures the key is tracked in state even if activation fails;
 	// the next apply will retry via the Update path rather than orphan or duplicate it.
 	// FailedPrecondition (key already active) is treated as idempotent success.
-	v, hasActive := d.GetOkExists(activeVar)
-	wantActive := hasActive && v.(bool)
+	//
+	// Use the raw config rather than d.Get/d.GetOkExists so we can distinguish
+	// "absent from config" from "present and false" — d.Get-based readers blend
+	// state and config, which is ambiguous for Optional+Computed attributes.
+	wantActive := configBool(d, activeVar)
 
 	// Persist active=false to state BEFORE attempting activation so that, if Activate
 	// returns a non-precondition error, the partial state we leave behind matches the
@@ -125,14 +145,20 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 		return nil
 	}
 
-	// Only act when the user has an explicit active value in config. If the field has
-	// been removed (Optional+Computed transitioning to unset) we preserve the current
-	// remote state rather than implicitly deactivating a key the user no longer manages.
-	v, hasActive := d.GetOkExists(activeVar)
-	if !hasActive {
+	// Only act when the user has an explicit active value in *config*. If the field
+	// has been removed we preserve the current remote state rather than implicitly
+	// deactivating a key the user no longer manages. We inspect the raw config (not
+	// d.Get/d.GetOkExists, which blend state and config) so this stays correct even
+	// when state has a value populated by Create or Read.
+	rawConfig := d.GetRawConfig()
+	if rawConfig.IsNull() || !rawConfig.IsKnown() {
 		return nil
 	}
-	wantActive := v.(bool)
+	configActive := rawConfig.GetAttr(activeVar)
+	if configActive.IsNull() || !configActive.IsKnown() {
+		return nil
+	}
+	wantActive := configActive.True()
 
 	clientinfo, ok := m.(*helper.ClientInfo)
 	if !ok {

--- a/zitadel/action_target_public_key/funcs.go
+++ b/zitadel/action_target_public_key/funcs.go
@@ -88,18 +88,29 @@ func create(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 	// Only call ActivatePublicKey when the user explicitly opted in via active=true.
 	// An unset active leaves the key in ZITADEL's default (inactive) state to preserve
 	// pre-existing behavior for configs that don't set the field.
+	// d.SetId above ensures the key is tracked in state even if activation fails;
+	// the next apply will retry via the Update path rather than orphan or duplicate it.
+	// FailedPrecondition (key already active) is treated as idempotent success.
+	active := false
 	if v, ok := d.GetOkExists(activeVar); ok && v.(bool) {
 		if _, err := client.ActivatePublicKey(ctx, &actionv2.ActivatePublicKeyRequest{
 			TargetId: req.TargetId,
 			KeyId:    resp.GetKeyId(),
-		}); err != nil {
+		}); err != nil && helper.IgnorePreconditionError(err) != nil {
 			return diag.Errorf("failed to activate public key: %v", err)
 		}
+		active = true
 	}
 
-	// AddPublicKey only returns the key ID, so call read() to populate the remaining
-	// computed attributes (active, fingerprint, creation_date) from the server.
-	return read(ctx, d, m)
+	// AddPublicKey only returns the key ID; populate `active` from what we just did so
+	// state reflects the post-apply server state. ZITADEL's list API is eventually
+	// consistent immediately after creation, so we rely on the next refresh (which the
+	// SDK runs before the following plan) to fill `fingerprint` and `creation_date`.
+	if err := d.Set(activeVar, active); err != nil {
+		return diag.Errorf("failed to set active: %v", err)
+	}
+
+	return nil
 }
 
 func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
@@ -108,6 +119,15 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 	if !d.HasChange(activeVar) {
 		return nil
 	}
+
+	// Only act when the user has an explicit active value in config. If the field has
+	// been removed (Optional+Computed transitioning to unset) we preserve the current
+	// remote state rather than implicitly deactivating a key the user no longer manages.
+	v, hasActive := d.GetOkExists(activeVar)
+	if !hasActive {
+		return nil
+	}
+	wantActive := v.(bool)
 
 	clientinfo, ok := m.(*helper.ClientInfo)
 	if !ok {
@@ -122,23 +142,26 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 	targetID := d.Get(targetIDVar).(string)
 	keyID := d.Id()
 
-	if d.Get(activeVar).(bool) {
+	if wantActive {
 		if _, err := client.ActivatePublicKey(ctx, &actionv2.ActivatePublicKeyRequest{
 			TargetId: targetID,
 			KeyId:    keyID,
-		}); err != nil {
+		}); err != nil && helper.IgnorePreconditionError(err) != nil {
 			return diag.Errorf("failed to activate public key: %v", err)
 		}
-		return read(ctx, d, m)
+	} else {
+		if _, err := client.DeactivatePublicKey(ctx, &actionv2.DeactivatePublicKeyRequest{
+			TargetId: targetID,
+			KeyId:    keyID,
+		}); err != nil && helper.IgnorePreconditionError(err) != nil {
+			return diag.Errorf("failed to deactivate public key: %v", err)
+		}
 	}
 
-	if _, err := client.DeactivatePublicKey(ctx, &actionv2.DeactivatePublicKeyRequest{
-		TargetId: targetID,
-		KeyId:    keyID,
-	}); err != nil && helper.IgnorePreconditionError(err) != nil {
-		return diag.Errorf("failed to deactivate public key: %v", err)
+	if err := d.Set(activeVar, wantActive); err != nil {
+		return diag.Errorf("failed to set active: %v", err)
 	}
-	return read(ctx, d, m)
+	return nil
 }
 
 func read(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/zitadel/action_target_public_key/funcs.go
+++ b/zitadel/action_target_public_key/funcs.go
@@ -14,11 +14,16 @@ import (
 	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/helper"
 )
 
-// configBool reports the practitioner-supplied value of a bool attribute from the
-// raw configuration, returning false when the attribute is absent or unknown.
-// Unlike d.Get / d.GetOkExists it does NOT fall back to state, which makes it
-// the right primitive for distinguishing "the user wrote `active = false`" from
-// "the user did not write `active` at all" on Optional+Computed attributes.
+// configBool reports whether a bool attribute is set to `true` in the raw,
+// practitioner-supplied configuration. It returns false for every other case —
+// the attribute is absent, set to `false`, null, or not yet known. The intended
+// use is as an opt-in gate ("did the user explicitly request this?"); callers
+// that need to distinguish "absent" from "explicit false" should inspect
+// d.GetRawConfig() directly.
+//
+// Unlike d.Get / d.GetOkExists this does NOT fall back to state, so it stays
+// correct on Optional+Computed attributes where state may carry a value that
+// was never in config (e.g. populated by Create or refreshed by Read).
 func configBool(d *schema.ResourceData, attr string) bool {
 	raw := d.GetRawConfig()
 	if raw.IsNull() || !raw.IsKnown() {

--- a/zitadel/action_target_public_key/funcs.go
+++ b/zitadel/action_target_public_key/funcs.go
@@ -91,23 +91,28 @@ func create(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 	// d.SetId above ensures the key is tracked in state even if activation fails;
 	// the next apply will retry via the Update path rather than orphan or duplicate it.
 	// FailedPrecondition (key already active) is treated as idempotent success.
-	active := false
-	if v, ok := d.GetOkExists(activeVar); ok && v.(bool) {
+	v, hasActive := d.GetOkExists(activeVar)
+	wantActive := hasActive && v.(bool)
+
+	// Persist active=false to state BEFORE attempting activation so that, if Activate
+	// returns a non-precondition error, the partial state we leave behind matches the
+	// server (key exists, inactive) and the next plan correctly shows false -> true.
+	// This is important when users run with -refresh=false, which would otherwise skip
+	// the read() that reconciles state.
+	if err := d.Set(activeVar, false); err != nil {
+		return diag.Errorf("failed to set active: %v", err)
+	}
+
+	if wantActive {
 		if _, err := client.ActivatePublicKey(ctx, &actionv2.ActivatePublicKeyRequest{
 			TargetId: req.TargetId,
 			KeyId:    resp.GetKeyId(),
 		}); err != nil && helper.IgnorePreconditionError(err) != nil {
 			return diag.Errorf("failed to activate public key: %v", err)
 		}
-		active = true
-	}
-
-	// AddPublicKey only returns the key ID; populate `active` from what we just did so
-	// state reflects the post-apply server state. ZITADEL's list API is eventually
-	// consistent immediately after creation, so we rely on the next refresh (which the
-	// SDK runs before the following plan) to fill `fingerprint` and `creation_date`.
-	if err := d.Set(activeVar, active); err != nil {
-		return diag.Errorf("failed to set active: %v", err)
+		if err := d.Set(activeVar, true); err != nil {
+			return diag.Errorf("failed to set active: %v", err)
+		}
 	}
 
 	return nil

--- a/zitadel/action_target_public_key/funcs.go
+++ b/zitadel/action_target_public_key/funcs.go
@@ -114,9 +114,11 @@ func create(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 	// the next apply will retry via the Update path rather than orphan or duplicate it.
 	// FailedPrecondition (key already active) is treated as idempotent success.
 	//
-	// Use the raw config rather than d.Get/d.GetOkExists so we can distinguish
-	// "absent from config" from "present and false" — d.Get-based readers blend
-	// state and config, which is ambiguous for Optional+Computed attributes.
+	// Inspect the raw config (not d.Get/d.GetOkExists, which blend state and
+	// config) so this stays correct on Optional+Computed attributes where state
+	// may already carry a value populated by Create or Read. configBool returns
+	// true only for an explicit `active = true` in config; anything else
+	// (absent, false, null, unknown) is treated as "do not activate on create".
 	wantActive := configBool(d, activeVar)
 
 	// Persist active=false to state BEFORE attempting activation so that, if Activate

--- a/zitadel/action_target_public_key/funcs.go
+++ b/zitadel/action_target_public_key/funcs.go
@@ -97,7 +97,9 @@ func create(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 		}
 	}
 
-	return nil
+	// AddPublicKey only returns the key ID, so call read() to populate the remaining
+	// computed attributes (active, fingerprint, creation_date) from the server.
+	return read(ctx, d, m)
 }
 
 func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
@@ -127,7 +129,7 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 		}); err != nil {
 			return diag.Errorf("failed to activate public key: %v", err)
 		}
-		return nil
+		return read(ctx, d, m)
 	}
 
 	if _, err := client.DeactivatePublicKey(ctx, &actionv2.DeactivatePublicKeyRequest{
@@ -136,7 +138,7 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 	}); err != nil && helper.IgnorePreconditionError(err) != nil {
 		return diag.Errorf("failed to deactivate public key: %v", err)
 	}
-	return nil
+	return read(ctx, d, m)
 }
 
 func read(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/zitadel/action_target_public_key/resource.go
+++ b/zitadel/action_target_public_key/resource.go
@@ -37,7 +37,7 @@ func GetResource() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Computed:    true,
-				Description: "Whether the public key is active and used for payload encryption. If unset, the key is created in the state ZITADEL returns (inactive) and is not modified by this provider. Set to true to activate the key after creation, or to toggle activation on an existing key.",
+				Description: "Whether the public key is active and used for payload encryption. If unset, the key is created in ZITADEL's default (inactive) state and the provider does not modify its activation state. Set to true to activate the key after creation, or to toggle activation on an existing key.",
 			},
 			fingerprintVar: {
 				Type:        schema.TypeString,

--- a/zitadel/action_target_public_key/resource.go
+++ b/zitadel/action_target_public_key/resource.go
@@ -35,8 +35,9 @@ func GetResource() *schema.Resource {
 			},
 			activeVar: {
 				Type:        schema.TypeBool,
+				Optional:    true,
 				Computed:    true,
-				Description: "Whether the public key is active and used for payload encryption.",
+				Description: "Whether the public key is active and used for payload encryption. If unset, the key is created in the state ZITADEL returns (inactive) and is not modified by this provider. Set to true to activate the key after creation, or to toggle activation on an existing key.",
 			},
 			fingerprintVar: {
 				Type:        schema.TypeString,
@@ -51,6 +52,7 @@ func GetResource() *schema.Resource {
 		},
 		CreateContext: create,
 		ReadContext:   read,
+		UpdateContext: update,
 		DeleteContext: delete,
 		Importer: helper.ImportWithID(
 			keyIDVar,

--- a/zitadel/action_target_public_key/resource_test.go
+++ b/zitadel/action_target_public_key/resource_test.go
@@ -310,6 +310,15 @@ EOT
 					test_utils.CheckAMinute(checkRemoteProperty(frame, true)),
 				),
 			},
+			// Explicitly verify that, after the out-of-band activation has been
+			// reconciled into state, a follow-up plan against the same `active`-less
+			// config is a no-op. PlanOnly fails the test if the plan is non-empty,
+			// which would catch any regression to "removing `active` from config
+			// silently deactivates the key".
+			{
+				Config:   configNoActive,
+				PlanOnly: true,
+			},
 			// Adding `active = true` to config when the server already matches must be a
 			// no-op (idempotent activate; FailedPrecondition is swallowed).
 			{

--- a/zitadel/action_target_public_key/resource_test.go
+++ b/zitadel/action_target_public_key/resource_test.go
@@ -90,12 +90,11 @@ EOT
 		ProtoV6ProviderFactories: frame.V6ProviderFactories(),
 		Steps: []resource.TestStep{
 			// Pre-existing behavior: no `active` in config -> key is created and remains inactive.
-			// We assert via the remote check; SDKv2 may leave an unset Optional+Computed bool
-			// absent from the local state until a future refresh writes it.
 			{
 				Config: configWithoutActive,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(frame.TerraformName, "key_id"),
+					resource.TestCheckResourceAttr(frame.TerraformName, "active", "false"),
 					test_utils.CheckAMinute(checkRemoteProperty(frame, false)),
 				),
 			},

--- a/zitadel/action_target_public_key/resource_test.go
+++ b/zitadel/action_target_public_key/resource_test.go
@@ -17,7 +17,17 @@ import (
 func TestAccActionTargetPublicKey(t *testing.T) {
 	frame := test_utils.NewInstanceTestFrame(t, "zitadel_action_target_public_key")
 
-	resourceConfig := fmt.Sprintf(`
+	const publicKey = `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0Z3VS5JJcds3xfn/ygWe
+FsXpOJFdGMqhBJCnISAAnNPBKSFwETb4FIxgpJMtzBCIR2YEKXE6OryMpO6E8yoI
+6sFawwLY1ViELOE7FD7sJVMUQF1WLiMjb7n1feGfToGarnWjKrx8IXjlgVnJ5kQ0
+GNOwjKBOmgJiJEhBuTflS0ppODBdKP2oq6iAdf5bMmkv0wMKJnxBKPQsXLcCn2u4
+ym9AXkcdH2QviCBWMpGrjVoGLFGqf5E4MiwMuNl7rHIExmBm2mlnmuIPhILRs/jS
+tKKLrdazqFCxD2fWXt9a2yzXoE6Hv0sWBnJSRASez2dn6ki3GFbLHeR2dMhT8wbf
+cQIDAQAB
+-----END PUBLIC KEY-----`
+
+	configWithoutActive := fmt.Sprintf(`
 %s
 resource "zitadel_action_target" "default" {
   name               = "%s"
@@ -31,27 +41,78 @@ resource "zitadel_action_target" "default" {
 resource "zitadel_action_target_public_key" "default" {
   target_id  = zitadel_action_target.default.id
   public_key = <<-EOT
------BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0Z3VS5JJcds3xfn/ygWe
-FsXpOJFdGMqhBJCnISAAnNPBKSFwETb4FIxgpJMtzBCIR2YEKXE6OryMpO6E8yoI
-6sFawwLY1ViELOE7FD7sJVMUQF1WLiMjb7n1feGfToGarnWjKrx8IXjlgVnJ5kQ0
-GNOwjKBOmgJiJEhBuTflS0ppODBdKP2oq6iAdf5bMmkv0wMKJnxBKPQsXLcCn2u4
-ym9AXkcdH2QviCBWMpGrjVoGLFGqf5E4MiwMuNl7rHIExmBm2mlnmuIPhILRs/jS
-tKKLrdazqFCxD2fWXt9a2yzXoE6Hv0sWBnJSRASez2dn6ki3GFbLHeR2dMhT8wbf
-cQIDAQAB
------END PUBLIC KEY-----
+%s
 EOT
 }
-`, frame.ProviderSnippet, frame.UniqueResourcesID)
+`, frame.ProviderSnippet, frame.UniqueResourcesID, publicKey)
+
+	configActive := fmt.Sprintf(`
+%s
+resource "zitadel_action_target" "default" {
+  name               = "%s"
+  endpoint           = "https://example.com/test"
+  target_type        = "REST_ASYNC"
+  timeout            = "10s"
+  interrupt_on_error = false
+  payload_type       = "PAYLOAD_TYPE_JWE"
+}
+
+resource "zitadel_action_target_public_key" "default" {
+  target_id  = zitadel_action_target.default.id
+  active     = true
+  public_key = <<-EOT
+%s
+EOT
+}
+`, frame.ProviderSnippet, frame.UniqueResourcesID, publicKey)
+
+	configInactive := fmt.Sprintf(`
+%s
+resource "zitadel_action_target" "default" {
+  name               = "%s"
+  endpoint           = "https://example.com/test"
+  target_type        = "REST_ASYNC"
+  timeout            = "10s"
+  interrupt_on_error = false
+  payload_type       = "PAYLOAD_TYPE_JWE"
+}
+
+resource "zitadel_action_target_public_key" "default" {
+  target_id  = zitadel_action_target.default.id
+  active     = false
+  public_key = <<-EOT
+%s
+EOT
+}
+`, frame.ProviderSnippet, frame.UniqueResourcesID, publicKey)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: frame.V6ProviderFactories(),
 		Steps: []resource.TestStep{
+			// Pre-existing behavior: no `active` in config -> key is created and remains inactive.
+			// We assert via the remote check; SDKv2 may leave an unset Optional+Computed bool
+			// absent from the local state until a future refresh writes it.
 			{
-				Config: resourceConfig,
+				Config: configWithoutActive,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(frame.TerraformName, "key_id"),
-					test_utils.CheckAMinute(checkRemoteProperty(frame)),
+					test_utils.CheckAMinute(checkRemoteProperty(frame, false)),
+				),
+			},
+			// Toggle to active=true via update (no recreate).
+			{
+				Config: configActive,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(frame.TerraformName, "active", "true"),
+					test_utils.CheckAMinute(checkRemoteProperty(frame, true)),
+				),
+			},
+			// Toggle back to active=false via update.
+			{
+				Config: configInactive,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(frame.TerraformName, "active", "false"),
+					test_utils.CheckAMinute(checkRemoteProperty(frame, false)),
 				),
 			},
 			{
@@ -68,7 +129,7 @@ EOT
 	})
 }
 
-func checkRemoteProperty(frame *test_utils.InstanceTestFrame) resource.TestCheckFunc {
+func checkRemoteProperty(frame *test_utils.InstanceTestFrame, wantActive bool) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 		rs, ok := state.RootModule().Resources[frame.TerraformName]
 		if !ok {
@@ -102,6 +163,10 @@ func checkRemoteProperty(frame *test_utils.InstanceTestFrame) resource.TestCheck
 		keys := resp.GetPublicKeys()
 		if len(keys) == 0 {
 			return fmt.Errorf("public key %s not found on target %s", keyID, targetID)
+		}
+
+		if got := keys[0].GetActive(); got != wantActive {
+			return fmt.Errorf("public key %s on target %s: want active=%v, got active=%v", keyID, targetID, wantActive, got)
 		}
 
 		return nil

--- a/zitadel/action_target_public_key/resource_test.go
+++ b/zitadel/action_target_public_key/resource_test.go
@@ -179,6 +179,132 @@ EOT
 	})
 }
 
+// TestAccActionTargetPublicKeyNoAccidentalToggle proves the upgrade is non-breaking:
+//
+//   - A key activated out-of-band (e.g. via the API by a user who upgraded from a
+//     provider release that did not manage activation) must NOT be silently
+//     deactivated when terraform applies a config that omits the `active` field.
+//   - Removing `active` from config must NOT change the remote activation state.
+//   - Adding `active = true` to config when the server is already active must be a
+//     plan/apply no-op (FailedPrecondition idempotency).
+func TestAccActionTargetPublicKeyNoAccidentalToggle(t *testing.T) {
+	frame := test_utils.NewInstanceTestFrame(t, "zitadel_action_target_public_key")
+
+	const publicKey = `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0Z3VS5JJcds3xfn/ygWe
+FsXpOJFdGMqhBJCnISAAnNPBKSFwETb4FIxgpJMtzBCIR2YEKXE6OryMpO6E8yoI
+6sFawwLY1ViELOE7FD7sJVMUQF1WLiMjb7n1feGfToGarnWjKrx8IXjlgVnJ5kQ0
+GNOwjKBOmgJiJEhBuTflS0ppODBdKP2oq6iAdf5bMmkv0wMKJnxBKPQsXLcCn2u4
+ym9AXkcdH2QviCBWMpGrjVoGLFGqf5E4MiwMuNl7rHIExmBm2mlnmuIPhILRs/jS
+tKKLrdazqFCxD2fWXt9a2yzXoE6Hv0sWBnJSRASez2dn6ki3GFbLHeR2dMhT8wbf
+cQIDAQAB
+-----END PUBLIC KEY-----`
+
+	target := fmt.Sprintf(`
+%s
+resource "zitadel_action_target" "default" {
+  name               = "%s"
+  endpoint           = "https://example.com/test"
+  target_type        = "REST_ASYNC"
+  timeout            = "10s"
+  interrupt_on_error = false
+  payload_type       = "PAYLOAD_TYPE_JWE"
+}
+`, frame.ProviderSnippet, frame.UniqueResourcesID)
+
+	configNoActive := target + fmt.Sprintf(`
+resource "zitadel_action_target_public_key" "default" {
+  target_id  = zitadel_action_target.default.id
+  public_key = <<-EOT
+%s
+EOT
+}
+`, publicKey)
+
+	configActiveTrue := target + fmt.Sprintf(`
+resource "zitadel_action_target_public_key" "default" {
+  target_id  = zitadel_action_target.default.id
+  active     = true
+  public_key = <<-EOT
+%s
+EOT
+}
+`, publicKey)
+
+	var captured struct {
+		targetID, keyID string
+	}
+	captureIDs := func(state *terraform.State) error {
+		rs, ok := state.RootModule().Resources[frame.TerraformName]
+		if !ok {
+			return fmt.Errorf("not found: %s", frame.TerraformName)
+		}
+		captured.targetID = rs.Primary.Attributes["target_id"]
+		captured.keyID = rs.Primary.ID
+		return nil
+	}
+	activateExternally := func() {
+		if captured.targetID == "" || captured.keyID == "" {
+			t.Fatal("captureIDs did not run before activateExternally")
+		}
+		client, err := helper.GetActionClient(context.Background(), frame.ClientInfo)
+		if err != nil {
+			t.Fatalf("failed to get client: %v", err)
+		}
+		if _, err := client.ActivatePublicKey(context.Background(), &actionv2.ActivatePublicKeyRequest{
+			TargetId: captured.targetID,
+			KeyId:    captured.keyID,
+		}); err != nil && helper.IgnorePreconditionError(err) != nil {
+			t.Fatalf("external activation failed: %v", err)
+		}
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: frame.V6ProviderFactories(),
+		Steps: []resource.TestStep{
+			// Baseline: create without `active` -> key inactive on server (mirrors the
+			// behaviour every existing user has been getting from prior provider releases).
+			{
+				Config: configNoActive,
+				Check: resource.ComposeTestCheckFunc(
+					captureIDs,
+					resource.TestCheckResourceAttr(frame.TerraformName, "active", "false"),
+					test_utils.CheckAMinute(checkRemoteProperty(frame, false)),
+				),
+			},
+			// User (or another tool) activates the key out-of-band via the ZITADEL API.
+			// Apply the SAME config: the provider must refresh state, see active=true,
+			// and produce no plan diff / no deactivation. This is the critical upgrade
+			// safety property.
+			{
+				PreConfig: activateExternally,
+				Config:    configNoActive,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(frame.TerraformName, "active", "true"),
+					test_utils.CheckAMinute(checkRemoteProperty(frame, true)),
+				),
+			},
+			// Adding `active = true` to config when the server already matches must be a
+			// no-op (idempotent activate; FailedPrecondition is swallowed).
+			{
+				Config: configActiveTrue,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(frame.TerraformName, "active", "true"),
+					test_utils.CheckAMinute(checkRemoteProperty(frame, true)),
+				),
+			},
+			// Removing `active` from config again must NOT deactivate the key. The
+			// remote state stays active even though the field is gone from config.
+			{
+				Config: configNoActive,
+				Check: resource.ComposeTestCheckFunc(
+					test_utils.CheckAMinute(checkRemoteProperty(frame, true)),
+				),
+			},
+		},
+	})
+}
+
 func checkRemoteProperty(frame *test_utils.InstanceTestFrame, wantActive bool) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 		rs, ok := state.RootModule().Resources[frame.TerraformName]

--- a/zitadel/action_target_public_key/resource_test.go
+++ b/zitadel/action_target_public_key/resource_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/helper/test_utils"
 )
 
-func TestAccActionTargetPublicKey(t *testing.T) {
-	frame := test_utils.NewInstanceTestFrame(t, "zitadel_action_target_public_key")
-
-	const publicKey = `-----BEGIN PUBLIC KEY-----
+// testPublicKey is a static RSA public key used by all acceptance tests in this
+// package. ZITADEL never sees the matching private key; the PEM only has to be
+// a syntactically valid public key, so a single fixed value is reused.
+const testPublicKey = `-----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0Z3VS5JJcds3xfn/ygWe
 FsXpOJFdGMqhBJCnISAAnNPBKSFwETb4FIxgpJMtzBCIR2YEKXE6OryMpO6E8yoI
 6sFawwLY1ViELOE7FD7sJVMUQF1WLiMjb7n1feGfToGarnWjKrx8IXjlgVnJ5kQ0
@@ -26,6 +26,9 @@ ym9AXkcdH2QviCBWMpGrjVoGLFGqf5E4MiwMuNl7rHIExmBm2mlnmuIPhILRs/jS
 tKKLrdazqFCxD2fWXt9a2yzXoE6Hv0sWBnJSRASez2dn6ki3GFbLHeR2dMhT8wbf
 cQIDAQAB
 -----END PUBLIC KEY-----`
+
+func TestAccActionTargetPublicKey(t *testing.T) {
+	frame := test_utils.NewInstanceTestFrame(t, "zitadel_action_target_public_key")
 
 	configWithoutActive := fmt.Sprintf(`
 %s
@@ -44,7 +47,7 @@ resource "zitadel_action_target_public_key" "default" {
 %s
 EOT
 }
-`, frame.ProviderSnippet, frame.UniqueResourcesID, publicKey)
+`, frame.ProviderSnippet, frame.UniqueResourcesID, testPublicKey)
 
 	configActive := fmt.Sprintf(`
 %s
@@ -64,7 +67,7 @@ resource "zitadel_action_target_public_key" "default" {
 %s
 EOT
 }
-`, frame.ProviderSnippet, frame.UniqueResourcesID, publicKey)
+`, frame.ProviderSnippet, frame.UniqueResourcesID, testPublicKey)
 
 	configInactive := fmt.Sprintf(`
 %s
@@ -84,7 +87,7 @@ resource "zitadel_action_target_public_key" "default" {
 %s
 EOT
 }
-`, frame.ProviderSnippet, frame.UniqueResourcesID, publicKey)
+`, frame.ProviderSnippet, frame.UniqueResourcesID, testPublicKey)
 
 	// Capture the key ID after the initial create so subsequent toggle steps can
 	// assert it stays stable — proves activation toggling is an in-place update,
@@ -160,16 +163,6 @@ EOT
 func TestAccActionTargetPublicKeyCreateActive(t *testing.T) {
 	frame := test_utils.NewInstanceTestFrame(t, "zitadel_action_target_public_key")
 
-	const publicKey = `-----BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0Z3VS5JJcds3xfn/ygWe
-FsXpOJFdGMqhBJCnISAAnNPBKSFwETb4FIxgpJMtzBCIR2YEKXE6OryMpO6E8yoI
-6sFawwLY1ViELOE7FD7sJVMUQF1WLiMjb7n1feGfToGarnWjKrx8IXjlgVnJ5kQ0
-GNOwjKBOmgJiJEhBuTflS0ppODBdKP2oq6iAdf5bMmkv0wMKJnxBKPQsXLcCn2u4
-ym9AXkcdH2QviCBWMpGrjVoGLFGqf5E4MiwMuNl7rHIExmBm2mlnmuIPhILRs/jS
-tKKLrdazqFCxD2fWXt9a2yzXoE6Hv0sWBnJSRASez2dn6ki3GFbLHeR2dMhT8wbf
-cQIDAQAB
------END PUBLIC KEY-----`
-
 	configActiveOnCreate := fmt.Sprintf(`
 %s
 resource "zitadel_action_target" "default" {
@@ -188,7 +181,7 @@ resource "zitadel_action_target_public_key" "default" {
 %s
 EOT
 }
-`, frame.ProviderSnippet, frame.UniqueResourcesID, publicKey)
+`, frame.ProviderSnippet, frame.UniqueResourcesID, testPublicKey)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: frame.V6ProviderFactories(),
@@ -216,16 +209,6 @@ EOT
 func TestAccActionTargetPublicKeyNoAccidentalToggle(t *testing.T) {
 	frame := test_utils.NewInstanceTestFrame(t, "zitadel_action_target_public_key")
 
-	const publicKey = `-----BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0Z3VS5JJcds3xfn/ygWe
-FsXpOJFdGMqhBJCnISAAnNPBKSFwETb4FIxgpJMtzBCIR2YEKXE6OryMpO6E8yoI
-6sFawwLY1ViELOE7FD7sJVMUQF1WLiMjb7n1feGfToGarnWjKrx8IXjlgVnJ5kQ0
-GNOwjKBOmgJiJEhBuTflS0ppODBdKP2oq6iAdf5bMmkv0wMKJnxBKPQsXLcCn2u4
-ym9AXkcdH2QviCBWMpGrjVoGLFGqf5E4MiwMuNl7rHIExmBm2mlnmuIPhILRs/jS
-tKKLrdazqFCxD2fWXt9a2yzXoE6Hv0sWBnJSRASez2dn6ki3GFbLHeR2dMhT8wbf
-cQIDAQAB
------END PUBLIC KEY-----`
-
 	target := fmt.Sprintf(`
 %s
 resource "zitadel_action_target" "default" {
@@ -245,7 +228,7 @@ resource "zitadel_action_target_public_key" "default" {
 %s
 EOT
 }
-`, publicKey)
+`, testPublicKey)
 
 	configActiveTrue := target + fmt.Sprintf(`
 resource "zitadel_action_target_public_key" "default" {
@@ -255,7 +238,7 @@ resource "zitadel_action_target_public_key" "default" {
 %s
 EOT
 }
-`, publicKey)
+`, testPublicKey)
 
 	var captured struct {
 		targetID, keyID string

--- a/zitadel/action_target_public_key/resource_test.go
+++ b/zitadel/action_target_public_key/resource_test.go
@@ -86,6 +86,29 @@ EOT
 }
 `, frame.ProviderSnippet, frame.UniqueResourcesID, publicKey)
 
+	// Capture the key ID after the initial create so subsequent toggle steps can
+	// assert it stays stable — proves activation toggling is an in-place update,
+	// not a recreate that would break rotation flows.
+	var initialKeyID string
+	captureKeyID := func(state *terraform.State) error {
+		rs, ok := state.RootModule().Resources[frame.TerraformName]
+		if !ok {
+			return fmt.Errorf("not found: %s", frame.TerraformName)
+		}
+		initialKeyID = rs.Primary.ID
+		return nil
+	}
+	assertKeyIDStable := func(state *terraform.State) error {
+		rs, ok := state.RootModule().Resources[frame.TerraformName]
+		if !ok {
+			return fmt.Errorf("not found: %s", frame.TerraformName)
+		}
+		if rs.Primary.ID != initialKeyID {
+			return fmt.Errorf("key_id changed across toggle: want %q, got %q", initialKeyID, rs.Primary.ID)
+		}
+		return nil
+	}
+
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: frame.V6ProviderFactories(),
 		Steps: []resource.TestStep{
@@ -95,6 +118,7 @@ EOT
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(frame.TerraformName, "key_id"),
 					resource.TestCheckResourceAttr(frame.TerraformName, "active", "false"),
+					captureKeyID,
 					test_utils.CheckAMinute(checkRemoteProperty(frame, false)),
 				),
 			},
@@ -103,6 +127,7 @@ EOT
 				Config: configActive,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(frame.TerraformName, "active", "true"),
+					assertKeyIDStable,
 					test_utils.CheckAMinute(checkRemoteProperty(frame, true)),
 				),
 			},
@@ -111,6 +136,7 @@ EOT
 				Config: configInactive,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(frame.TerraformName, "active", "false"),
+					assertKeyIDStable,
 					test_utils.CheckAMinute(checkRemoteProperty(frame, false)),
 				),
 			},

--- a/zitadel/action_target_public_key/resource_test.go
+++ b/zitadel/action_target_public_key/resource_test.go
@@ -129,6 +129,57 @@ EOT
 	})
 }
 
+// TestAccActionTargetPublicKeyCreateActive verifies that a resource created with
+// active=true is activated on the server during Create (not just after a subsequent
+// Update), so the key is usable for payload encryption immediately after apply.
+func TestAccActionTargetPublicKeyCreateActive(t *testing.T) {
+	frame := test_utils.NewInstanceTestFrame(t, "zitadel_action_target_public_key")
+
+	const publicKey = `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0Z3VS5JJcds3xfn/ygWe
+FsXpOJFdGMqhBJCnISAAnNPBKSFwETb4FIxgpJMtzBCIR2YEKXE6OryMpO6E8yoI
+6sFawwLY1ViELOE7FD7sJVMUQF1WLiMjb7n1feGfToGarnWjKrx8IXjlgVnJ5kQ0
+GNOwjKBOmgJiJEhBuTflS0ppODBdKP2oq6iAdf5bMmkv0wMKJnxBKPQsXLcCn2u4
+ym9AXkcdH2QviCBWMpGrjVoGLFGqf5E4MiwMuNl7rHIExmBm2mlnmuIPhILRs/jS
+tKKLrdazqFCxD2fWXt9a2yzXoE6Hv0sWBnJSRASez2dn6ki3GFbLHeR2dMhT8wbf
+cQIDAQAB
+-----END PUBLIC KEY-----`
+
+	configActiveOnCreate := fmt.Sprintf(`
+%s
+resource "zitadel_action_target" "default" {
+  name               = "%s"
+  endpoint           = "https://example.com/test"
+  target_type        = "REST_ASYNC"
+  timeout            = "10s"
+  interrupt_on_error = false
+  payload_type       = "PAYLOAD_TYPE_JWE"
+}
+
+resource "zitadel_action_target_public_key" "default" {
+  target_id  = zitadel_action_target.default.id
+  active     = true
+  public_key = <<-EOT
+%s
+EOT
+}
+`, frame.ProviderSnippet, frame.UniqueResourcesID, publicKey)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: frame.V6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: configActiveOnCreate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(frame.TerraformName, "key_id"),
+					resource.TestCheckResourceAttr(frame.TerraformName, "active", "true"),
+					test_utils.CheckAMinute(checkRemoteProperty(frame, true)),
+				),
+			},
+		},
+	})
+}
+
 func checkRemoteProperty(frame *test_utils.InstanceTestFrame, wantActive bool) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 		rs, ok := state.RootModule().Resources[frame.TerraformName]


### PR DESCRIPTION
This pull request adds an optional `active` attribute to `zitadel_action_target_public_key`. When `active = true`, the provider calls `ActivatePublicKey` after the key is added so it is usable for payload encryption immediately after `terraform apply`; toggling it on an existing resource updates in place via `Activate`/`DeactivatePublicKey` without recreating the key. When unset, behaviour is unchanged: the key is added in ZITADEL's default inactive state and existing configurations require no action.

**Example**

```hcl
resource "zitadel_action_target_public_key" "default" {
  target_id  = zitadel_action_target.default.id
  active     = true
  public_key = file("path/to/public_key.pem")
}
```

Closes #408

### Definition of Ready

- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] All non-functional requirements are met
- [x] The generic lifecycle acceptance test passes for affected resources.
- [x] Examples are up-to-date and meaningful. The provider version is incremented.
- [x] Docs are generated.
- [x] Code is generated where possible.