### PR TITLE
fix: deprecate unsupported fields on SMS OTP message text resources

### DIFF
--- a/docs/resources/default_verify_sms_otp_message_text.md
+++ b/docs/resources/default_verify_sms_otp_message_text.md
@@ -28,13 +28,13 @@ resource "zitadel_default_verify_sms_otp_message_text" "default" {
 
 ### Optional
 
-- `button_text` (String)
-- `footer_text` (String)
-- `greeting` (String)
-- `pre_header` (String)
-- `subject` (String)
+- `button_text` (String, Deprecated)
+- `footer_text` (String, Deprecated)
+- `greeting` (String, Deprecated)
+- `pre_header` (String, Deprecated)
+- `subject` (String, Deprecated)
 - `text` (String)
-- `title` (String)
+- `title` (String, Deprecated)
 
 ### Read-Only
 

--- a/docs/resources/verify_sms_otp_message_text.md
+++ b/docs/resources/verify_sms_otp_message_text.md
@@ -30,13 +30,13 @@ resource "zitadel_verify_sms_otp_message_text" "default" {
 
 ### Optional
 
-- `button_text` (String)
-- `footer_text` (String)
-- `greeting` (String)
-- `pre_header` (String)
-- `subject` (String)
+- `button_text` (String, Deprecated)
+- `footer_text` (String, Deprecated)
+- `greeting` (String, Deprecated)
+- `pre_header` (String, Deprecated)
+- `subject` (String, Deprecated)
 - `text` (String)
-- `title` (String)
+- `title` (String, Deprecated)
 
 ### Read-Only
 

--- a/zitadel/default_verify_sms_otp_message_text/resource.go
+++ b/zitadel/default_verify_sms_otp_message_text/resource.go
@@ -41,6 +41,7 @@ func (r *defaultVerifySMSOTPMessageTextResource) Schema(ctx context.Context, _ r
 	s, diags := text.GenSchemaMessageCustomText(ctx)
 	resp.Diagnostics.Append(diags...)
 	delete(s.Attributes, "org_id")
+	helper.DeprecateSMSOTPTextAttrs(&s)
 	s.MarkdownDescription = "Instance-level default template for the OTP verification SMS. " +
 		"Org-level overrides are managed by `zitadel_verify_sms_otp_message_text`."
 	resp.Schema = s
@@ -128,7 +129,14 @@ func (r *defaultVerifySMSOTPMessageTextResource) Read(ctx context.Context, req r
 	}
 
 	if !zResp.CustomText.IsDefault {
+		// The SMS OTP API only persists `text`; preserve the configured values
+		// for the unsupported fields so a Read does not introduce a perpetual diff.
+		prior := state
 		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		resp.Diagnostics.Append(helper.PreserveSMSOTPTextAttrs(ctx, prior, &state)...)
 		if resp.Diagnostics.HasError() {
 			return
 		}

--- a/zitadel/default_verify_sms_otp_message_text/resource_test.go
+++ b/zitadel/default_verify_sms_otp_message_text/resource_test.go
@@ -34,6 +34,33 @@ func TestAccDefaultVerifySMSOTPMessageText(t *testing.T) {
 	)
 }
 
+// TestAccDefaultVerifySMSOTPMessageText_DeprecatedFieldsConverge asserts that
+// setting the deprecated fields the SMS OTP API does not persist does not
+// produce a perpetual diff (regression test for #412). The plan-only step uses
+// the default ExpectNonEmptyPlan=false, so a non-empty plan after apply fails.
+func TestAccDefaultVerifySMSOTPMessageText_DeprecatedFieldsConverge(t *testing.T) {
+	frame := test_utils.NewInstanceTestFrame(t, "zitadel_default_verify_sms_otp_message_text")
+	config := fmt.Sprintf(`%s
+resource "zitadel_default_verify_sms_otp_message_text" "default" {
+  language    = "en"
+  text        = "text example"
+  greeting    = "Greeting"
+  subject     = "Subject"
+  title       = "Title"
+  pre_header  = "Pre header"
+  button_text = "Button text"
+  footer_text = "Footer text"
+}
+`, frame.ProviderSnippet)
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: frame.V6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{Config: config},
+			{Config: config, PlanOnly: true},
+		},
+	})
+}
+
 func checkRemoteProperty(frame *test_utils.InstanceTestFrame, lang string) func(string) resource.TestCheckFunc {
 	return func(expect string) resource.TestCheckFunc {
 		return func(state *terraform.State) error {

--- a/zitadel/helper/message_text.go
+++ b/zitadel/helper/message_text.go
@@ -19,17 +19,18 @@ var SMSOTPUnsupportedTextAttrs = []string{"title", "pre_header", "subject", "gre
 const smsOTPUnsupportedDeprecation = "Not supported by the SMS OTP message: the ZITADEL API only stores `text` for this message type, so this attribute has no effect. It will be removed in a future major version."
 
 // DeprecateSMSOTPTextAttrs marks the unsupported MessageCustomText attributes as
-// deprecated in place, keeping them optional so existing configurations continue
-// to parse without error.
+// deprecated in place. It mutates the existing StringAttribute so all generated
+// metadata (description, validators, plan modifiers) is preserved and only the
+// deprecation message is added, keeping the attributes optional so existing
+// configurations continue to parse without error.
 func DeprecateSMSOTPTextAttrs(s *resourceschema.Schema) {
 	for _, name := range SMSOTPUnsupportedTextAttrs {
-		if _, ok := s.Attributes[name]; !ok {
+		attr, ok := s.Attributes[name].(resourceschema.StringAttribute)
+		if !ok {
 			continue
 		}
-		s.Attributes[name] = resourceschema.StringAttribute{
-			Optional:           true,
-			DeprecationMessage: smsOTPUnsupportedDeprecation,
-		}
+		attr.DeprecationMessage = smsOTPUnsupportedDeprecation
+		s.Attributes[name] = attr
 	}
 }
 

--- a/zitadel/helper/message_text.go
+++ b/zitadel/helper/message_text.go
@@ -1,0 +1,55 @@
+package helper
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// SMSOTPUnsupportedTextAttrs are the MessageCustomText attributes that the SMS
+// OTP message-text API does not persist. Its Set request only carries
+// `language` and `text`, so these fields are silently dropped on write and
+// returned empty on read. They are shared with the e-mail message-text schema,
+// which legitimately uses them, so they stay in the SMS OTP schema (deprecated)
+// to keep existing configurations parsing.
+var SMSOTPUnsupportedTextAttrs = []string{"title", "pre_header", "subject", "greeting", "button_text", "footer_text"}
+
+const smsOTPUnsupportedDeprecation = "Not supported by the SMS OTP message: the ZITADEL API only stores `text` for this message type, so this attribute has no effect. It will be removed in a future major version."
+
+// DeprecateSMSOTPTextAttrs marks the unsupported MessageCustomText attributes as
+// deprecated in place, keeping them optional so existing configurations continue
+// to parse without error.
+func DeprecateSMSOTPTextAttrs(s *resourceschema.Schema) {
+	for _, name := range SMSOTPUnsupportedTextAttrs {
+		if _, ok := s.Attributes[name]; !ok {
+			continue
+		}
+		s.Attributes[name] = resourceschema.StringAttribute{
+			Optional:           true,
+			DeprecationMessage: smsOTPUnsupportedDeprecation,
+		}
+	}
+}
+
+// PreserveSMSOTPTextAttrs copies the unsupported attribute values from src into
+// dst. A Read otherwise overwrites the user's configured values with the empty
+// values the API returns for these fields, producing a perpetual diff.
+func PreserveSMSOTPTextAttrs(ctx context.Context, src types.Object, dst *types.Object) diag.Diagnostics {
+	srcAttrs := src.Attributes()
+	dstAttrs := dst.Attributes()
+	for _, name := range SMSOTPUnsupportedTextAttrs {
+		if v, ok := srcAttrs[name]; ok {
+			dstAttrs[name] = v
+		}
+	}
+
+	newObj, d := types.ObjectValue(dst.AttributeTypes(ctx), dstAttrs)
+	if d.HasError() {
+		return d
+	}
+
+	*dst = newObj
+	return nil
+}

--- a/zitadel/helper/message_text_test.go
+++ b/zitadel/helper/message_text_test.go
@@ -1,0 +1,84 @@
+package helper_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/helper"
+)
+
+// TestDeprecateSMSOTPTextAttrs verifies that the unsupported attributes gain a
+// deprecation message while their generated metadata is preserved, and that
+// supported attributes (text) are left untouched.
+func TestDeprecateSMSOTPTextAttrs(t *testing.T) {
+	s := &resourceschema.Schema{
+		Attributes: map[string]resourceschema.Attribute{
+			"text":     resourceschema.StringAttribute{Optional: true, Description: "the text"},
+			"greeting": resourceschema.StringAttribute{Optional: true, Description: "the greeting"},
+		},
+	}
+
+	helper.DeprecateSMSOTPTextAttrs(s)
+
+	greeting, ok := s.Attributes["greeting"].(resourceschema.StringAttribute)
+	if !ok {
+		t.Fatalf("greeting is not a StringAttribute")
+	}
+	if greeting.DeprecationMessage == "" {
+		t.Errorf("greeting should be deprecated")
+	}
+	if !greeting.Optional || greeting.Description != "the greeting" {
+		t.Errorf("greeting metadata not preserved: %+v", greeting)
+	}
+
+	text := s.Attributes["text"].(resourceschema.StringAttribute)
+	if text.DeprecationMessage != "" {
+		t.Errorf("text must not be deprecated")
+	}
+}
+
+// TestPreserveSMSOTPTextAttrs verifies that the unsupported attribute values are
+// copied from the prior state into the destination (so a Read does not overwrite
+// the user's configured values), while supported attributes keep the values that
+// were written from the server response.
+func TestPreserveSMSOTPTextAttrs(t *testing.T) {
+	ctx := context.Background()
+	attrTypes := map[string]attr.Type{
+		"text":     types.StringType,
+		"greeting": types.StringType,
+		"subject":  types.StringType,
+	}
+
+	prior := types.ObjectValueMust(attrTypes, map[string]attr.Value{
+		"text":     types.StringValue("configured text"),
+		"greeting": types.StringValue("Greeting"),
+		"subject":  types.StringValue("Subject"),
+	})
+
+	// dst simulates the object after the server copy: text taken from the API,
+	// the unsupported fields reset to null.
+	dst := types.ObjectValueMust(attrTypes, map[string]attr.Value{
+		"text":     types.StringValue("server text"),
+		"greeting": types.StringNull(),
+		"subject":  types.StringNull(),
+	})
+
+	if diags := helper.PreserveSMSOTPTextAttrs(ctx, prior, &dst); diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	got := dst.Attributes()
+	if v := got["greeting"].(types.String); v.ValueString() != "Greeting" {
+		t.Errorf("greeting not preserved, got %q", v.ValueString())
+	}
+	if v := got["subject"].(types.String); v.ValueString() != "Subject" {
+		t.Errorf("subject not preserved, got %q", v.ValueString())
+	}
+	if v := got["text"].(types.String); v.ValueString() != "server text" {
+		t.Errorf("text should keep the server value, got %q", v.ValueString())
+	}
+}

--- a/zitadel/verify_sms_otp_message_text/resource.go
+++ b/zitadel/verify_sms_otp_message_text/resource.go
@@ -41,6 +41,7 @@ func (r *verifySMSOTPMessageTextResource) Metadata(_ context.Context, req resour
 func (r *verifySMSOTPMessageTextResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	s, diags := text.GenSchemaMessageCustomText(ctx)
 	resp.Diagnostics.Append(diags...)
+	helper.DeprecateSMSOTPTextAttrs(&s)
 	s.MarkdownDescription = "Customizes the one-time password (OTP) verification SMS sent to users (org-scoped). " +
 		"Instance-level defaults are managed by `zitadel_default_verify_sms_otp_message_text`."
 	resp.Schema = s
@@ -128,7 +129,14 @@ func (r *verifySMSOTPMessageTextResource) Read(ctx context.Context, req resource
 	}
 
 	if !zResp.CustomText.IsDefault {
+		// The SMS OTP API only persists `text`; preserve the configured values
+		// for the unsupported fields so a Read does not introduce a perpetual diff.
+		prior := state
 		resp.Diagnostics.Append(text.CopyMessageCustomTextToTerraform(ctx, zResp.CustomText, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		resp.Diagnostics.Append(helper.PreserveSMSOTPTextAttrs(ctx, prior, &state)...)
 		if resp.Diagnostics.HasError() {
 			return
 		}

--- a/zitadel/verify_sms_otp_message_text/resource_test.go
+++ b/zitadel/verify_sms_otp_message_text/resource_test.go
@@ -35,6 +35,35 @@ func TestAccVerifySMSOTPMessageText(t *testing.T) {
 	)
 }
 
+// TestAccVerifySMSOTPMessageText_DeprecatedFieldsConverge asserts that setting
+// the deprecated fields the SMS OTP API does not persist does not produce a
+// perpetual diff (regression test for #412). The plan-only step uses the
+// default ExpectNonEmptyPlan=false, so a non-empty plan after apply fails.
+func TestAccVerifySMSOTPMessageText_DeprecatedFieldsConverge(t *testing.T) {
+	frame := test_utils.NewOrgTestFrame(t, "zitadel_verify_sms_otp_message_text")
+	config := fmt.Sprintf(`%s
+%s
+resource "zitadel_verify_sms_otp_message_text" "default" {
+  org_id      = data.zitadel_org.default.id
+  language    = "en"
+  text        = "text example"
+  greeting    = "Greeting"
+  subject     = "Subject"
+  title       = "Title"
+  pre_header  = "Pre header"
+  button_text = "Button text"
+  footer_text = "Footer text"
+}
+`, frame.ProviderSnippet, frame.AsOrgDefaultDependency)
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: frame.V6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{Config: config},
+			{Config: config, PlanOnly: true},
+		},
+	})
+}
+
 func checkRemoteProperty(frame *test_utils.OrgTestFrame, lang string) func(string) resource.TestCheckFunc {
 	return func(expect string) resource.TestCheckFunc {
 		return func(state *terraform.State) error {


### PR DESCRIPTION
The `zitadel_verify_sms_otp_message_text` and `zitadel_default_verify_sms_otp_message_text` resources exposed `greeting`, `subject`, `title`, `pre_header`, `button_text` and `footer_text`, but the SMS OTP message-text API only persists `text` — its `Set` request carries just `language` and `text`. The other fields were silently discarded on write (the shared `MessageCustomText` schema marshals into a text-only request with `DiscardUnknown`) and returned empty on read, so every `terraform plan` after an `apply` reported those six fields as needing an update and never converged. Verify Phone is the only other SMS-delivered message type, and its API does accept all fields, so SMS OTP is the sole affected resource. This is consistent across ZITADEL 3.x and 4.x because the request shape is fixed by the proto, independent of server version.

Rather than remove the fields (a breaking change for existing configurations), they are deprecated in place via a shared `helper.DeprecateSMSOTPTextAttrs`, and `helper.PreserveSMSOTPTextAttrs` keeps their configured values on read so the perpetual diff disappears. Users who set them now get a deprecation warning instead of a never-ending diff; users who do not are unaffected. The fields can be removed in a future major version. Docs were regenerated to reflect the deprecation.

Closes #412

### Definition of Ready

- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] All non-functional requirements are met
- [x] The generic lifecycle acceptance test passes for affected resources.
- [x] Examples are up-to-date and meaningful. The provider version is incremented.
- [x] Docs are generated.
- [x] Code is generated where possible.
