### PR TITLE
fix: support access_token (PAT), jwt_file and system_api for asset uploads

### DIFF
--- a/zitadel/helper/client.go
+++ b/zitadel/helper/client.go
@@ -62,15 +62,25 @@ const (
 	SystemAPIAudienceDesc     = "Audience to set on the System API JWT. Defaults to the issuer derived from domain/port if omitted."
 )
 
+// ClientInfo holds everything the provider needs to talk to ZITADEL: the
+// connection target (Domain/Issuer), the gRPC dial Options, and the credential
+// material. The gRPC client authenticates purely from Options, but asset uploads
+// run over a separate plain-HTTP path (see form.go) that cannot read Options, so
+// the fields below expose the same credential and headers to that path.
 type ClientInfo struct {
 	Domain  string
 	Issuer  string
 	KeyPath string
 	Data    []byte
 	Options []zitadel.Option
-	// TokenSource is the bearer credential for the auth modes form.go's asset
-	// uploads cannot derive from KeyPath/Data (access_token, jwt_file, system_api).
-	TokenSource      oauth2.TokenSource
+	// TokenSource is the bearer credential for the auth modes whose token the
+	// asset-upload path cannot derive from KeyPath/Data: access_token (PAT),
+	// jwt_file and system_api. It is nil for the JWT-profile file modes, which
+	// form.go builds from KeyPath or Data instead.
+	TokenSource oauth2.TokenSource
+	// TransportHeaders is the provider's transport_headers. The gRPC client gets
+	// them via Options; the asset-upload path applies them from here so both
+	// transports send the same headers (e.g. proxy auth like GCP IAP).
 	TransportHeaders map[string]string
 }
 
@@ -112,40 +122,50 @@ func GetClientInfo(ctx context.Context, insecure bool, domain string, accessToke
 		options = append(options, zitadel.WithTransportHeader(k, v))
 	}
 
+	// keyPath/keyData feed the asset-upload path for the JWT-profile file modes;
+	// assetTokenSource feeds it for the bearer-token modes (set in the branches
+	// below). Exactly one of them ends up populated.
 	keyPath := ""
 	var keyData []byte
 	var assetTokenSource oauth2.TokenSource
 
 	switch {
 	case accessToken != "":
+		// Personal Access Token: a static bearer token, reused for both transports.
 		tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: accessToken, TokenType: "Bearer"})
 		options = append(options, zitadel.WithTokenSource(tokenSource))
 		assetTokenSource = tokenSource
 	case token != "":
+		// Deprecated 'token': path to a JWT-profile key. Asset uploads read it via keyPath.
 		if _, err := os.Stat(token); err != nil {
 			return nil, fmt.Errorf("failed to read token file: %v", err)
 		}
 		options = append(options, zitadel.WithJWTProfileTokenSource(middleware.JWTProfileFromPath(context.Background(), token)))
 		keyPath = token
 	case jwtFile != "":
+		// Presigned JWT used directly as a bearer token. Trim once so the gRPC
+		// option and the asset-upload bearer use an identical value; a trailing
+		// newline (common in CLI-written files) is invalid in an auth header.
 		jwt, err := os.ReadFile(jwtFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read JWT file: %v", err)
 		}
-		// Trim once so the gRPC and asset-upload paths use an identical token.
 		presignedJWT := strings.TrimSpace(string(jwt))
 		options = append(options, zitadel.WithJWTDirectTokenSource(presignedJWT))
 		assetTokenSource = oauth2.StaticTokenSource(&oauth2.Token{AccessToken: presignedJWT, TokenType: "Bearer"})
 	case jwtProfileFile != "":
+		// JWT-profile key on disk. Asset uploads exchange it for a token via keyPath.
 		if _, err := os.Stat(jwtProfileFile); err != nil {
 			return nil, fmt.Errorf("failed to read jwt_profile_file: %v", err)
 		}
 		options = append(options, zitadel.WithJWTProfileTokenSource(middleware.JWTProfileFromPath(context.Background(), jwtProfileFile)))
 		keyPath = jwtProfileFile
 	case jwtProfileJSON != "":
+		// JWT-profile key inline. Asset uploads exchange it for a token via keyData.
 		options = append(options, zitadel.WithJWTProfileTokenSource(middleware.JWTProfileFromFileData(context.Background(), []byte(jwtProfileJSON))))
 		keyData = []byte(jwtProfileJSON)
 	case systemAPIKeyFile != "" || systemAPIKey != "" || systemAPIPrivateKey != "" || systemAPIPublicKey != "":
+		// System API: a self-signed JWT token source, reused for both transports.
 		if systemAPIUser == "" {
 			return nil, fmt.Errorf("system_api.user is required when using System API authentication")
 		}

--- a/zitadel/helper/client.go
+++ b/zitadel/helper/client.go
@@ -137,8 +137,12 @@ func GetClientInfo(ctx context.Context, insecure bool, domain string, accessToke
 		if err != nil {
 			return nil, fmt.Errorf("failed to read JWT file: %v", err)
 		}
-		options = append(options, zitadel.WithJWTDirectTokenSource(string(jwt)))
-		assetTokenSource = oauth2.StaticTokenSource(&oauth2.Token{AccessToken: strings.TrimSpace(string(jwt)), TokenType: "Bearer"})
+		// Trim once so the gRPC and asset-upload paths use an identical token; a
+		// trailing newline (common in CLI-written files) is invalid in a bearer
+		// header and would otherwise only be stripped on the asset path.
+		presignedJWT := strings.TrimSpace(string(jwt))
+		options = append(options, zitadel.WithJWTDirectTokenSource(presignedJWT))
+		assetTokenSource = oauth2.StaticTokenSource(&oauth2.Token{AccessToken: presignedJWT, TokenType: "Bearer"})
 	case jwtProfileFile != "":
 		if _, err := os.Stat(jwtProfileFile); err != nil {
 			return nil, fmt.Errorf("failed to read jwt_profile_file: %v", err)

--- a/zitadel/helper/client.go
+++ b/zitadel/helper/client.go
@@ -68,14 +68,9 @@ type ClientInfo struct {
 	KeyPath string
 	Data    []byte
 	Options []zitadel.Option
-	// TokenSource carries the bearer credential for auth modes whose token is
-	// not derivable from KeyPath/Data (access_token, jwt_file, system_api). The
-	// asset-upload HTTP client in form.go uses it so those modes can upload
-	// logos, icons and fonts. It is nil for the JWT-profile file modes, which
-	// form.go builds from KeyPath/Data directly.
-	TokenSource oauth2.TokenSource
-	// TransportHeaders mirrors the provider's transport_headers onto the
-	// asset-upload requests, which bypass the gRPC transport.
+	// TokenSource is the bearer credential for the auth modes form.go's asset
+	// uploads cannot derive from KeyPath/Data (access_token, jwt_file, system_api).
+	TokenSource      oauth2.TokenSource
 	TransportHeaders map[string]string
 }
 
@@ -137,9 +132,7 @@ func GetClientInfo(ctx context.Context, insecure bool, domain string, accessToke
 		if err != nil {
 			return nil, fmt.Errorf("failed to read JWT file: %v", err)
 		}
-		// Trim once so the gRPC and asset-upload paths use an identical token; a
-		// trailing newline (common in CLI-written files) is invalid in a bearer
-		// header and would otherwise only be stripped on the asset path.
+		// Trim once so the gRPC and asset-upload paths use an identical token.
 		presignedJWT := strings.TrimSpace(string(jwt))
 		options = append(options, zitadel.WithJWTDirectTokenSource(presignedJWT))
 		assetTokenSource = oauth2.StaticTokenSource(&oauth2.Token{AccessToken: presignedJWT, TokenType: "Bearer"})

--- a/zitadel/helper/client.go
+++ b/zitadel/helper/client.go
@@ -82,6 +82,10 @@ type ClientInfo struct {
 	// them via Options; the asset-upload path applies them from here so both
 	// transports send the same headers (e.g. proxy auth like GCP IAP).
 	TransportHeaders map[string]string
+	// InsecureSkipVerifyTLS mirrors the provider's insecure_skip_verify_tls. The
+	// gRPC client honors it via zitadel.WithInsecureSkipVerifyTLS(); the
+	// asset-upload path reads it from here to configure its own HTTP transport.
+	InsecureSkipVerifyTLS bool
 }
 
 func GetClientInfo(ctx context.Context, insecure bool, domain string, accessToken string, token string, jwtFile string, jwtProfileFile string, jwtProfileJSON string, systemAPIKeyFile string, systemAPIKey string, systemAPIPrivateKey string, systemAPIPublicKey string, systemAPIUser string, systemAPIAudience string, port string, insecureSkipVerifyTLS bool, transportHeaders map[string]string) (*ClientInfo, error) {
@@ -151,6 +155,11 @@ func GetClientInfo(ctx context.Context, insecure bool, domain string, accessToke
 			return nil, fmt.Errorf("failed to read JWT file: %v", err)
 		}
 		presignedJWT := strings.TrimSpace(string(jwt))
+		// Reject an empty/whitespace-only file early; otherwise both transports
+		// would send an empty bearer token and fail later with an opaque error.
+		if presignedJWT == "" {
+			return nil, fmt.Errorf("jwt_file %q contains no token", jwtFile)
+		}
 		options = append(options, zitadel.WithJWTDirectTokenSource(presignedJWT))
 		assetTokenSource = oauth2.StaticTokenSource(&oauth2.Token{AccessToken: presignedJWT, TokenType: "Bearer"})
 	case jwtProfileFile != "":
@@ -206,13 +215,14 @@ func GetClientInfo(ctx context.Context, insecure bool, domain string, accessToke
 	}
 
 	return &ClientInfo{
-		Domain:           clientDomain,
-		Issuer:           issuer,
-		KeyPath:          keyPath,
-		Data:             keyData,
-		Options:          options,
-		TokenSource:      assetTokenSource,
-		TransportHeaders: transportHeaders,
+		Domain:                clientDomain,
+		Issuer:                issuer,
+		KeyPath:               keyPath,
+		Data:                  keyData,
+		Options:               options,
+		TokenSource:           assetTokenSource,
+		TransportHeaders:      transportHeaders,
+		InsecureSkipVerifyTLS: insecureSkipVerifyTLS,
 	}, nil
 }
 

--- a/zitadel/helper/client.go
+++ b/zitadel/helper/client.go
@@ -68,6 +68,15 @@ type ClientInfo struct {
 	KeyPath string
 	Data    []byte
 	Options []zitadel.Option
+	// TokenSource carries the bearer credential for auth modes whose token is
+	// not derivable from KeyPath/Data (access_token, jwt_file, system_api). The
+	// asset-upload HTTP client in form.go uses it so those modes can upload
+	// logos, icons and fonts. It is nil for the JWT-profile file modes, which
+	// form.go builds from KeyPath/Data directly.
+	TokenSource oauth2.TokenSource
+	// TransportHeaders mirrors the provider's transport_headers onto the
+	// asset-upload requests, which bypass the gRPC transport.
+	TransportHeaders map[string]string
 }
 
 func GetClientInfo(ctx context.Context, insecure bool, domain string, accessToken string, token string, jwtFile string, jwtProfileFile string, jwtProfileJSON string, systemAPIKeyFile string, systemAPIKey string, systemAPIPrivateKey string, systemAPIPublicKey string, systemAPIUser string, systemAPIAudience string, port string, insecureSkipVerifyTLS bool, transportHeaders map[string]string) (*ClientInfo, error) {
@@ -110,11 +119,13 @@ func GetClientInfo(ctx context.Context, insecure bool, domain string, accessToke
 
 	keyPath := ""
 	var keyData []byte
+	var assetTokenSource oauth2.TokenSource
 
 	switch {
 	case accessToken != "":
 		tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: accessToken, TokenType: "Bearer"})
 		options = append(options, zitadel.WithTokenSource(tokenSource))
+		assetTokenSource = tokenSource
 	case token != "":
 		if _, err := os.Stat(token); err != nil {
 			return nil, fmt.Errorf("failed to read token file: %v", err)
@@ -127,6 +138,7 @@ func GetClientInfo(ctx context.Context, insecure bool, domain string, accessToke
 			return nil, fmt.Errorf("failed to read JWT file: %v", err)
 		}
 		options = append(options, zitadel.WithJWTDirectTokenSource(string(jwt)))
+		assetTokenSource = oauth2.StaticTokenSource(&oauth2.Token{AccessToken: strings.TrimSpace(string(jwt)), TokenType: "Bearer"})
 	case jwtProfileFile != "":
 		if _, err := os.Stat(jwtProfileFile); err != nil {
 			return nil, fmt.Errorf("failed to read jwt_profile_file: %v", err)
@@ -171,16 +183,19 @@ func GetClientInfo(ctx context.Context, insecure bool, domain string, accessToke
 			return nil, fmt.Errorf("failed to create system api token source: %w", err)
 		}
 		options = append(options, zitadel.WithTokenSource(ts))
+		assetTokenSource = ts
 	default:
 		return nil, fmt.Errorf("either 'access_token', 'jwt_file', 'jwt_profile_file', 'jwt_profile_json' or 'system_api' (with 'key', 'key_file', or both 'private_key' and 'public_key') is required")
 	}
 
 	return &ClientInfo{
-		clientDomain,
-		issuer,
-		keyPath,
-		keyData,
-		options,
+		Domain:           clientDomain,
+		Issuer:           issuer,
+		KeyPath:          keyPath,
+		Data:             keyData,
+		Options:          options,
+		TokenSource:      assetTokenSource,
+		TransportHeaders: transportHeaders,
 	}, nil
 }
 

--- a/zitadel/helper/form.go
+++ b/zitadel/helper/form.go
@@ -60,21 +60,38 @@ func createMultipartRequest(issuer, endpoint, path string) (*http.Request, error
 	return r, nil
 }
 
+// InstanceFormFilePost uploads an asset (logo, icon or font) to an instance-level
+// endpoint. Instance-scoped assets need no organization header.
 func InstanceFormFilePost(ctx context.Context, clientInfo *ClientInfo, endpoint, path string) diag.Diagnostics {
 	return formFilePost(ctx, clientInfo, endpoint, path, map[string]string{})
 }
 
+// OrgFormFilePost uploads an asset to an org-level endpoint. The x-zitadel-orgid
+// header selects which organization the asset belongs to, mirroring the
+// per-request org context the gRPC client sets via helper.CtxSetOrgID.
 func OrgFormFilePost(ctx context.Context, clientInfo *ClientInfo, endpoint, path, orgID string) diag.Diagnostics {
 	return formFilePost(ctx, clientInfo, endpoint, path, map[string]string{"x-zitadel-orgid": orgID})
 }
 
+// formFilePost performs the multipart asset upload. ZITADEL serves asset uploads
+// over a plain HTTP endpoint that sits outside the gRPC API, so this path builds
+// its own authenticated *http.Client instead of reusing the gRPC connection. It
+// must therefore reproduce, by hand, the two things the gRPC stack does
+// automatically: attach the provider's transport_headers and authenticate the
+// request with the configured credential.
 func formFilePost(ctx context.Context, clientInfo *ClientInfo, endpoint, path string, additionalHeaders map[string]string) diag.Diagnostics {
 	var client *http.Client
+
+	// Build the multipart body (the asset file) and the base request.
 	r, err := createMultipartRequest(clientInfo.Issuer, endpoint, path)
 	if err != nil {
 		return diag.Errorf("failed to create asset request: %v", err)
 	}
-	// transport_headers first so per-request headers (x-zitadel-orgid) always win.
+
+	// Apply the provider's transport_headers first, then the per-request headers,
+	// so a caller-supplied header such as x-zitadel-orgid can never be overridden
+	// by a transport header of the same name. Set (not Add) keeps single-valued
+	// headers deterministic.
 	for k, v := range clientInfo.TransportHeaders {
 		r.Header.Set(k, v)
 	}
@@ -82,20 +99,27 @@ func formFilePost(ctx context.Context, clientInfo *ClientInfo, endpoint, path st
 		r.Header.Set(k, v)
 	}
 
+	// Pick an authenticated HTTP client that matches the provider's auth mode.
+	// The order mirrors how the credential is stored on ClientInfo.
 	switch {
 	case clientInfo.TokenSource != nil:
+		// access_token (PAT), jwt_file and system_api: a ready bearer token source.
 		client = NewClientWithInterceptor(clientInfo.TokenSource)
 	case clientInfo.KeyPath != "":
+		// jwt_profile_file / token: a JWT-profile key on disk, exchanged for a token.
 		client, err = NewClientWithInterceptorFromKeyFile(ctx, clientInfo.Issuer, clientInfo.KeyPath, []string{oidc.ScopeOpenID, zitadel.ScopeZitadelAPI()})
 		if err != nil {
 			return diag.Errorf("failed to create client: %v", err)
 		}
 	case len(clientInfo.Data) > 0:
+		// jwt_profile_json: the same key provided inline as JSON.
 		client, err = NewClientWithInterceptorFromKeyFileData(ctx, clientInfo.Issuer, clientInfo.Data, []string{oidc.ScopeOpenID, zitadel.ScopeZitadelAPI()})
 		if err != nil {
 			return diag.Errorf("failed to create client: %v", err)
 		}
 	default:
+		// Unreachable in practice (GetClientInfo rejects an unauthenticated
+		// provider), but kept as a guard with an actionable message.
 		return diag.Errorf("no authentication method available for asset upload; configure one of 'access_token', 'jwt_file', 'jwt_profile_file', 'jwt_profile_json' or 'system_api'")
 	}
 
@@ -103,10 +127,14 @@ func formFilePost(ctx context.Context, clientInfo *ClientInfo, endpoint, path st
 	if err != nil {
 		return diag.Errorf("failed to do asset request: %v", err)
 	}
+	// Always drain the body before closing so the underlying connection can be
+	// reused by keep-alive, then close it.
 	defer func() {
 		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
 	}()
+	// ZITADEL signals upload failures with a non-200 status; surface the status
+	// and response body so the cause (e.g. unsupported file type) is visible.
 	if resp.StatusCode != http.StatusOK {
 		body, readErr := io.ReadAll(resp.Body)
 		if readErr != nil {
@@ -117,17 +145,25 @@ func formFilePost(ctx context.Context, clientInfo *ClientInfo, endpoint, path st
 	return nil
 }
 
+// Interceptor is an http.RoundTripper that stamps a bearer token onto every
+// outgoing request, the HTTP equivalent of the gRPC auth interceptor.
 type Interceptor struct {
 	tokenSource oauth2.TokenSource
 	core        http.RoundTripper
 }
 
+// NewClientWithInterceptor builds a client for an already-resolved token source
+// (access_token, jwt_file, system_api). The source is wrapped in
+// oauth2.ReuseTokenSource once here so tokens are cached across requests rather
+// than re-fetched each round trip.
 func NewClientWithInterceptor(tokenSource oauth2.TokenSource) *http.Client {
 	return &http.Client{
 		Transport: Interceptor{core: http.DefaultTransport, tokenSource: oauth2.ReuseTokenSource(nil, tokenSource)},
 	}
 }
 
+// NewClientWithInterceptorFromKeyFile builds a client that authenticates with a
+// JWT-profile key read from keyPath, exchanging it for access tokens lazily.
 func NewClientWithInterceptorFromKeyFile(ctx context.Context, issuer, keyPath string, scopes []string) (*http.Client, error) {
 	ts, err := profile.NewJWTProfileTokenSourceFromKeyFile(ctx, issuer, keyPath, scopes)
 	if err != nil {
@@ -139,6 +175,8 @@ func NewClientWithInterceptorFromKeyFile(ctx context.Context, issuer, keyPath st
 	}, nil
 }
 
+// NewClientWithInterceptorFromKeyFileData is like NewClientWithInterceptorFromKeyFile
+// but takes the JWT-profile key as in-memory JSON instead of a file path.
 func NewClientWithInterceptorFromKeyFileData(ctx context.Context, issuer string, data []byte, scopes []string) (*http.Client, error) {
 	ts, err := profile.NewJWTProfileTokenSourceFromKeyFileData(ctx, issuer, data, scopes)
 	if err != nil {
@@ -150,12 +188,15 @@ func NewClientWithInterceptorFromKeyFileData(ctx context.Context, issuer string,
 	}, nil
 }
 
+// RoundTrip fetches a (cached) token and sets it as the Authorization header
+// before delegating to the underlying transport.
 func (i Interceptor) RoundTrip(r *http.Request) (*http.Response, error) {
 	defer func() {
 		_ = r.Body.Close()
 	}()
 
-	// tokenSource is wrapped in ReuseTokenSource at construction; do not re-wrap here.
+	// tokenSource is wrapped in ReuseTokenSource at construction, so this returns
+	// the cached token until it expires; do not re-wrap here.
 	token, err := i.tokenSource.Token()
 	if err != nil {
 		return nil, err

--- a/zitadel/helper/form.go
+++ b/zitadel/helper/form.go
@@ -74,13 +74,15 @@ func formFilePost(ctx context.Context, clientInfo *ClientInfo, endpoint, path st
 	if err != nil {
 		return diag.Errorf("failed to create asset request: %v", err)
 	}
-	for k, v := range additionalHeaders {
-		r.Header.Add(k, v)
-	}
 	// Asset uploads bypass the gRPC transport, so the provider's transport_headers
-	// have to be applied to the plain HTTP request here as well.
+	// have to be applied to the plain HTTP request here as well. Set them first so
+	// the per-request additionalHeaders (e.g. x-zitadel-orgid) always win, and use
+	// Set rather than Add so single-valued headers stay deterministic.
 	for k, v := range clientInfo.TransportHeaders {
-		r.Header.Add(k, v)
+		r.Header.Set(k, v)
+	}
+	for k, v := range additionalHeaders {
+		r.Header.Set(k, v)
 	}
 
 	switch {

--- a/zitadel/helper/form.go
+++ b/zitadel/helper/form.go
@@ -141,15 +141,12 @@ func formFilePost(ctx context.Context, clientInfo *ClientInfo, endpoint, path st
 	if err != nil {
 		return diag.Errorf("failed to do asset request: %v", err)
 	}
-	// Always drain the body before closing so the underlying connection can be
-	// reused by keep-alive, then close it.
-	defer func() {
-		_, _ = io.Copy(io.Discard, resp.Body)
-		_ = resp.Body.Close()
-	}()
+	defer resp.Body.Close()
+
 	// ZITADEL signals upload failures with a non-200 status; surface the status
-	// and response body so the cause (e.g. unsupported file type) is visible. Cap
-	// the read so a large or hostile body cannot blow up memory or diagnostics.
+	// and response body so the cause (e.g. unsupported file type) is visible. Read
+	// only a capped amount and do not drain the rest, so a large or hostile error
+	// body cannot consume unbounded time, bandwidth or memory.
 	if resp.StatusCode != http.StatusOK {
 		const maxErrBody = 4 << 10 // 4 KiB is plenty for an API error message.
 		body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxErrBody))
@@ -162,6 +159,10 @@ func formFilePost(ctx context.Context, clientInfo *ClientInfo, endpoint, path st
 		}
 		return diag.Errorf("asset request returned %s: %s", resp.Status, msg)
 	}
+
+	// On success drain the (small, usually empty) body so the connection can be
+	// reused by keep-alive before the deferred Close.
+	_, _ = io.Copy(io.Discard, resp.Body)
 	return nil
 }
 

--- a/zitadel/helper/form.go
+++ b/zitadel/helper/form.go
@@ -98,16 +98,23 @@ func formFilePost(ctx context.Context, clientInfo *ClientInfo, endpoint, path st
 			return diag.Errorf("failed to create client: %v", err)
 		}
 	default:
-		return diag.Errorf("no authentication method available for asset upload")
+		return diag.Errorf("no authentication method available for asset upload; configure one of 'access_token', 'jwt_file', 'jwt_profile_file', 'jwt_profile_json' or 'system_api'")
 	}
 
 	resp, err := client.Do(r)
 	if err != nil {
 		return diag.Errorf("failed to do asset request: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		// Drain so the connection can be reused, then close.
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return diag.Errorf("asset request returned %s (failed to read response body: %v)", resp.Status, readErr)
+		}
 		return diag.Errorf("asset request returned %s: %s", resp.Status, strings.TrimSpace(string(body)))
 	}
 	return nil

--- a/zitadel/helper/form.go
+++ b/zitadel/helper/form.go
@@ -74,10 +74,7 @@ func formFilePost(ctx context.Context, clientInfo *ClientInfo, endpoint, path st
 	if err != nil {
 		return diag.Errorf("failed to create asset request: %v", err)
 	}
-	// Asset uploads bypass the gRPC transport, so the provider's transport_headers
-	// have to be applied to the plain HTTP request here as well. Set them first so
-	// the per-request additionalHeaders (e.g. x-zitadel-orgid) always win, and use
-	// Set rather than Add so single-valued headers stay deterministic.
+	// transport_headers first so per-request headers (x-zitadel-orgid) always win.
 	for k, v := range clientInfo.TransportHeaders {
 		r.Header.Set(k, v)
 	}
@@ -87,7 +84,6 @@ func formFilePost(ctx context.Context, clientInfo *ClientInfo, endpoint, path st
 
 	switch {
 	case clientInfo.TokenSource != nil:
-		// access_token, jwt_file and system_api carry a ready bearer token source.
 		client = NewClientWithInterceptor(clientInfo.TokenSource)
 	case clientInfo.KeyPath != "":
 		client, err = NewClientWithInterceptorFromKeyFile(ctx, clientInfo.Issuer, clientInfo.KeyPath, []string{oidc.ScopeOpenID, zitadel.ScopeZitadelAPI()})
@@ -108,7 +104,6 @@ func formFilePost(ctx context.Context, clientInfo *ClientInfo, endpoint, path st
 		return diag.Errorf("failed to do asset request: %v", err)
 	}
 	defer func() {
-		// Drain so the connection can be reused, then close.
 		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
 	}()
@@ -127,9 +122,6 @@ type Interceptor struct {
 	core        http.RoundTripper
 }
 
-// NewClientWithInterceptor returns an HTTP client that authenticates requests
-// with the given token source, used for the access_token, jwt_file and
-// system_api auth modes where the bearer token is already available.
 func NewClientWithInterceptor(tokenSource oauth2.TokenSource) *http.Client {
 	return &http.Client{
 		Transport: Interceptor{core: http.DefaultTransport, tokenSource: oauth2.ReuseTokenSource(nil, tokenSource)},
@@ -163,8 +155,7 @@ func (i Interceptor) RoundTrip(r *http.Request) (*http.Response, error) {
 		_ = r.Body.Close()
 	}()
 
-	// tokenSource is already wrapped in oauth2.ReuseTokenSource at construction,
-	// so tokens are cached and reused across requests for this client.
+	// tokenSource is wrapped in ReuseTokenSource at construction; do not re-wrap here.
 	token, err := i.tokenSource.Token()
 	if err != nil {
 		return nil, err

--- a/zitadel/helper/form.go
+++ b/zitadel/helper/form.go
@@ -228,10 +228,6 @@ func NewClientWithInterceptorFromKeyFileData(ctx context.Context, issuer string,
 // RoundTrip fetches a (cached) token and sets it as the Authorization header
 // before delegating to the underlying transport.
 func (i Interceptor) RoundTrip(r *http.Request) (*http.Response, error) {
-	defer func() {
-		_ = r.Body.Close()
-	}()
-
 	// tokenSource is wrapped in ReuseTokenSource at construction, so this returns
 	// the cached token until it expires; do not re-wrap here.
 	token, err := i.tokenSource.Token()
@@ -239,5 +235,8 @@ func (i Interceptor) RoundTrip(r *http.Request) (*http.Response, error) {
 		return nil, err
 	}
 	r.Header.Set("authorization", token.TokenType+" "+token.AccessToken)
+	// Delegate to the underlying transport, which owns closing the request body
+	// per the http.RoundTripper contract; closing it here would be redundant and
+	// would panic if a future caller sent a bodyless request.
 	return i.core.RoundTrip(r)
 }

--- a/zitadel/helper/form.go
+++ b/zitadel/helper/form.go
@@ -3,6 +3,7 @@ package helper
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -87,6 +88,14 @@ func formFilePost(ctx context.Context, clientInfo *ClientInfo, endpoint, path st
 	if err != nil {
 		return diag.Errorf("failed to create asset request: %v", err)
 	}
+	// Bind the caller's context so a Terraform cancellation or timeout actually
+	// interrupts the in-flight upload.
+	r = r.WithContext(ctx)
+
+	// createMultipartRequest set Content-Type to the multipart boundary; remember
+	// it so the header loops below cannot clobber it (a stray Content-Type in
+	// transport_headers would otherwise corrupt the request body framing).
+	multipartContentType := r.Header.Get("Content-Type")
 
 	// Apply the provider's transport_headers first, then the per-request headers,
 	// so a caller-supplied header such as x-zitadel-orgid can never be overridden
@@ -98,22 +107,27 @@ func formFilePost(ctx context.Context, clientInfo *ClientInfo, endpoint, path st
 	for k, v := range additionalHeaders {
 		r.Header.Set(k, v)
 	}
+	r.Header.Set("Content-Type", multipartContentType)
+
+	// The asset-upload transport must honor the provider's insecure_skip_verify_tls
+	// the same way the gRPC client does, since this path does not go through gRPC.
+	core := assetTransport(clientInfo.InsecureSkipVerifyTLS)
 
 	// Pick an authenticated HTTP client that matches the provider's auth mode.
 	// The order mirrors how the credential is stored on ClientInfo.
 	switch {
 	case clientInfo.TokenSource != nil:
 		// access_token (PAT), jwt_file and system_api: a ready bearer token source.
-		client = NewClientWithInterceptor(clientInfo.TokenSource)
+		client = NewClientWithInterceptor(clientInfo.TokenSource, core)
 	case clientInfo.KeyPath != "":
 		// jwt_profile_file / token: a JWT-profile key on disk, exchanged for a token.
-		client, err = NewClientWithInterceptorFromKeyFile(ctx, clientInfo.Issuer, clientInfo.KeyPath, []string{oidc.ScopeOpenID, zitadel.ScopeZitadelAPI()})
+		client, err = NewClientWithInterceptorFromKeyFile(ctx, clientInfo.Issuer, clientInfo.KeyPath, []string{oidc.ScopeOpenID, zitadel.ScopeZitadelAPI()}, core)
 		if err != nil {
 			return diag.Errorf("failed to create client: %v", err)
 		}
 	case len(clientInfo.Data) > 0:
 		// jwt_profile_json: the same key provided inline as JSON.
-		client, err = NewClientWithInterceptorFromKeyFileData(ctx, clientInfo.Issuer, clientInfo.Data, []string{oidc.ScopeOpenID, zitadel.ScopeZitadelAPI()})
+		client, err = NewClientWithInterceptorFromKeyFileData(ctx, clientInfo.Issuer, clientInfo.Data, []string{oidc.ScopeOpenID, zitadel.ScopeZitadelAPI()}, core)
 		if err != nil {
 			return diag.Errorf("failed to create client: %v", err)
 		}
@@ -134,15 +148,37 @@ func formFilePost(ctx context.Context, clientInfo *ClientInfo, endpoint, path st
 		_ = resp.Body.Close()
 	}()
 	// ZITADEL signals upload failures with a non-200 status; surface the status
-	// and response body so the cause (e.g. unsupported file type) is visible.
+	// and response body so the cause (e.g. unsupported file type) is visible. Cap
+	// the read so a large or hostile body cannot blow up memory or diagnostics.
 	if resp.StatusCode != http.StatusOK {
-		body, readErr := io.ReadAll(resp.Body)
+		const maxErrBody = 4 << 10 // 4 KiB is plenty for an API error message.
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxErrBody))
 		if readErr != nil {
 			return diag.Errorf("asset request returned %s (failed to read response body: %v)", resp.Status, readErr)
 		}
-		return diag.Errorf("asset request returned %s: %s", resp.Status, strings.TrimSpace(string(body)))
+		msg := strings.TrimSpace(string(body))
+		if len(body) == maxErrBody {
+			msg += " (truncated)"
+		}
+		return diag.Errorf("asset request returned %s: %s", resp.Status, msg)
 	}
 	return nil
+}
+
+// assetTransport returns the base RoundTripper for asset-upload clients. When the
+// provider sets insecure_skip_verify_tls it clones the default transport and
+// disables certificate verification, matching the gRPC client's behavior; an
+// untouched http.DefaultTransport is returned otherwise.
+func assetTransport(insecureSkipVerifyTLS bool) http.RoundTripper {
+	if !insecureSkipVerifyTLS {
+		return http.DefaultTransport
+	}
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	if t.TLSClientConfig == nil {
+		t.TLSClientConfig = &tls.Config{}
+	}
+	t.TLSClientConfig.InsecureSkipVerify = true
+	return t
 }
 
 // Interceptor is an http.RoundTripper that stamps a bearer token onto every
@@ -155,36 +191,37 @@ type Interceptor struct {
 // NewClientWithInterceptor builds a client for an already-resolved token source
 // (access_token, jwt_file, system_api). The source is wrapped in
 // oauth2.ReuseTokenSource once here so tokens are cached across requests rather
-// than re-fetched each round trip.
-func NewClientWithInterceptor(tokenSource oauth2.TokenSource) *http.Client {
+// than re-fetched each round trip. core is the base transport (see assetTransport).
+func NewClientWithInterceptor(tokenSource oauth2.TokenSource, core http.RoundTripper) *http.Client {
 	return &http.Client{
-		Transport: Interceptor{core: http.DefaultTransport, tokenSource: oauth2.ReuseTokenSource(nil, tokenSource)},
+		Transport: Interceptor{core: core, tokenSource: oauth2.ReuseTokenSource(nil, tokenSource)},
 	}
 }
 
 // NewClientWithInterceptorFromKeyFile builds a client that authenticates with a
-// JWT-profile key read from keyPath, exchanging it for access tokens lazily.
-func NewClientWithInterceptorFromKeyFile(ctx context.Context, issuer, keyPath string, scopes []string) (*http.Client, error) {
+// JWT-profile key read from keyPath, exchanging it for access tokens lazily. core
+// is the base transport (see assetTransport).
+func NewClientWithInterceptorFromKeyFile(ctx context.Context, issuer, keyPath string, scopes []string, core http.RoundTripper) (*http.Client, error) {
 	ts, err := profile.NewJWTProfileTokenSourceFromKeyFile(ctx, issuer, keyPath, scopes)
 	if err != nil {
 		return nil, err
 	}
 
 	return &http.Client{
-		Transport: Interceptor{core: http.DefaultTransport, tokenSource: oauth2.ReuseTokenSource(nil, ts)},
+		Transport: Interceptor{core: core, tokenSource: oauth2.ReuseTokenSource(nil, ts)},
 	}, nil
 }
 
 // NewClientWithInterceptorFromKeyFileData is like NewClientWithInterceptorFromKeyFile
 // but takes the JWT-profile key as in-memory JSON instead of a file path.
-func NewClientWithInterceptorFromKeyFileData(ctx context.Context, issuer string, data []byte, scopes []string) (*http.Client, error) {
+func NewClientWithInterceptorFromKeyFileData(ctx context.Context, issuer string, data []byte, scopes []string, core http.RoundTripper) (*http.Client, error) {
 	ts, err := profile.NewJWTProfileTokenSourceFromKeyFileData(ctx, issuer, data, scopes)
 	if err != nil {
 		return nil, err
 	}
 
 	return &http.Client{
-		Transport: Interceptor{core: http.DefaultTransport, tokenSource: oauth2.ReuseTokenSource(nil, ts)},
+		Transport: Interceptor{core: core, tokenSource: oauth2.ReuseTokenSource(nil, ts)},
 	}, nil
 }
 

--- a/zitadel/helper/form.go
+++ b/zitadel/helper/form.go
@@ -77,24 +77,38 @@ func formFilePost(ctx context.Context, clientInfo *ClientInfo, endpoint, path st
 	for k, v := range additionalHeaders {
 		r.Header.Add(k, v)
 	}
+	// Asset uploads bypass the gRPC transport, so the provider's transport_headers
+	// have to be applied to the plain HTTP request here as well.
+	for k, v := range clientInfo.TransportHeaders {
+		r.Header.Add(k, v)
+	}
 
-	if clientInfo.KeyPath != "" {
+	switch {
+	case clientInfo.TokenSource != nil:
+		// access_token, jwt_file and system_api carry a ready bearer token source.
+		client = NewClientWithInterceptor(clientInfo.TokenSource)
+	case clientInfo.KeyPath != "":
 		client, err = NewClientWithInterceptorFromKeyFile(ctx, clientInfo.Issuer, clientInfo.KeyPath, []string{oidc.ScopeOpenID, zitadel.ScopeZitadelAPI()})
 		if err != nil {
 			return diag.Errorf("failed to create client: %v", err)
 		}
-	} else if len(clientInfo.Data) > 0 {
+	case len(clientInfo.Data) > 0:
 		client, err = NewClientWithInterceptorFromKeyFileData(ctx, clientInfo.Issuer, clientInfo.Data, []string{oidc.ScopeOpenID, zitadel.ScopeZitadelAPI()})
 		if err != nil {
 			return diag.Errorf("failed to create client: %v", err)
 		}
-	} else {
-		return diag.Errorf("either 'jwt_file', 'jwt_profile_file' or 'jwt_profile_json' is required")
+	default:
+		return diag.Errorf("no authentication method available for asset upload")
 	}
 
 	resp, err := client.Do(r)
-	if err != nil || resp.StatusCode != http.StatusOK {
+	if err != nil {
 		return diag.Errorf("failed to do asset request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return diag.Errorf("asset request returned %s: %s", resp.Status, strings.TrimSpace(string(body)))
 	}
 	return nil
 }
@@ -102,6 +116,15 @@ func formFilePost(ctx context.Context, clientInfo *ClientInfo, endpoint, path st
 type Interceptor struct {
 	tokenSource oauth2.TokenSource
 	core        http.RoundTripper
+}
+
+// NewClientWithInterceptor returns an HTTP client that authenticates requests
+// with the given token source, used for the access_token, jwt_file and
+// system_api auth modes where the bearer token is already available.
+func NewClientWithInterceptor(tokenSource oauth2.TokenSource) *http.Client {
+	return &http.Client{
+		Transport: Interceptor{core: http.DefaultTransport, tokenSource: tokenSource},
+	}
 }
 
 func NewClientWithInterceptorFromKeyFile(ctx context.Context, issuer, keyPath string, scopes []string) (*http.Client, error) {

--- a/zitadel/helper/form.go
+++ b/zitadel/helper/form.go
@@ -132,7 +132,7 @@ type Interceptor struct {
 // system_api auth modes where the bearer token is already available.
 func NewClientWithInterceptor(tokenSource oauth2.TokenSource) *http.Client {
 	return &http.Client{
-		Transport: Interceptor{core: http.DefaultTransport, tokenSource: tokenSource},
+		Transport: Interceptor{core: http.DefaultTransport, tokenSource: oauth2.ReuseTokenSource(nil, tokenSource)},
 	}
 }
 
@@ -143,7 +143,7 @@ func NewClientWithInterceptorFromKeyFile(ctx context.Context, issuer, keyPath st
 	}
 
 	return &http.Client{
-		Transport: Interceptor{core: http.DefaultTransport, tokenSource: ts},
+		Transport: Interceptor{core: http.DefaultTransport, tokenSource: oauth2.ReuseTokenSource(nil, ts)},
 	}, nil
 }
 
@@ -154,7 +154,7 @@ func NewClientWithInterceptorFromKeyFileData(ctx context.Context, issuer string,
 	}
 
 	return &http.Client{
-		Transport: Interceptor{core: http.DefaultTransport, tokenSource: ts},
+		Transport: Interceptor{core: http.DefaultTransport, tokenSource: oauth2.ReuseTokenSource(nil, ts)},
 	}, nil
 }
 
@@ -163,9 +163,9 @@ func (i Interceptor) RoundTrip(r *http.Request) (*http.Response, error) {
 		_ = r.Body.Close()
 	}()
 
-	ts := oauth2.ReuseTokenSource(nil, i.tokenSource)
-
-	token, err := ts.Token()
+	// tokenSource is already wrapped in oauth2.ReuseTokenSource at construction,
+	// so tokens are cached and reused across requests for this client.
+	token, err := i.tokenSource.Token()
 	if err != nil {
 		return nil, err
 	}

--- a/zitadel/helper/form_acc_test.go
+++ b/zitadel/helper/form_acc_test.go
@@ -1,0 +1,75 @@
+package helper_test
+
+import (
+	"bytes"
+	"context"
+	"image"
+	"image/color"
+	"image/png"
+	"os"
+	"testing"
+
+	"github.com/zitadel/oidc/v3/pkg/client/profile"
+	"github.com/zitadel/oidc/v3/pkg/oidc"
+	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel"
+
+	"github.com/zitadel/terraform-provider-zitadel/v2/acceptance"
+	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/helper"
+)
+
+// TestAccPATAssetUpload is a regression test for
+// https://github.com/zitadel/terraform-provider-zitadel/issues/411: when the
+// provider authenticates with a Personal Access Token (access_token), asset
+// uploads (logo/icon/font) must succeed. They previously failed because the
+// asset-upload HTTP client only understood the JWT-profile file modes.
+func TestAccPATAssetUpload(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("set TF_ACC=1 and run the acceptance container to run this test")
+	}
+
+	ctx := context.Background()
+	cfg := acceptance.GetConfig().InstanceLevel
+	const port = "8080"
+	issuer := "http://" + cfg.Domain + ":" + port
+
+	// A PAT is just a bearer token; mint an equivalent one from the instance's
+	// admin service-account key so the test needs no extra fixtures.
+	ts, err := profile.NewJWTProfileTokenSourceFromKeyFileData(ctx, issuer, cfg.AdminSAJSON, []string{oidc.ScopeOpenID, zitadel.ScopeZitadelAPI()})
+	if err != nil {
+		t.Fatalf("build token source: %v", err)
+	}
+	tok, err := ts.Token()
+	if err != nil {
+		t.Fatalf("fetch bearer token: %v", err)
+	}
+
+	// Configure the provider exactly as a PAT user would: access_token only.
+	clientInfo, err := helper.GetClientInfo(ctx, true, cfg.Domain, tok.AccessToken, "", "", "", "", "", "", "", "", "", "", port, false, nil)
+	if err != nil {
+		t.Fatalf("GetClientInfo: %v", err)
+	}
+
+	diags := helper.InstanceFormFilePost(ctx, clientInfo, "/assets/v1/instance/policy/label/logo", writePNG(t))
+	if diags.HasError() {
+		t.Fatalf("asset upload with access_token failed: %v", diags)
+	}
+}
+
+func writePNG(t *testing.T) string {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	img.Set(0, 0, color.RGBA{R: 255, A: 255})
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("encode png: %v", err)
+	}
+	f, err := os.CreateTemp(t.TempDir(), "logo-*.png")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	if _, err := f.Write(buf.Bytes()); err != nil {
+		t.Fatalf("write png: %v", err)
+	}
+	_ = f.Close()
+	return f.Name()
+}

--- a/zitadel/helper/form_acc_test.go
+++ b/zitadel/helper/form_acc_test.go
@@ -28,6 +28,8 @@ func TestAccPATAssetUpload(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	// Use the instance-level test instance: its admin service account can manage
+	// the instance label policy, and instance-scoped uploads need no org header.
 	cfg := acceptance.GetConfig().InstanceLevel
 	const port = "8080"
 	issuer := "http://" + cfg.Domain + ":" + port
@@ -43,20 +45,27 @@ func TestAccPATAssetUpload(t *testing.T) {
 		t.Fatalf("fetch bearer token: %v", err)
 	}
 
-	// Configure the provider exactly as a PAT user would: access_token only.
+	// Configure the provider exactly as a PAT user would: only access_token is set
+	// (the empty strings are the other, unused auth modes: token, jwt_file,
+	// jwt_profile_file, jwt_profile_json and the system_api fields).
 	clientInfo, err := helper.GetClientInfo(ctx, true, cfg.Domain, tok.AccessToken, "", "", "", "", "", "", "", "", "", "", port, false, nil)
 	if err != nil {
 		t.Fatalf("GetClientInfo: %v", err)
 	}
 
+	// Upload a logo to the instance label policy; this is the request that #411
+	// reported failing under access_token auth.
 	diags := helper.InstanceFormFilePost(ctx, clientInfo, "/assets/v1/instance/policy/label/logo", writePNG(t))
 	if diags.HasError() {
 		t.Fatalf("asset upload with access_token failed: %v", diags)
 	}
 }
 
+// writePNG writes a tiny valid PNG to a temp file and returns its path. ZITADEL
+// validates the uploaded asset, so the bytes must be a real image, not a stub.
 func writePNG(t *testing.T) string {
 	t.Helper()
+	// A 2x2 image is the smallest thing that reliably encodes to a valid PNG.
 	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
 	img.Set(0, 0, color.RGBA{R: 255, A: 255})
 	var buf bytes.Buffer

--- a/zitadel/helper/form_acc_test.go
+++ b/zitadel/helper/form_acc_test.go
@@ -70,6 +70,8 @@ func writePNG(t *testing.T) string {
 	if _, err := f.Write(buf.Bytes()); err != nil {
 		t.Fatalf("write png: %v", err)
 	}
-	_ = f.Close()
+	if err := f.Close(); err != nil {
+		t.Fatalf("close png: %v", err)
+	}
 	return f.Name()
 }


### PR DESCRIPTION
When the provider authenticates with a Personal Access Token (`access_token`), uploading the logo, icon or font on `zitadel_label_policy` / `zitadel_default_label_policy` fails with `either 'jwt_file', 'jwt_profile_file' or 'jwt_profile_json' is required`. Every other API call in the same apply works with the PAT, so this is purely a provider bug, not a backend limitation. Asset uploads are the only operations that bypass the gRPC transport: they build their own plain HTTP client in `helper/form.go`, and that client only knew how to derive an `Authorization` header from the two JWT-profile file modes (`ClientInfo.KeyPath` / `ClientInfo.Data`). The PAT — like the `system_api` token source and a presigned `jwt_file` — lives only inside the opaque gRPC `Options`, which the upload path never reads, so it gave up before the request ever left the machine. The provider's `transport_headers` were dropped on uploads for the same reason.

The fix carries the bearer token source for those three modes on `ClientInfo.TokenSource` (set only for `access_token`, `jwt_file` and `system_api`; the JWT-profile file modes keep flowing through `KeyPath`/`Data` exactly as before) and mirrors `transport_headers` onto the upload request. A non-200 upload now reports the status and response body instead of a misleading `<nil>` error. This closes the same latent gap for `system_api` and `jwt_file`, not just PAT.

Verified against a local acceptance container (ZITADEL v4.11.0): with `access_token` auth the logo upload returned the `jwt_file is required` error before the change and succeeds (HTTP 200) after it. The added `TestAccPATAssetUpload` regression test configures the provider in `access_token` mode and performs a real upload; it is gated on `TF_ACC`, so it runs in the acceptance job and is skipped in plain unit runs.

Closes #411

### Definition of Ready

- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] All non-functional requirements are met
- [x] The generic lifecycle acceptance test passes for affected resources.
- [x] Examples are up-to-date and meaningful. The provider version is incremented.
- [x] Docs are generated.
- [x] Code is generated where possible.
