### PR TITLE
feat: ephemeral resources for state-free secret generation

### DIFF
--- a/examples/ephemeral-resources/zitadel_application_api_client_secret/ephemeral-resource.tf
+++ b/examples/ephemeral-resources/zitadel_application_api_client_secret/ephemeral-resource.tf
@@ -1,0 +1,7 @@
+# Regenerate the client secret of a zitadel_application_api application without
+# persisting it to Terraform state. Gate with count/for_each to rotate only on
+# demand (every evaluation rotates the secret).
+ephemeral "zitadel_application_api_client_secret" "this" {
+  project_id = zitadel_application_api.this.project_id
+  app_id     = zitadel_application_api.this.id
+}

--- a/examples/ephemeral-resources/zitadel_application_key/ephemeral-resource.tf
+++ b/examples/ephemeral-resources/zitadel_application_key/ephemeral-resource.tf
@@ -1,0 +1,8 @@
+# Create a new JSON key for an API application and hand the key material to a
+# secret store, without it ever being written to Terraform state. Each
+# evaluation adds a new key, so gate with count/for_each to add a key on demand.
+ephemeral "zitadel_application_key" "this" {
+  project_id      = zitadel_application_api.this.project_id
+  app_id          = zitadel_application_api.this.id
+  expiration_date = "2519-04-01T08:45:00Z"
+}

--- a/examples/ephemeral-resources/zitadel_application_oidc_client_secret/ephemeral-resource.tf
+++ b/examples/ephemeral-resources/zitadel_application_oidc_client_secret/ephemeral-resource.tf
@@ -1,0 +1,7 @@
+# Regenerate the client secret of a zitadel_application_oidc application without
+# persisting it to Terraform state. Gate with count/for_each to rotate only on
+# demand (every evaluation rotates the secret).
+ephemeral "zitadel_application_oidc_client_secret" "this" {
+  project_id = zitadel_application_oidc.this.project_id
+  app_id     = zitadel_application_oidc.this.id
+}

--- a/examples/ephemeral-resources/zitadel_application_v2_client_secret/ephemeral-resource.tf
+++ b/examples/ephemeral-resources/zitadel_application_v2_client_secret/ephemeral-resource.tf
@@ -1,0 +1,8 @@
+# Regenerate the client secret of an OIDC/API application created with
+# zitadel_application_v2 and hand it to a secret store, without the secret ever
+# being written to Terraform state. Gate with count/for_each to rotate only on
+# demand (every evaluation rotates the secret).
+ephemeral "zitadel_application_v2_client_secret" "this" {
+  project_id     = zitadel_application_v2.this.project_id
+  application_id = zitadel_application_v2.this.id
+}

--- a/examples/ephemeral-resources/zitadel_machine_key/ephemeral-resource.tf
+++ b/examples/ephemeral-resources/zitadel_machine_key/ephemeral-resource.tf
@@ -1,0 +1,7 @@
+# Create a new JSON key for a machine (service) user and hand the key material
+# to a secret store, without it ever being written to Terraform state. Each
+# evaluation adds a new key, so gate with count/for_each to add a key on demand.
+ephemeral "zitadel_machine_key" "this" {
+  user_id         = zitadel_machine_user.this.id
+  expiration_date = "2519-04-01T08:45:00Z"
+}

--- a/examples/ephemeral-resources/zitadel_machine_user_client_secret/ephemeral-resource.tf
+++ b/examples/ephemeral-resources/zitadel_machine_user_client_secret/ephemeral-resource.tf
@@ -1,0 +1,6 @@
+# Generate a fresh client_id/client_secret pair for a machine (service) user
+# without persisting the secret to Terraform state. Gate with count/for_each to
+# rotate only on demand (every evaluation rotates the secret).
+ephemeral "zitadel_machine_user_client_secret" "this" {
+  user_id = zitadel_machine_user.this.id
+}

--- a/examples/ephemeral-resources/zitadel_organization_domain_validation/ephemeral-resource.tf
+++ b/examples/ephemeral-resources/zitadel_organization_domain_validation/ephemeral-resource.tf
@@ -1,0 +1,8 @@
+# (Re)generate the verification token for an organization domain without
+# persisting it to Terraform state. Each evaluation generates a fresh challenge,
+# so gate with count/for_each to (re)issue on demand.
+ephemeral "zitadel_organization_domain_validation" "this" {
+  org_id          = zitadel_organization_domain.this.organization_id
+  domain          = zitadel_organization_domain.this.domain
+  validation_type = "DOMAIN_VALIDATION_TYPE_DNS"
+}

--- a/examples/ephemeral-resources/zitadel_personal_access_token/ephemeral-resource.tf
+++ b/examples/ephemeral-resources/zitadel_personal_access_token/ephemeral-resource.tf
@@ -1,6 +1,6 @@
-# Mint a new personal access token (PAT) for a machine (service) user and hand
-# it to a secret store, without it ever being written to Terraform state. Each
-# evaluation mints a new token, so gate with count/for_each to issue on demand.
+# Mint a new personal access token (PAT) for a user and hand it to a secret
+# store, without it ever being written to Terraform state. Each evaluation mints
+# a new token, so gate with count/for_each to issue on demand.
 ephemeral "zitadel_personal_access_token" "this" {
   user_id         = zitadel_machine_user.this.id
   expiration_date = "2519-04-01T08:45:00Z"

--- a/examples/ephemeral-resources/zitadel_personal_access_token/ephemeral-resource.tf
+++ b/examples/ephemeral-resources/zitadel_personal_access_token/ephemeral-resource.tf
@@ -1,0 +1,7 @@
+# Mint a new personal access token (PAT) for a machine (service) user and hand
+# it to a secret store, without it ever being written to Terraform state. Each
+# evaluation mints a new token, so gate with count/for_each to issue on demand.
+ephemeral "zitadel_personal_access_token" "this" {
+  user_id         = zitadel_machine_user.this.id
+  expiration_date = "2519-04-01T08:45:00Z"
+}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-mux v0.21.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1
+	github.com/hashicorp/terraform-plugin-testing v1.14.0
 	github.com/zclconf/go-cty v1.17.0
 	github.com/zitadel/oidc/v3 v3.45.1
 	github.com/zitadel/zitadel-go/v3 v3.26.1
@@ -46,8 +47,8 @@ require (
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/hashicorp/hc-install v0.9.2 // indirect
 	github.com/hashicorp/logutils v1.0.0 // indirect
-	github.com/hashicorp/terraform-exec v0.23.1 // indirect
-	github.com/hashicorp/terraform-json v0.27.1 // indirect
+	github.com/hashicorp/terraform-exec v0.24.0 // indirect
+	github.com/hashicorp/terraform-json v0.27.2 // indirect
 	github.com/hashicorp/terraform-registry-address v0.4.0 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -97,10 +97,10 @@ github.com/hashicorp/hcl/v2 v2.24.0 h1:2QJdZ454DSsYGoaE6QheQZjtKZSUs9Nh2izTWiwQx
 github.com/hashicorp/hcl/v2 v2.24.0/go.mod h1:oGoO1FIQYfn/AgyOhlg9qLC6/nOJPX3qGbkZpYAcqfM=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
-github.com/hashicorp/terraform-exec v0.23.1 h1:diK5NSSDXDKqHEOIQefBMu9ny+FhzwlwV0xgUTB7VTo=
-github.com/hashicorp/terraform-exec v0.23.1/go.mod h1:e4ZEg9BJDRaSalGm2z8vvrPONt0XWG0/tXpmzYTf+dM=
-github.com/hashicorp/terraform-json v0.27.1 h1:zWhEracxJW6lcjt/JvximOYyc12pS/gaKSy/wzzE7nY=
-github.com/hashicorp/terraform-json v0.27.1/go.mod h1:GzPLJ1PLdUG5xL6xn1OXWIjteQRT2CNT9o/6A9mi9hE=
+github.com/hashicorp/terraform-exec v0.24.0 h1:mL0xlk9H5g2bn0pPF6JQZk5YlByqSqrO5VoaNtAf8OE=
+github.com/hashicorp/terraform-exec v0.24.0/go.mod h1:lluc/rDYfAhYdslLJQg3J0oDqo88oGQAdHR+wDqFvo4=
+github.com/hashicorp/terraform-json v0.27.2 h1:BwGuzM6iUPqf9JYM/Z4AF1OJ5VVJEEzoKST/tRDBJKU=
+github.com/hashicorp/terraform-json v0.27.2/go.mod h1:GzPLJ1PLdUG5xL6xn1OXWIjteQRT2CNT9o/6A9mi9hE=
 github.com/hashicorp/terraform-plugin-framework v1.17.0 h1:JdX50CFrYcYFY31gkmitAEAzLKoBgsK+iaJjDC8OexY=
 github.com/hashicorp/terraform-plugin-framework v1.17.0/go.mod h1:4OUXKdHNosX+ys6rLgVlgklfxN3WHR5VHSOABeS/BM0=
 github.com/hashicorp/terraform-plugin-go v0.29.0 h1:1nXKl/nSpaYIUBU1IG/EsDOX0vv+9JxAltQyDMpq5mU=
@@ -111,6 +111,8 @@ github.com/hashicorp/terraform-plugin-mux v0.21.0 h1:QsEYnzSD2c3zT8zUrUGqaFGhV/Z
 github.com/hashicorp/terraform-plugin-mux v0.21.0/go.mod h1:Qpt8+6AD7NmL0DS7ASkN0EXpDQ2J/FnnIgeUr1tzr5A=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1 h1:mlAq/OrMlg04IuJT7NpefI1wwtdpWudnEmjuQs04t/4=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1/go.mod h1:GQhpKVvvuwzD79e8/NZ+xzj+ZpWovdPAe8nfV/skwNU=
+github.com/hashicorp/terraform-plugin-testing v1.14.0 h1:5t4VKrjOJ0rg0sVuSJ86dz5K7PHsMO6OKrHFzDBerWA=
+github.com/hashicorp/terraform-plugin-testing v1.14.0/go.mod h1:1qfWkecyYe1Do2EEOK/5/WnTyvC8wQucUkkhiGLg5nk=
 github.com/hashicorp/terraform-registry-address v0.4.0 h1:S1yCGomj30Sao4l5BMPjTGZmCNzuv7/GDTDX99E9gTk=
 github.com/hashicorp/terraform-registry-address v0.4.0/go.mod h1:LRS1Ay0+mAiRkUyltGT+UHWkIqTFvigGn/LbMshfflE=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=

--- a/zitadel/ephemeral/application_api_client_secret/resource.go
+++ b/zitadel/ephemeral/application_api_client_secret/resource.go
@@ -1,0 +1,99 @@
+// Package application_api_client_secret implements the
+// zitadel_application_api_client_secret ephemeral resource.
+//
+// It regenerates the client secret of a zitadel_application_api application and
+// returns it for the duration of a single apply only, never writing it to
+// Terraform state (issue #413). Evaluating it rotates the secret, so gate it
+// behind count/for_each for explicit, on-demand rotation.
+package application_api_client_secret
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
+	ephschema "github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/management"
+
+	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/helper"
+)
+
+var (
+	_ ephemeral.EphemeralResource              = &resourceImpl{}
+	_ ephemeral.EphemeralResourceWithConfigure = &resourceImpl{}
+)
+
+func New() ephemeral.EphemeralResource {
+	return &resourceImpl{}
+}
+
+type resourceImpl struct {
+	helper.EphemeralSecretBase
+}
+
+type model struct {
+	ProjectID    types.String `tfsdk:"project_id"`
+	AppID        types.String `tfsdk:"app_id"`
+	OrgID        types.String `tfsdk:"org_id"`
+	ClientSecret types.String `tfsdk:"client_secret"`
+}
+
+func (r *resourceImpl) Metadata(_ context.Context, req ephemeral.MetadataRequest, resp *ephemeral.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_application_api_client_secret"
+}
+
+func (r *resourceImpl) Schema(_ context.Context, _ ephemeral.SchemaRequest, resp *ephemeral.SchemaResponse) {
+	resp.Schema = ephschema.Schema{
+		MarkdownDescription: "Regenerates and returns the client secret of a `zitadel_application_api` application " +
+			"without persisting it to Terraform state. Evaluating this ephemeral resource rotates the secret.",
+		Attributes: map[string]ephschema.Attribute{
+			"project_id": ephschema.StringAttribute{
+				Required:    true,
+				Description: "ID of the project the application belongs to.",
+			},
+			"app_id": ephschema.StringAttribute{
+				Required:    true,
+				Description: "ID of the application whose client secret should be regenerated.",
+			},
+			"org_id": ephschema.StringAttribute{
+				Optional:    true,
+				Description: "ID of the organization that owns the application. Defaults to the organization of the authenticated user.",
+			},
+			"client_secret": ephschema.StringAttribute{
+				Computed:    true,
+				Sensitive:   true,
+				Description: "The newly generated client secret. Only available during apply; never stored in state.",
+			},
+		},
+	}
+}
+
+func (r *resourceImpl) Open(ctx context.Context, req ephemeral.OpenRequest, resp *ephemeral.OpenResponse) {
+	var data model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client, err := helper.GetManagementClient(ctx, r.ClientInfo)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to get client", err.Error())
+		return
+	}
+
+	if orgID := data.OrgID.ValueString(); orgID != "" {
+		ctx = helper.CtxSetOrgID(ctx, orgID)
+	}
+
+	zResp, err := client.RegenerateAPIClientSecret(ctx, &management.RegenerateAPIClientSecretRequest{
+		ProjectId: data.ProjectID.ValueString(),
+		AppId:     data.AppID.ValueString(),
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("failed to regenerate client secret", err.Error())
+		return
+	}
+
+	data.ClientSecret = types.StringValue(zResp.GetClientSecret())
+	resp.Diagnostics.Append(resp.Result.Set(ctx, &data)...)
+}

--- a/zitadel/ephemeral/application_api_client_secret/resource_test.go
+++ b/zitadel/ephemeral/application_api_client_secret/resource_test.go
@@ -1,0 +1,55 @@
+package application_api_client_secret_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+
+	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/ephemeral/ephtest"
+)
+
+// TestAccApplicationAPIClientSecret verifies the ephemeral resource regenerates
+// and returns the client secret of a zitadel_application_api app.
+func TestAccApplicationAPIClientSecret(t *testing.T) {
+	frame := ephtest.NewOrgFrame(t)
+	config := fmt.Sprintf(`
+%s
+%s
+resource "zitadel_project" "default" {
+  name   = "proj-%s"
+  org_id = data.zitadel_org.default.id
+}
+resource "zitadel_application_api" "default" {
+  org_id           = data.zitadel_org.default.id
+  project_id       = zitadel_project.default.id
+  name             = "appapi-%s"
+  auth_method_type = "API_AUTH_METHOD_TYPE_BASIC"
+}
+ephemeral "zitadel_application_api_client_secret" "test" {
+  project_id = zitadel_project.default.id
+  app_id     = zitadel_application_api.default.id
+  org_id     = data.zitadel_org.default.id
+}
+provider "echo" {
+  data = ephemeral.zitadel_application_api_client_secret.test
+}
+resource "echo" "test" {}
+`, frame.ProviderSnippet, frame.OrgDependency, frame.UniqueID, frame.UniqueID)
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_10_0),
+		},
+		ProtoV6ProviderFactories: frame.ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("echo.test", "data.client_secret"),
+				),
+			},
+		},
+	})
+}

--- a/zitadel/ephemeral/application_key/resource.go
+++ b/zitadel/ephemeral/application_key/resource.go
@@ -120,7 +120,16 @@ func (r *resourceImpl) Open(ctx context.Context, req ephemeral.OpenRequest, resp
 		return
 	}
 
+	// Guard against an empty payload: the whole point of this resource is to
+	// return key material, so a missing key_details is a hard error rather than
+	// a silently empty result that would break consumers expecting a JSON key.
+	keyDetails := zResp.GetKeyDetails()
+	if len(keyDetails) == 0 {
+		resp.Diagnostics.AddError("empty key material", "the server returned no key_details for the application key")
+		return
+	}
+
 	data.KeyID = types.StringValue(zResp.GetId())
-	data.KeyDetails = types.StringValue(string(zResp.GetKeyDetails()))
+	data.KeyDetails = types.StringValue(string(keyDetails))
 	resp.Diagnostics.Append(resp.Result.Set(ctx, &data)...)
 }

--- a/zitadel/ephemeral/application_key/resource.go
+++ b/zitadel/ephemeral/application_key/resource.go
@@ -1,0 +1,126 @@
+// Package application_key implements the zitadel_application_key ephemeral
+// resource.
+//
+// It creates a new (JSON) key for an API application and returns the
+// key_details for the duration of a single apply only, never writing them to
+// Terraform state (issue #413). Each evaluation adds a new key, so gate it
+// behind count/for_each to add a key only on demand. Old keys remain valid
+// until removed via the managed zitadel_application_key resource or the API.
+package application_key
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
+	ephschema "github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/authn"
+	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/management"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/helper"
+)
+
+var (
+	_ ephemeral.EphemeralResource              = &resourceImpl{}
+	_ ephemeral.EphemeralResourceWithConfigure = &resourceImpl{}
+)
+
+func New() ephemeral.EphemeralResource {
+	return &resourceImpl{}
+}
+
+type resourceImpl struct {
+	helper.EphemeralSecretBase
+}
+
+type model struct {
+	ProjectID      types.String `tfsdk:"project_id"`
+	AppID          types.String `tfsdk:"app_id"`
+	OrgID          types.String `tfsdk:"org_id"`
+	ExpirationDate types.String `tfsdk:"expiration_date"`
+	KeyID          types.String `tfsdk:"key_id"`
+	KeyDetails     types.String `tfsdk:"key_details"`
+}
+
+func (r *resourceImpl) Metadata(_ context.Context, req ephemeral.MetadataRequest, resp *ephemeral.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_application_key"
+}
+
+func (r *resourceImpl) Schema(_ context.Context, _ ephemeral.SchemaRequest, resp *ephemeral.SchemaResponse) {
+	resp.Schema = ephschema.Schema{
+		MarkdownDescription: "Creates a new JSON key for an API application and returns the key material without persisting " +
+			"it to Terraform state. Each evaluation adds a new key, so gate it behind `count`/`for_each`.",
+		Attributes: map[string]ephschema.Attribute{
+			"project_id": ephschema.StringAttribute{
+				Required:    true,
+				Description: "ID of the project the application belongs to.",
+			},
+			"app_id": ephschema.StringAttribute{
+				Required:    true,
+				Description: "ID of the application the key is created for.",
+			},
+			"org_id": ephschema.StringAttribute{
+				Optional:    true,
+				Description: "ID of the organization that owns the application. Defaults to the organization of the authenticated user.",
+			},
+			"expiration_date": ephschema.StringAttribute{
+				Optional:    true,
+				Description: "Optional expiration date for the key, in RFC3339 format (e.g. 2519-04-01T08:45:00Z).",
+			},
+			"key_id": ephschema.StringAttribute{
+				Computed:    true,
+				Description: "ID of the generated key.",
+			},
+			"key_details": ephschema.StringAttribute{
+				Computed:    true,
+				Sensitive:   true,
+				Description: "The generated key material (JSON). Only available during apply; never stored in state.",
+			},
+		},
+	}
+}
+
+func (r *resourceImpl) Open(ctx context.Context, req ephemeral.OpenRequest, resp *ephemeral.OpenResponse) {
+	var data model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client, err := helper.GetManagementClient(ctx, r.ClientInfo)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to get client", err.Error())
+		return
+	}
+
+	if orgID := data.OrgID.ValueString(); orgID != "" {
+		ctx = helper.CtxSetOrgID(ctx, orgID)
+	}
+
+	zReq := &management.AddAppKeyRequest{
+		ProjectId: data.ProjectID.ValueString(),
+		AppId:     data.AppID.ValueString(),
+		// Only JSON keys are supported, matching the managed resource.
+		Type: authn.KeyType_KEY_TYPE_JSON,
+	}
+	if exp := data.ExpirationDate.ValueString(); exp != "" {
+		t, perr := time.Parse(time.RFC3339, exp)
+		if perr != nil {
+			resp.Diagnostics.AddError("failed to parse expiration_date", perr.Error())
+			return
+		}
+		zReq.ExpirationDate = timestamppb.New(t)
+	}
+
+	zResp, err := client.AddAppKey(ctx, zReq)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to add application key", err.Error())
+		return
+	}
+
+	data.KeyID = types.StringValue(zResp.GetId())
+	data.KeyDetails = types.StringValue(string(zResp.GetKeyDetails()))
+	resp.Diagnostics.Append(resp.Result.Set(ctx, &data)...)
+}

--- a/zitadel/ephemeral/application_key/resource_test.go
+++ b/zitadel/ephemeral/application_key/resource_test.go
@@ -1,0 +1,59 @@
+package application_key_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+
+	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/ephemeral/ephtest"
+)
+
+// TestAccApplicationKey verifies the ephemeral resource creates a new JSON key
+// for an API application and returns the key material. The type name
+// zitadel_application_key is shared with the managed resource; this also
+// confirms the muxed provider serves both forms without conflict.
+func TestAccApplicationKey(t *testing.T) {
+	frame := ephtest.NewOrgFrame(t)
+	config := fmt.Sprintf(`
+%s
+%s
+resource "zitadel_project" "default" {
+  name   = "proj-%s"
+  org_id = data.zitadel_org.default.id
+}
+resource "zitadel_application_api" "default" {
+  org_id           = data.zitadel_org.default.id
+  project_id       = zitadel_project.default.id
+  name             = "appapi-%s"
+  auth_method_type = "API_AUTH_METHOD_TYPE_PRIVATE_KEY_JWT"
+}
+ephemeral "zitadel_application_key" "test" {
+  project_id      = zitadel_project.default.id
+  app_id          = zitadel_application_api.default.id
+  org_id          = data.zitadel_org.default.id
+  expiration_date = "2519-04-01T08:45:00Z"
+}
+provider "echo" {
+  data = ephemeral.zitadel_application_key.test
+}
+resource "echo" "test" {}
+`, frame.ProviderSnippet, frame.OrgDependency, frame.UniqueID, frame.UniqueID)
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_10_0),
+		},
+		ProtoV6ProviderFactories: frame.ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("echo.test", "data.key_id"),
+					resource.TestCheckResourceAttrSet("echo.test", "data.key_details"),
+				),
+			},
+		},
+	})
+}

--- a/zitadel/ephemeral/application_oidc_client_secret/resource.go
+++ b/zitadel/ephemeral/application_oidc_client_secret/resource.go
@@ -1,0 +1,99 @@
+// Package application_oidc_client_secret implements the
+// zitadel_application_oidc_client_secret ephemeral resource.
+//
+// It regenerates the client secret of a zitadel_application_oidc application
+// and returns it for the duration of a single apply only, never writing it to
+// Terraform state (issue #413). Evaluating it rotates the secret, so gate it
+// behind count/for_each for explicit, on-demand rotation.
+package application_oidc_client_secret
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
+	ephschema "github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/management"
+
+	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/helper"
+)
+
+var (
+	_ ephemeral.EphemeralResource              = &resourceImpl{}
+	_ ephemeral.EphemeralResourceWithConfigure = &resourceImpl{}
+)
+
+func New() ephemeral.EphemeralResource {
+	return &resourceImpl{}
+}
+
+type resourceImpl struct {
+	helper.EphemeralSecretBase
+}
+
+type model struct {
+	ProjectID    types.String `tfsdk:"project_id"`
+	AppID        types.String `tfsdk:"app_id"`
+	OrgID        types.String `tfsdk:"org_id"`
+	ClientSecret types.String `tfsdk:"client_secret"`
+}
+
+func (r *resourceImpl) Metadata(_ context.Context, req ephemeral.MetadataRequest, resp *ephemeral.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_application_oidc_client_secret"
+}
+
+func (r *resourceImpl) Schema(_ context.Context, _ ephemeral.SchemaRequest, resp *ephemeral.SchemaResponse) {
+	resp.Schema = ephschema.Schema{
+		MarkdownDescription: "Regenerates and returns the client secret of a `zitadel_application_oidc` application " +
+			"without persisting it to Terraform state. Evaluating this ephemeral resource rotates the secret.",
+		Attributes: map[string]ephschema.Attribute{
+			"project_id": ephschema.StringAttribute{
+				Required:    true,
+				Description: "ID of the project the application belongs to.",
+			},
+			"app_id": ephschema.StringAttribute{
+				Required:    true,
+				Description: "ID of the application whose client secret should be regenerated.",
+			},
+			"org_id": ephschema.StringAttribute{
+				Optional:    true,
+				Description: "ID of the organization that owns the application. Defaults to the organization of the authenticated user.",
+			},
+			"client_secret": ephschema.StringAttribute{
+				Computed:    true,
+				Sensitive:   true,
+				Description: "The newly generated client secret. Only available during apply; never stored in state.",
+			},
+		},
+	}
+}
+
+func (r *resourceImpl) Open(ctx context.Context, req ephemeral.OpenRequest, resp *ephemeral.OpenResponse) {
+	var data model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client, err := helper.GetManagementClient(ctx, r.ClientInfo)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to get client", err.Error())
+		return
+	}
+
+	if orgID := data.OrgID.ValueString(); orgID != "" {
+		ctx = helper.CtxSetOrgID(ctx, orgID)
+	}
+
+	zResp, err := client.RegenerateOIDCClientSecret(ctx, &management.RegenerateOIDCClientSecretRequest{
+		ProjectId: data.ProjectID.ValueString(),
+		AppId:     data.AppID.ValueString(),
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("failed to regenerate client secret", err.Error())
+		return
+	}
+
+	data.ClientSecret = types.StringValue(zResp.GetClientSecret())
+	resp.Diagnostics.Append(resp.Result.Set(ctx, &data)...)
+}

--- a/zitadel/ephemeral/application_oidc_client_secret/resource_test.go
+++ b/zitadel/ephemeral/application_oidc_client_secret/resource_test.go
@@ -1,0 +1,62 @@
+package application_oidc_client_secret_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+
+	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/ephemeral/ephtest"
+)
+
+// TestAccApplicationOIDCClientSecret verifies the ephemeral resource
+// regenerates and returns the client secret of a zitadel_application_oidc app.
+func TestAccApplicationOIDCClientSecret(t *testing.T) {
+	frame := ephtest.NewOrgFrame(t)
+	config := fmt.Sprintf(`
+%s
+%s
+resource "zitadel_project" "default" {
+  name   = "proj-%s"
+  org_id = data.zitadel_org.default.id
+}
+resource "zitadel_application_oidc" "default" {
+  project_id                = zitadel_project.default.id
+  org_id                    = data.zitadel_org.default.id
+  name                      = "appoidc-%s"
+  redirect_uris             = ["https://localhost.com"]
+  response_types            = ["OIDC_RESPONSE_TYPE_CODE"]
+  grant_types               = ["OIDC_GRANT_TYPE_AUTHORIZATION_CODE"]
+  post_logout_redirect_uris = ["https://localhost.com"]
+  app_type                  = "OIDC_APP_TYPE_WEB"
+  auth_method_type          = "OIDC_AUTH_METHOD_TYPE_BASIC"
+  version                   = "OIDC_VERSION_1_0"
+  dev_mode                  = true
+}
+ephemeral "zitadel_application_oidc_client_secret" "test" {
+  project_id = zitadel_project.default.id
+  app_id     = zitadel_application_oidc.default.id
+  org_id     = data.zitadel_org.default.id
+}
+provider "echo" {
+  data = ephemeral.zitadel_application_oidc_client_secret.test
+}
+resource "echo" "test" {}
+`, frame.ProviderSnippet, frame.OrgDependency, frame.UniqueID, frame.UniqueID)
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_10_0),
+		},
+		ProtoV6ProviderFactories: frame.ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("echo.test", "data.client_secret"),
+				),
+			},
+		},
+	})
+}

--- a/zitadel/ephemeral/application_v2_client_secret/resource.go
+++ b/zitadel/ephemeral/application_v2_client_secret/resource.go
@@ -1,0 +1,115 @@
+// Package application_v2_client_secret implements the
+// zitadel_application_v2_client_secret ephemeral resource.
+//
+// It rotates (regenerates) the client secret of a zitadel_application_v2 OIDC
+// or API application and returns the freshly generated secret for the duration
+// of a single `terraform apply` only. Unlike the Computed `client_secret`
+// attribute on the managed zitadel_application_v2 resource, the value produced
+// here is never written to Terraform state, which keeps the secret out of
+// remote state backends (issue #413).
+//
+// Because opening this ephemeral resource calls the server's GenerateClientSecret
+// RPC, every apply that evaluates it rotates the secret. Operators are expected
+// to gate it behind count/for_each so rotation is explicit rather than
+// happening on every run.
+package application_v2_client_secret
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
+	ephschema "github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	appv2pb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/application/v2"
+
+	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/helper"
+)
+
+// Interface assertions: this resource opens (Open) and needs provider data
+// (Configure, provided by the embedded EphemeralSecretBase).
+var (
+	_ ephemeral.EphemeralResource              = &resourceImpl{}
+	_ ephemeral.EphemeralResourceWithConfigure = &resourceImpl{}
+)
+
+func New() ephemeral.EphemeralResource {
+	return &resourceImpl{}
+}
+
+type resourceImpl struct {
+	// Configure (from the embedded base) populates ClientInfo before Open.
+	helper.EphemeralSecretBase
+}
+
+// model maps the HCL config and result attributes to Go. application_id and
+// project_id identify the v2 application; org_id optionally scopes the call to
+// a specific organization. client_secret is the result populated by Open.
+type model struct {
+	ApplicationID types.String `tfsdk:"application_id"`
+	ProjectID     types.String `tfsdk:"project_id"`
+	OrgID         types.String `tfsdk:"org_id"`
+	ClientSecret  types.String `tfsdk:"client_secret"`
+}
+
+func (r *resourceImpl) Metadata(_ context.Context, req ephemeral.MetadataRequest, resp *ephemeral.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_application_v2_client_secret"
+}
+
+func (r *resourceImpl) Schema(_ context.Context, _ ephemeral.SchemaRequest, resp *ephemeral.SchemaResponse) {
+	resp.Schema = ephschema.Schema{
+		MarkdownDescription: "Regenerates and returns the client secret of a `zitadel_application_v2` OIDC or API application " +
+			"without persisting it to Terraform state. Evaluating this ephemeral resource rotates the secret, so gate it " +
+			"behind `count`/`for_each` to rotate only on demand.",
+		Attributes: map[string]ephschema.Attribute{
+			"application_id": ephschema.StringAttribute{
+				Required:    true,
+				Description: "ID of the application whose client secret should be regenerated.",
+			},
+			"project_id": ephschema.StringAttribute{
+				Required:    true,
+				Description: "ID of the project the application belongs to.",
+			},
+			"org_id": ephschema.StringAttribute{
+				Optional:    true,
+				Description: "ID of the organization that owns the application. Defaults to the organization of the authenticated user.",
+			},
+			"client_secret": ephschema.StringAttribute{
+				Computed:    true,
+				Sensitive:   true,
+				Description: "The newly generated client secret. Only available during apply; never stored in state.",
+			},
+		},
+	}
+}
+
+func (r *resourceImpl) Open(ctx context.Context, req ephemeral.OpenRequest, resp *ephemeral.OpenResponse) {
+	var data model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client, err := helper.GetAppV2Client(ctx, r.ClientInfo)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to get client", err.Error())
+		return
+	}
+
+	// Only override the org from config when supplied; otherwise the call is
+	// scoped to the authenticated user's organization.
+	if orgID := data.OrgID.ValueString(); orgID != "" {
+		ctx = helper.CtxSetOrgID(ctx, orgID)
+	}
+
+	zResp, err := client.GenerateClientSecret(ctx, &appv2pb.GenerateClientSecretRequest{
+		ApplicationId: data.ApplicationID.ValueString(),
+		ProjectId:     data.ProjectID.ValueString(),
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("failed to regenerate client secret", err.Error())
+		return
+	}
+
+	data.ClientSecret = types.StringValue(zResp.GetClientSecret())
+	resp.Diagnostics.Append(resp.Result.Set(ctx, &data)...)
+}

--- a/zitadel/ephemeral/application_v2_client_secret/resource.go
+++ b/zitadel/ephemeral/application_v2_client_secret/resource.go
@@ -57,13 +57,13 @@ func (r *resourceImpl) Metadata(_ context.Context, req ephemeral.MetadataRequest
 
 func (r *resourceImpl) Schema(_ context.Context, _ ephemeral.SchemaRequest, resp *ephemeral.SchemaResponse) {
 	resp.Schema = ephschema.Schema{
-		MarkdownDescription: "Regenerates and returns the client secret of a `zitadel_application_v2` OIDC or API application " +
-			"without persisting it to Terraform state. Evaluating this ephemeral resource rotates the secret, so gate it " +
-			"behind `count`/`for_each` to rotate only on demand.",
+		MarkdownDescription: "Generates a new client secret for a `zitadel_application_v2` OIDC or API application and " +
+			"returns it without persisting it to Terraform state. Each evaluation generates a new secret (rotating any " +
+			"existing one), so gate it behind `count`/`for_each` to do so only on demand.",
 		Attributes: map[string]ephschema.Attribute{
 			"application_id": ephschema.StringAttribute{
 				Required:    true,
-				Description: "ID of the application whose client secret should be regenerated.",
+				Description: "ID of the application to generate a client secret for.",
 			},
 			"project_id": ephschema.StringAttribute{
 				Required:    true,

--- a/zitadel/ephemeral/application_v2_client_secret/resource.go
+++ b/zitadel/ephemeral/application_v2_client_secret/resource.go
@@ -106,7 +106,7 @@ func (r *resourceImpl) Open(ctx context.Context, req ephemeral.OpenRequest, resp
 		ProjectId:     data.ProjectID.ValueString(),
 	})
 	if err != nil {
-		resp.Diagnostics.AddError("failed to regenerate client secret", err.Error())
+		resp.Diagnostics.AddError("failed to generate client secret", err.Error())
 		return
 	}
 

--- a/zitadel/ephemeral/application_v2_client_secret/resource_test.go
+++ b/zitadel/ephemeral/application_v2_client_secret/resource_test.go
@@ -1,0 +1,73 @@
+package application_v2_client_secret_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+
+	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/ephemeral/ephtest"
+)
+
+// TestAccApplicationV2ClientSecret verifies that the ephemeral resource
+// regenerates and returns the client secret of a zitadel_application_v2 OIDC
+// application. The echo provider captures the ephemeral value so we can assert
+// it was produced; the secret itself is never written to state.
+func TestAccApplicationV2ClientSecret(t *testing.T) {
+	frame := ephtest.NewOrgFrame(t)
+	config := fmt.Sprintf(`
+%s
+%s
+resource "zitadel_project" "default" {
+  name   = "proj-%s"
+  org_id = data.zitadel_org.default.id
+}
+resource "zitadel_application_v2" "default" {
+  project_id = zitadel_project.default.id
+  org_id     = data.zitadel_org.default.id
+  name       = "appv2-%s"
+  oidc {
+    redirect_uris                = ["https://localhost.com"]
+    response_types               = ["OIDC_RESPONSE_TYPE_CODE"]
+    grant_types                  = ["OIDC_GRANT_TYPE_AUTHORIZATION_CODE"]
+    post_logout_redirect_uris    = ["https://localhost.com"]
+    app_type                     = "OIDC_APP_TYPE_WEB"
+    auth_method_type             = "OIDC_AUTH_METHOD_TYPE_BASIC"
+    version                      = "OIDC_VERSION_1_0"
+    clock_skew                   = "0s"
+    dev_mode                     = true
+    access_token_type            = "OIDC_TOKEN_TYPE_BEARER"
+    access_token_role_assertion  = false
+    id_token_role_assertion      = false
+    id_token_userinfo_assertion  = false
+    additional_origins           = []
+    skip_native_app_success_page = false
+  }
+}
+ephemeral "zitadel_application_v2_client_secret" "test" {
+  project_id     = zitadel_project.default.id
+  application_id = zitadel_application_v2.default.id
+  org_id         = data.zitadel_org.default.id
+}
+provider "echo" {
+  data = ephemeral.zitadel_application_v2_client_secret.test
+}
+resource "echo" "test" {}
+`, frame.ProviderSnippet, frame.OrgDependency, frame.UniqueID, frame.UniqueID)
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_10_0),
+		},
+		ProtoV6ProviderFactories: frame.ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("echo.test", "data.client_secret"),
+				),
+			},
+		},
+	})
+}

--- a/zitadel/ephemeral/ephtest/frame.go
+++ b/zitadel/ephemeral/ephtest/frame.go
@@ -111,7 +111,7 @@ data "zitadel_org" "default" {
 	providerSnippet := fmt.Sprintf(`
 provider "zitadel" {
   domain           = "%s"
-  insecure         = "%t"
+  insecure         = %t
   port             = "%s"
   jwt_profile_json = <<KEY
 %s

--- a/zitadel/ephemeral/ephtest/frame.go
+++ b/zitadel/ephemeral/ephtest/frame.go
@@ -1,0 +1,157 @@
+// Package ephtest provides a minimal acceptance-test harness for the ephemeral
+// secret resources.
+//
+// It deliberately does NOT depend on zitadel/helper/test_utils. That package
+// pulls in github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource, whose
+// init() registers a global `-sweep` flag. The ephemeral tests must use the
+// newer github.com/hashicorp/terraform-plugin-testing/helper/resource (only it
+// understands ephemeral resources and TerraformVersionChecks), and that package
+// registers the SAME `-sweep` flag. Importing both into one test binary panics
+// with "flag redefined: sweep". Keeping this harness free of the SDKv2 testing
+// package lets the ephemeral tests link cleanly.
+package ephtest
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
+	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/echoprovider"
+	mgmt "github.com/zitadel/zitadel-go/v3/pkg/client/management"
+	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/management"
+
+	"github.com/zitadel/terraform-provider-zitadel/v2/acceptance"
+	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel"
+	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/helper"
+)
+
+const (
+	insecure = true
+	port     = "8080"
+)
+
+// OrgFrame bundles everything an ephemeral resource test needs: the provider
+// HCL snippet, a data "zitadel_org" "default" dependency, the resolved default
+// org id, a unique suffix for resource names, a management client for remote
+// assertions, and the proto-v6 provider factories (zitadel + echo).
+type OrgFrame struct {
+	Context           context.Context
+	ProviderSnippet   string
+	OrgDependency     string
+	OrgID             string
+	UniqueID          string
+	Client            *mgmt.Client
+	ProviderFactories map[string]func() (tfprotov6.ProviderServer, error)
+}
+
+// NewOrgFrame configures a provider against the org-level acceptance instance
+// and resolves the default organization. Use it for ephemeral resources scoped
+// to the default org (client secrets, machine secrets, keys, PATs).
+func NewOrgFrame(t *testing.T) *OrgFrame {
+	t.Helper()
+	return newFrame(t, acceptance.GetConfig().OrgLevel, true)
+}
+
+// NewInstanceFrame configures a provider against the instance-level acceptance
+// instance and does NOT resolve a default org. Use it for tests that create a
+// fresh organization and need org-domain validation to actually require a
+// challenge: the instance-level instance's domain policy keeps added domains
+// unverified, whereas the org-level instance auto-verifies them.
+func NewInstanceFrame(t *testing.T) *OrgFrame {
+	t.Helper()
+	return newFrame(t, acceptance.GetConfig().InstanceLevel, false)
+}
+
+// newFrame builds a frame for the given isolated instance. When resolveOrg is
+// true it looks up the default organization and exposes a data "zitadel_org"
+// "default" dependency; otherwise OrgID/OrgDependency are left empty.
+func newFrame(t *testing.T, cfg acceptance.IsolatedInstance, resolveOrg bool) *OrgFrame {
+	t.Helper()
+	ctx := context.Background()
+
+	// Configure the SDKv2 provider once so we obtain a *helper.ClientInfo (its
+	// Meta) and can build a management client for remote assertions.
+	sdkProvider := zitadel.Provider()
+	if d := sdkProvider.Configure(ctx, terraform.NewResourceConfigRaw(map[string]interface{}{
+		"domain":           cfg.Domain,
+		"insecure":         insecure,
+		"port":             port,
+		"jwt_profile_json": string(cfg.AdminSAJSON),
+	})); d.HasError() {
+		t.Fatalf("failed to configure test provider: %v", d)
+	}
+	clientInfo := sdkProvider.Meta().(*helper.ClientInfo)
+
+	client, err := helper.GetManagementClient(ctx, clientInfo)
+	if err != nil {
+		t.Fatalf("failed to build management client: %v", err)
+	}
+
+	var orgID, orgDependency string
+	if resolveOrg {
+		org, oerr := client.GetOrgByDomainGlobal(ctx, &management.GetOrgByDomainGlobalRequest{Domain: "zitadel." + cfg.Domain})
+		if oerr != nil {
+			t.Fatalf("failed to look up default org: %v", oerr)
+		}
+		orgID = org.GetOrg().GetId()
+		orgDependency = fmt.Sprintf(`
+data "zitadel_org" "default" {
+  id = "%s"
+}
+`, orgID)
+	}
+
+	providerSnippet := fmt.Sprintf(`
+provider "zitadel" {
+  domain           = "%s"
+  insecure         = "%t"
+  port             = "%s"
+  jwt_profile_json = <<KEY
+%s
+KEY
+}
+`, cfg.Domain, insecure, port, string(cfg.AdminSAJSON))
+
+	// The mux factory serves both halves of the provider: the plugin-framework
+	// provider (which hosts the ephemeral resources under test) and the SDKv2
+	// provider upgraded to protocol v6 (which hosts the managed dependency
+	// resources such as zitadel_project / zitadel_application_v2).
+	factory := func() (tfprotov6.ProviderServer, error) {
+		muxServer, err := tf6muxserver.NewMuxServer(ctx,
+			providerserver.NewProtocol6(zitadel.NewProviderPV6()),
+			func() tfprotov6.ProviderServer {
+				upgraded, uerr := tf5to6server.UpgradeServer(ctx, func() tfprotov5.ProviderServer {
+					return zitadel.Provider().GRPCProvider()
+				})
+				if uerr != nil {
+					return nil
+				}
+				return upgraded
+			},
+		)
+		if err != nil {
+			return nil, err
+		}
+		return muxServer.ProviderServer(), nil
+	}
+
+	return &OrgFrame{
+		Context:         ctx,
+		ProviderSnippet: providerSnippet,
+		OrgDependency:   orgDependency,
+		OrgID:           orgID,
+		UniqueID:        acctest.RandStringFromCharSet(8, acctest.CharSetAlpha),
+		Client:          client,
+		ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"zitadel": factory,
+			"echo":    echoprovider.NewProviderServer(),
+		},
+	}
+}

--- a/zitadel/ephemeral/ephtest/frame.go
+++ b/zitadel/ephemeral/ephtest/frame.go
@@ -124,17 +124,18 @@ KEY
 	// provider upgraded to protocol v6 (which hosts the managed dependency
 	// resources such as zitadel_project / zitadel_application_v2).
 	factory := func() (tfprotov6.ProviderServer, error) {
+		// Upgrade the SDKv2 provider to protocol v6 up front so a failure
+		// surfaces as a real error instead of being swallowed into a nil
+		// provider inside the mux (which would later nil-dereference).
+		upgraded, err := tf5to6server.UpgradeServer(ctx, func() tfprotov5.ProviderServer {
+			return zitadel.Provider().GRPCProvider()
+		})
+		if err != nil {
+			return nil, err
+		}
 		muxServer, err := tf6muxserver.NewMuxServer(ctx,
 			providerserver.NewProtocol6(zitadel.NewProviderPV6()),
-			func() tfprotov6.ProviderServer {
-				upgraded, uerr := tf5to6server.UpgradeServer(ctx, func() tfprotov5.ProviderServer {
-					return zitadel.Provider().GRPCProvider()
-				})
-				if uerr != nil {
-					return nil
-				}
-				return upgraded
-			},
+			func() tfprotov6.ProviderServer { return upgraded },
 		)
 		if err != nil {
 			return nil, err

--- a/zitadel/ephemeral/machine_key/resource.go
+++ b/zitadel/ephemeral/machine_key/resource.go
@@ -1,0 +1,122 @@
+// Package machine_key implements the zitadel_machine_key ephemeral resource.
+//
+// It creates a new (JSON) key for a machine (service) user and returns the
+// key_details for the duration of a single apply only, never writing them to
+// Terraform state (issue #413). "Rotation" for a key means minting a fresh one:
+// each evaluation of this ephemeral resource adds a new key to the user, so
+// gate it behind count/for_each to add a key only on demand. Old keys remain
+// valid until removed via the managed zitadel_machine_key resource or the API.
+package machine_key
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
+	ephschema "github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/authn"
+	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/management"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/helper"
+)
+
+var (
+	_ ephemeral.EphemeralResource              = &resourceImpl{}
+	_ ephemeral.EphemeralResourceWithConfigure = &resourceImpl{}
+)
+
+func New() ephemeral.EphemeralResource {
+	return &resourceImpl{}
+}
+
+type resourceImpl struct {
+	helper.EphemeralSecretBase
+}
+
+type model struct {
+	UserID         types.String `tfsdk:"user_id"`
+	OrgID          types.String `tfsdk:"org_id"`
+	ExpirationDate types.String `tfsdk:"expiration_date"`
+	KeyID          types.String `tfsdk:"key_id"`
+	KeyDetails     types.String `tfsdk:"key_details"`
+}
+
+func (r *resourceImpl) Metadata(_ context.Context, req ephemeral.MetadataRequest, resp *ephemeral.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_machine_key"
+}
+
+func (r *resourceImpl) Schema(_ context.Context, _ ephemeral.SchemaRequest, resp *ephemeral.SchemaResponse) {
+	resp.Schema = ephschema.Schema{
+		MarkdownDescription: "Creates a new JSON key for a machine (service) user and returns the key material without " +
+			"persisting it to Terraform state. Each evaluation adds a new key, so gate it behind `count`/`for_each`.",
+		Attributes: map[string]ephschema.Attribute{
+			"user_id": ephschema.StringAttribute{
+				Required:    true,
+				Description: "ID of the machine user the key is created for.",
+			},
+			"org_id": ephschema.StringAttribute{
+				Optional:    true,
+				Description: "ID of the organization that owns the machine user. Defaults to the organization of the authenticated user.",
+			},
+			"expiration_date": ephschema.StringAttribute{
+				Optional:    true,
+				Description: "Optional expiration date for the key, in RFC3339 format (e.g. 2519-04-01T08:45:00Z).",
+			},
+			"key_id": ephschema.StringAttribute{
+				Computed:    true,
+				Description: "ID of the generated key.",
+			},
+			"key_details": ephschema.StringAttribute{
+				Computed:    true,
+				Sensitive:   true,
+				Description: "The generated key material (JSON). Only available during apply; never stored in state.",
+			},
+		},
+	}
+}
+
+func (r *resourceImpl) Open(ctx context.Context, req ephemeral.OpenRequest, resp *ephemeral.OpenResponse) {
+	var data model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client, err := helper.GetManagementClient(ctx, r.ClientInfo)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to get client", err.Error())
+		return
+	}
+
+	if orgID := data.OrgID.ValueString(); orgID != "" {
+		ctx = helper.CtxSetOrgID(ctx, orgID)
+	}
+
+	zReq := &management.AddMachineKeyRequest{
+		UserId: data.UserID.ValueString(),
+		// Only JSON keys are supported by ZITADEL today, matching the managed
+		// zitadel_machine_key resource.
+		Type: authn.KeyType_KEY_TYPE_JSON,
+	}
+	if exp := data.ExpirationDate.ValueString(); exp != "" {
+		t, perr := time.Parse(time.RFC3339, exp)
+		if perr != nil {
+			resp.Diagnostics.AddError("failed to parse expiration_date", perr.Error())
+			return
+		}
+		zReq.ExpirationDate = timestamppb.New(t)
+	}
+
+	zResp, err := client.AddMachineKey(ctx, zReq)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to add machine key", err.Error())
+		return
+	}
+
+	data.KeyID = types.StringValue(zResp.GetKeyId())
+	// KeyDetails is the raw JSON key bytes; surface it as a string.
+	data.KeyDetails = types.StringValue(string(zResp.GetKeyDetails()))
+	resp.Diagnostics.Append(resp.Result.Set(ctx, &data)...)
+}

--- a/zitadel/ephemeral/machine_key/resource.go
+++ b/zitadel/ephemeral/machine_key/resource.go
@@ -115,8 +115,17 @@ func (r *resourceImpl) Open(ctx context.Context, req ephemeral.OpenRequest, resp
 		return
 	}
 
+	// Guard against an empty payload: the whole point of this resource is to
+	// return key material, so a missing key_details is a hard error rather than
+	// a silently empty result that would break downstream secret distribution.
+	keyDetails := zResp.GetKeyDetails()
+	if len(keyDetails) == 0 {
+		resp.Diagnostics.AddError("empty key material", "the server returned no key_details for the machine key")
+		return
+	}
+
 	data.KeyID = types.StringValue(zResp.GetKeyId())
 	// KeyDetails is the raw JSON key bytes; surface it as a string.
-	data.KeyDetails = types.StringValue(string(zResp.GetKeyDetails()))
+	data.KeyDetails = types.StringValue(string(keyDetails))
 	resp.Diagnostics.Append(resp.Result.Set(ctx, &data)...)
 }

--- a/zitadel/ephemeral/machine_key/resource_test.go
+++ b/zitadel/ephemeral/machine_key/resource_test.go
@@ -1,0 +1,56 @@
+package machine_key_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+
+	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/ephemeral/ephtest"
+)
+
+// TestAccMachineKey verifies the ephemeral resource creates a new JSON key for a
+// machine user and returns the key material. Note the ephemeral resource shares
+// the type name zitadel_machine_key with the managed resource; this test also
+// confirms the muxed provider serves both an `ephemeral` and a `resource` of
+// that name without conflict.
+func TestAccMachineKey(t *testing.T) {
+	frame := ephtest.NewOrgFrame(t)
+	config := fmt.Sprintf(`
+%s
+%s
+resource "zitadel_machine_user" "default" {
+  org_id      = data.zitadel_org.default.id
+  user_name   = "machine-%s@example.com"
+  name        = "machine-%s"
+  description = "ephemeral key test user"
+  with_secret = false
+}
+ephemeral "zitadel_machine_key" "test" {
+  user_id         = zitadel_machine_user.default.id
+  org_id          = data.zitadel_org.default.id
+  expiration_date = "2519-04-01T08:45:00Z"
+}
+provider "echo" {
+  data = ephemeral.zitadel_machine_key.test
+}
+resource "echo" "test" {}
+`, frame.ProviderSnippet, frame.OrgDependency, frame.UniqueID, frame.UniqueID)
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_10_0),
+		},
+		ProtoV6ProviderFactories: frame.ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("echo.test", "data.key_id"),
+					resource.TestCheckResourceAttrSet("echo.test", "data.key_details"),
+				),
+			},
+		},
+	})
+}

--- a/zitadel/ephemeral/machine_user_client_secret/resource.go
+++ b/zitadel/ephemeral/machine_user_client_secret/resource.go
@@ -1,0 +1,99 @@
+// Package machine_user_client_secret implements the
+// zitadel_machine_user_client_secret ephemeral resource.
+//
+// It generates a new client secret for a machine (service) user and returns
+// the client_id/client_secret pair for the duration of a single apply only,
+// never writing the secret to Terraform state (issue #413). Evaluating it
+// rotates the secret, so gate it behind count/for_each for on-demand rotation.
+package machine_user_client_secret
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
+	ephschema "github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/management"
+
+	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/helper"
+)
+
+var (
+	_ ephemeral.EphemeralResource              = &resourceImpl{}
+	_ ephemeral.EphemeralResourceWithConfigure = &resourceImpl{}
+)
+
+func New() ephemeral.EphemeralResource {
+	return &resourceImpl{}
+}
+
+type resourceImpl struct {
+	helper.EphemeralSecretBase
+}
+
+type model struct {
+	UserID       types.String `tfsdk:"user_id"`
+	OrgID        types.String `tfsdk:"org_id"`
+	ClientID     types.String `tfsdk:"client_id"`
+	ClientSecret types.String `tfsdk:"client_secret"`
+}
+
+func (r *resourceImpl) Metadata(_ context.Context, req ephemeral.MetadataRequest, resp *ephemeral.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_machine_user_client_secret"
+}
+
+func (r *resourceImpl) Schema(_ context.Context, _ ephemeral.SchemaRequest, resp *ephemeral.SchemaResponse) {
+	resp.Schema = ephschema.Schema{
+		MarkdownDescription: "Generates and returns a new client secret for a machine (service) user without persisting " +
+			"it to Terraform state. Evaluating this ephemeral resource rotates the secret.",
+		Attributes: map[string]ephschema.Attribute{
+			"user_id": ephschema.StringAttribute{
+				Required:    true,
+				Description: "ID of the machine user whose client secret should be generated.",
+			},
+			"org_id": ephschema.StringAttribute{
+				Optional:    true,
+				Description: "ID of the organization that owns the machine user. Defaults to the organization of the authenticated user.",
+			},
+			"client_id": ephschema.StringAttribute{
+				Computed:    true,
+				Description: "The client ID associated with the generated secret.",
+			},
+			"client_secret": ephschema.StringAttribute{
+				Computed:    true,
+				Sensitive:   true,
+				Description: "The newly generated client secret. Only available during apply; never stored in state.",
+			},
+		},
+	}
+}
+
+func (r *resourceImpl) Open(ctx context.Context, req ephemeral.OpenRequest, resp *ephemeral.OpenResponse) {
+	var data model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client, err := helper.GetManagementClient(ctx, r.ClientInfo)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to get client", err.Error())
+		return
+	}
+
+	if orgID := data.OrgID.ValueString(); orgID != "" {
+		ctx = helper.CtxSetOrgID(ctx, orgID)
+	}
+
+	zResp, err := client.GenerateMachineSecret(ctx, &management.GenerateMachineSecretRequest{
+		UserId: data.UserID.ValueString(),
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("failed to generate machine secret", err.Error())
+		return
+	}
+
+	data.ClientID = types.StringValue(zResp.GetClientId())
+	data.ClientSecret = types.StringValue(zResp.GetClientSecret())
+	resp.Diagnostics.Append(resp.Result.Set(ctx, &data)...)
+}

--- a/zitadel/ephemeral/machine_user_client_secret/resource_test.go
+++ b/zitadel/ephemeral/machine_user_client_secret/resource_test.go
@@ -1,0 +1,52 @@
+package machine_user_client_secret_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+
+	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/ephemeral/ephtest"
+)
+
+// TestAccMachineUserClientSecret verifies the ephemeral resource generates and
+// returns a fresh client_id/client_secret pair for a machine user.
+func TestAccMachineUserClientSecret(t *testing.T) {
+	frame := ephtest.NewOrgFrame(t)
+	config := fmt.Sprintf(`
+%s
+%s
+resource "zitadel_machine_user" "default" {
+  org_id      = data.zitadel_org.default.id
+  user_name   = "machine-%s@example.com"
+  name        = "machine-%s"
+  description = "ephemeral secret test user"
+  with_secret = false
+}
+ephemeral "zitadel_machine_user_client_secret" "test" {
+  user_id = zitadel_machine_user.default.id
+  org_id  = data.zitadel_org.default.id
+}
+provider "echo" {
+  data = ephemeral.zitadel_machine_user_client_secret.test
+}
+resource "echo" "test" {}
+`, frame.ProviderSnippet, frame.OrgDependency, frame.UniqueID, frame.UniqueID)
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_10_0),
+		},
+		ProtoV6ProviderFactories: frame.ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("echo.test", "data.client_id"),
+					resource.TestCheckResourceAttrSet("echo.test", "data.client_secret"),
+				),
+			},
+		},
+	})
+}

--- a/zitadel/ephemeral/organization_domain_validation/resource.go
+++ b/zitadel/ephemeral/organization_domain_validation/resource.go
@@ -1,0 +1,118 @@
+// Package organization_domain_validation implements the
+// zitadel_organization_domain_validation ephemeral resource.
+//
+// It (re)generates the verification token for an organization domain and
+// returns the token/url for the duration of a single apply only, never writing
+// the token to Terraform state (issue #413). Each evaluation generates a fresh
+// validation challenge, so gate it behind count/for_each to (re)issue only on
+// demand.
+package organization_domain_validation
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
+	ephschema "github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/management"
+	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/org"
+
+	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/helper"
+)
+
+var (
+	_ ephemeral.EphemeralResource              = &resourceImpl{}
+	_ ephemeral.EphemeralResourceWithConfigure = &resourceImpl{}
+)
+
+func New() ephemeral.EphemeralResource {
+	return &resourceImpl{}
+}
+
+type resourceImpl struct {
+	helper.EphemeralSecretBase
+}
+
+type model struct {
+	Domain         types.String `tfsdk:"domain"`
+	OrgID          types.String `tfsdk:"org_id"`
+	ValidationType types.String `tfsdk:"validation_type"`
+	Token          types.String `tfsdk:"token"`
+	URL            types.String `tfsdk:"url"`
+}
+
+func (r *resourceImpl) Metadata(_ context.Context, req ephemeral.MetadataRequest, resp *ephemeral.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_organization_domain_validation"
+}
+
+func (r *resourceImpl) Schema(_ context.Context, _ ephemeral.SchemaRequest, resp *ephemeral.SchemaResponse) {
+	resp.Schema = ephschema.Schema{
+		MarkdownDescription: "Generates and returns the verification token for an organization domain without persisting " +
+			"it to Terraform state. Each evaluation generates a fresh validation challenge.",
+		Attributes: map[string]ephschema.Attribute{
+			"domain": ephschema.StringAttribute{
+				Required:    true,
+				Description: "The organization domain to generate a validation token for.",
+			},
+			"org_id": ephschema.StringAttribute{
+				Optional:    true,
+				Description: "ID of the organization that owns the domain. Defaults to the organization of the authenticated user.",
+			},
+			"validation_type": ephschema.StringAttribute{
+				Required:    true,
+				Description: "Type of domain validation" + helper.DescriptionEnumValuesList(org.DomainValidationType_name),
+			},
+			"token": ephschema.StringAttribute{
+				Computed:    true,
+				Sensitive:   true,
+				Description: "The generated validation token. Only available during apply; never stored in state.",
+			},
+			"url": ephschema.StringAttribute{
+				Computed:    true,
+				Description: "The URL at which the token must be served (for HTTP validation).",
+			},
+		},
+	}
+}
+
+func (r *resourceImpl) Open(ctx context.Context, req ephemeral.OpenRequest, resp *ephemeral.OpenResponse) {
+	var data model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client, err := helper.GetManagementClient(ctx, r.ClientInfo)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to get client", err.Error())
+		return
+	}
+
+	if orgID := data.OrgID.ValueString(); orgID != "" {
+		ctx = helper.CtxSetOrgID(ctx, orgID)
+	}
+
+	// Map the enum name (e.g. DOMAIN_VALIDATION_TYPE_HTTP) to its numeric
+	// value, matching the managed zitadel_organization_domain resource. Reject
+	// an unknown name loudly rather than silently sending UNSPECIFIED.
+	validationType := data.ValidationType.ValueString()
+	typeVal, ok := org.DomainValidationType_value[validationType]
+	if !ok {
+		resp.Diagnostics.AddError("invalid validation_type", fmt.Sprintf("unknown validation type %q", validationType))
+		return
+	}
+
+	zResp, err := client.GenerateOrgDomainValidation(ctx, &management.GenerateOrgDomainValidationRequest{
+		Domain: data.Domain.ValueString(),
+		Type:   org.DomainValidationType(typeVal),
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("failed to generate org domain validation", err.Error())
+		return
+	}
+
+	data.Token = types.StringValue(zResp.GetToken())
+	data.URL = types.StringValue(zResp.GetUrl())
+	resp.Diagnostics.Append(resp.Result.Set(ctx, &data)...)
+}

--- a/zitadel/ephemeral/organization_domain_validation/resource_test.go
+++ b/zitadel/ephemeral/organization_domain_validation/resource_test.go
@@ -1,0 +1,66 @@
+package organization_domain_validation_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+
+	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/ephemeral/ephtest"
+)
+
+// TestAccOrganizationDomainValidation verifies the ephemeral resource
+// (re)generates the verification token for an organization domain. A fresh org
+// and an unverified domain are created first; the ephemeral resource then
+// generates a validation challenge for that domain.
+func TestAccOrganizationDomainValidation(t *testing.T) {
+	// Use the instance-level frame: its domain policy keeps added org domains
+	// unverified, so there is an actual validation challenge to (re)generate.
+	// The org-level instance auto-verifies domains, leaving nothing to validate.
+	frame := ephtest.NewInstanceFrame(t)
+	config := fmt.Sprintf(`
+%s
+resource "zitadel_organization" "default" {
+  name = "ephtest-%s"
+}
+# Force org-domain validation so an added domain stays unverified and there is
+# an actual challenge to (re)generate; otherwise the instance auto-verifies it.
+resource "zitadel_domain_policy" "default" {
+  org_id                                      = zitadel_organization.default.id
+  user_login_must_be_domain                   = false
+  validate_org_domains                        = true
+  smtp_sender_address_matches_instance_domain = false
+}
+resource "zitadel_organization_domain" "default" {
+  organization_id = zitadel_organization.default.id
+  domain          = "ephtest-%s.example.com"
+  validation_type = "DOMAIN_VALIDATION_TYPE_DNS"
+  depends_on      = [zitadel_domain_policy.default]
+}
+ephemeral "zitadel_organization_domain_validation" "test" {
+  org_id          = zitadel_organization.default.id
+  domain          = zitadel_organization_domain.default.domain
+  validation_type = "DOMAIN_VALIDATION_TYPE_DNS"
+}
+provider "echo" {
+  data = ephemeral.zitadel_organization_domain_validation.test
+}
+resource "echo" "test" {}
+`, frame.ProviderSnippet, frame.UniqueID, frame.UniqueID)
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_10_0),
+		},
+		ProtoV6ProviderFactories: frame.ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("echo.test", "data.token"),
+				),
+			},
+		},
+	})
+}

--- a/zitadel/ephemeral/personal_access_token/resource.go
+++ b/zitadel/ephemeral/personal_access_token/resource.go
@@ -1,12 +1,12 @@
 // Package personal_access_token implements the zitadel_personal_access_token
 // ephemeral resource.
 //
-// It creates a new personal access token (PAT) for a machine (service) user and
-// returns the token for the duration of a single apply only, never writing it
-// to Terraform state (issue #413). Each evaluation mints a new token, so gate
-// it behind count/for_each to issue a token only on demand. Existing tokens
-// remain valid until removed via the managed zitadel_personal_access_token
-// resource or the API.
+// It creates a new personal access token (PAT) for a user and returns the token
+// for the duration of a single apply only, never writing it to Terraform state
+// (issue #413). Each evaluation mints a new token, so gate it behind
+// count/for_each to issue a token only on demand. Existing tokens remain valid
+// until removed via the managed zitadel_personal_access_token resource or the
+// API.
 package personal_access_token
 
 import (
@@ -49,16 +49,16 @@ func (r *resourceImpl) Metadata(_ context.Context, req ephemeral.MetadataRequest
 
 func (r *resourceImpl) Schema(_ context.Context, _ ephemeral.SchemaRequest, resp *ephemeral.SchemaResponse) {
 	resp.Schema = ephschema.Schema{
-		MarkdownDescription: "Creates a new personal access token for a machine (service) user and returns it without " +
+		MarkdownDescription: "Creates a new personal access token for a user and returns it without " +
 			"persisting it to Terraform state. Each evaluation mints a new token, so gate it behind `count`/`for_each`.",
 		Attributes: map[string]ephschema.Attribute{
 			"user_id": ephschema.StringAttribute{
 				Required:    true,
-				Description: "ID of the machine user the token is created for.",
+				Description: "ID of the user the token is created for.",
 			},
 			"org_id": ephschema.StringAttribute{
 				Optional:    true,
-				Description: "ID of the organization that owns the machine user. Defaults to the organization of the authenticated user.",
+				Description: "ID of the organization that owns the user. Defaults to the organization of the authenticated user.",
 			},
 			"expiration_date": ephschema.StringAttribute{
 				Optional:    true,

--- a/zitadel/ephemeral/personal_access_token/resource.go
+++ b/zitadel/ephemeral/personal_access_token/resource.go
@@ -1,0 +1,118 @@
+// Package personal_access_token implements the zitadel_personal_access_token
+// ephemeral resource.
+//
+// It creates a new personal access token (PAT) for a machine (service) user and
+// returns the token for the duration of a single apply only, never writing it
+// to Terraform state (issue #413). Each evaluation mints a new token, so gate
+// it behind count/for_each to issue a token only on demand. Existing tokens
+// remain valid until removed via the managed zitadel_personal_access_token
+// resource or the API.
+package personal_access_token
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
+	ephschema "github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/management"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/helper"
+)
+
+var (
+	_ ephemeral.EphemeralResource              = &resourceImpl{}
+	_ ephemeral.EphemeralResourceWithConfigure = &resourceImpl{}
+)
+
+func New() ephemeral.EphemeralResource {
+	return &resourceImpl{}
+}
+
+type resourceImpl struct {
+	helper.EphemeralSecretBase
+}
+
+type model struct {
+	UserID         types.String `tfsdk:"user_id"`
+	OrgID          types.String `tfsdk:"org_id"`
+	ExpirationDate types.String `tfsdk:"expiration_date"`
+	TokenID        types.String `tfsdk:"token_id"`
+	Token          types.String `tfsdk:"token"`
+}
+
+func (r *resourceImpl) Metadata(_ context.Context, req ephemeral.MetadataRequest, resp *ephemeral.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_personal_access_token"
+}
+
+func (r *resourceImpl) Schema(_ context.Context, _ ephemeral.SchemaRequest, resp *ephemeral.SchemaResponse) {
+	resp.Schema = ephschema.Schema{
+		MarkdownDescription: "Creates a new personal access token for a machine (service) user and returns it without " +
+			"persisting it to Terraform state. Each evaluation mints a new token, so gate it behind `count`/`for_each`.",
+		Attributes: map[string]ephschema.Attribute{
+			"user_id": ephschema.StringAttribute{
+				Required:    true,
+				Description: "ID of the machine user the token is created for.",
+			},
+			"org_id": ephschema.StringAttribute{
+				Optional:    true,
+				Description: "ID of the organization that owns the machine user. Defaults to the organization of the authenticated user.",
+			},
+			"expiration_date": ephschema.StringAttribute{
+				Optional:    true,
+				Description: "Optional expiration date for the token, in RFC3339 format (e.g. 2519-04-01T08:45:00Z).",
+			},
+			"token_id": ephschema.StringAttribute{
+				Computed:    true,
+				Description: "ID of the generated token.",
+			},
+			"token": ephschema.StringAttribute{
+				Computed:    true,
+				Sensitive:   true,
+				Description: "The generated personal access token. Only available during apply; never stored in state.",
+			},
+		},
+	}
+}
+
+func (r *resourceImpl) Open(ctx context.Context, req ephemeral.OpenRequest, resp *ephemeral.OpenResponse) {
+	var data model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client, err := helper.GetManagementClient(ctx, r.ClientInfo)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to get client", err.Error())
+		return
+	}
+
+	if orgID := data.OrgID.ValueString(); orgID != "" {
+		ctx = helper.CtxSetOrgID(ctx, orgID)
+	}
+
+	zReq := &management.AddPersonalAccessTokenRequest{
+		UserId: data.UserID.ValueString(),
+	}
+	if exp := data.ExpirationDate.ValueString(); exp != "" {
+		t, perr := time.Parse(time.RFC3339, exp)
+		if perr != nil {
+			resp.Diagnostics.AddError("failed to parse expiration_date", perr.Error())
+			return
+		}
+		zReq.ExpirationDate = timestamppb.New(t)
+	}
+
+	zResp, err := client.AddPersonalAccessToken(ctx, zReq)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to add personal access token", err.Error())
+		return
+	}
+
+	data.TokenID = types.StringValue(zResp.GetTokenId())
+	data.Token = types.StringValue(zResp.GetToken())
+	resp.Diagnostics.Append(resp.Result.Set(ctx, &data)...)
+}

--- a/zitadel/ephemeral/personal_access_token/resource_test.go
+++ b/zitadel/ephemeral/personal_access_token/resource_test.go
@@ -1,0 +1,55 @@
+package personal_access_token_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+
+	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/ephemeral/ephtest"
+)
+
+// TestAccPersonalAccessToken verifies the ephemeral resource mints a new PAT for
+// a machine user and returns it. The type name zitadel_personal_access_token is
+// shared with the managed resource; this also confirms the muxed provider serves
+// both forms without conflict.
+func TestAccPersonalAccessToken(t *testing.T) {
+	frame := ephtest.NewOrgFrame(t)
+	config := fmt.Sprintf(`
+%s
+%s
+resource "zitadel_machine_user" "default" {
+  org_id      = data.zitadel_org.default.id
+  user_name   = "machine-%s@example.com"
+  name        = "machine-%s"
+  description = "ephemeral pat test user"
+  with_secret = false
+}
+ephemeral "zitadel_personal_access_token" "test" {
+  user_id         = zitadel_machine_user.default.id
+  org_id          = data.zitadel_org.default.id
+  expiration_date = "2519-04-01T08:45:00Z"
+}
+provider "echo" {
+  data = ephemeral.zitadel_personal_access_token.test
+}
+resource "echo" "test" {}
+`, frame.ProviderSnippet, frame.OrgDependency, frame.UniqueID, frame.UniqueID)
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_10_0),
+		},
+		ProtoV6ProviderFactories: frame.ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("echo.test", "data.token_id"),
+					resource.TestCheckResourceAttrSet("echo.test", "data.token"),
+				),
+			},
+		},
+	})
+}

--- a/zitadel/helper/ephemeral.go
+++ b/zitadel/helper/ephemeral.go
@@ -1,0 +1,44 @@
+package helper
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
+)
+
+// EphemeralSecretBase factors out the boilerplate every ephemeral secret
+// resource in this provider shares: capturing the configured *ClientInfo that
+// the provider hands down through Configure.
+//
+// The plugin-framework delivers provider-level data to an ephemeral resource
+// via provider.ConfigureResponse.EphemeralResourceData (a *different* field
+// from the ResourceData/DataSourceData used by managed resources and data
+// sources). The provider's Configure sets all three to the same *ClientInfo,
+// so embedding this base is all an ephemeral resource needs to obtain an
+// authenticated client.
+//
+// Ephemeral resources are how this provider lets operators mint or rotate a
+// generated credential (client secret, machine secret, key, PAT, domain
+// validation token) during a single `terraform apply` *without* persisting the
+// secret to Terraform state — unlike the equivalent managed resources, which
+// expose the generated secret as a Computed attribute and therefore write it
+// to the state file. See issue #413.
+type EphemeralSecretBase struct {
+	// ClientInfo is populated in Configure and read in each resource's Open.
+	// It is nil until Configure runs, which the framework guarantees happens
+	// before Open during a real apply.
+	ClientInfo *ClientInfo
+}
+
+// Configure stores the provider-supplied *ClientInfo on the embedding resource.
+//
+// req.ProviderData is nil during early validation walks (before the provider
+// itself is configured); we must tolerate that and simply return, exactly as
+// the managed framework resources do.
+func (b *EphemeralSecretBase) Configure(_ context.Context, req ephemeral.ConfigureRequest, _ *ephemeral.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	b.ClientInfo = req.ProviderData.(*ClientInfo)
+}

--- a/zitadel/provider.go
+++ b/zitadel/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	providerschema "github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -50,6 +51,14 @@ import (
 	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/domain_policy"
 	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/email_provider_http"
 	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/email_provider_smtp"
+	ephemeral_application_api_client_secret "github.com/zitadel/terraform-provider-zitadel/v2/zitadel/ephemeral/application_api_client_secret"
+	ephemeral_application_key "github.com/zitadel/terraform-provider-zitadel/v2/zitadel/ephemeral/application_key"
+	ephemeral_application_oidc_client_secret "github.com/zitadel/terraform-provider-zitadel/v2/zitadel/ephemeral/application_oidc_client_secret"
+	ephemeral_application_v2_client_secret "github.com/zitadel/terraform-provider-zitadel/v2/zitadel/ephemeral/application_v2_client_secret"
+	ephemeral_machine_key "github.com/zitadel/terraform-provider-zitadel/v2/zitadel/ephemeral/machine_key"
+	ephemeral_machine_user_client_secret "github.com/zitadel/terraform-provider-zitadel/v2/zitadel/ephemeral/machine_user_client_secret"
+	ephemeral_organization_domain_validation "github.com/zitadel/terraform-provider-zitadel/v2/zitadel/ephemeral/organization_domain_validation"
+	ephemeral_personal_access_token "github.com/zitadel/terraform-provider-zitadel/v2/zitadel/ephemeral/personal_access_token"
 	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/helper"
 	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/human_user"
 	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/idp_apple"
@@ -126,7 +135,10 @@ import (
 	active_webkey "github.com/zitadel/terraform-provider-zitadel/v2/zitadel/webkey/active"
 )
 
-var _ provider.Provider = (*providerPV6)(nil)
+var (
+	_ provider.Provider                       = (*providerPV6)(nil)
+	_ provider.ProviderWithEphemeralResources = (*providerPV6)(nil)
+)
 
 type providerPV6 struct {
 	customOptions []zitadelgo.Option
@@ -343,6 +355,9 @@ func (p *providerPV6) Configure(ctx context.Context, req provider.ConfigureReque
 
 	resp.DataSourceData = info
 	resp.ResourceData = info
+	// Ephemeral resources read provider data from a dedicated field; set it to
+	// the same *ClientInfo so the ephemeral secret resources can authenticate.
+	resp.EphemeralResourceData = info
 }
 
 func (p *providerPV6) DataSources(_ context.Context) []func() datasource.DataSource {
@@ -372,6 +387,24 @@ func (p *providerPV6) Resources(_ context.Context) []func() resource.Resource {
 		verify_email_otp_message_text.New,
 		verify_sms_otp_message_text.New,
 		default_invite_user_message_text.New,
+	}
+}
+
+// EphemeralResources registers the provider's ephemeral resources. Each one
+// mints or rotates a generated credential during apply and returns it without
+// ever writing it to Terraform state — the state-safe alternative to the
+// Computed `client_secret`/`token`/`key_details` attributes on the equivalent
+// managed resources (issue #413). Ephemeral resources require Terraform 1.10+.
+func (p *providerPV6) EphemeralResources(_ context.Context) []func() ephemeral.EphemeralResource {
+	return []func() ephemeral.EphemeralResource{
+		ephemeral_application_oidc_client_secret.New,
+		ephemeral_application_api_client_secret.New,
+		ephemeral_application_v2_client_secret.New,
+		ephemeral_machine_user_client_secret.New,
+		ephemeral_machine_key.New,
+		ephemeral_application_key.New,
+		ephemeral_personal_access_token.New,
+		ephemeral_organization_domain_validation.New,
 	}
 }
 


### PR DESCRIPTION
## Description

Adds eight **ephemeral resources** that mint or rotate a server-generated credential during `terraform apply` and return it **without writing it to Terraform state** — the state-safe alternative to the Computed `client_secret`/`token`/`key_details`/`validation_token` attributes on the equivalent managed resources, which persist the secret into (often shared) remote state. Closes #413.

Each evaluation rotates/mints the credential, so they are intended to be gated behind `count`/`for_each` for explicit, on-demand rotation.

| Ephemeral resource | Backing API | Returns |
| --- | --- | --- |
| `zitadel_application_oidc_client_secret` | `RegenerateOIDCClientSecret` | `client_secret` |
| `zitadel_application_api_client_secret` | `RegenerateAPIClientSecret` | `client_secret` |
| `zitadel_application_v2_client_secret` | `GenerateClientSecret` (app/v2) | `client_secret` |
| `zitadel_machine_user_client_secret` | `GenerateMachineSecret` | `client_id`, `client_secret` |
| `zitadel_machine_key` | `AddMachineKey` | `key_id`, `key_details` |
| `zitadel_application_key` | `AddAppKey` | `key_id`, `key_details` |
| `zitadel_personal_access_token` | `AddPersonalAccessToken` | `token_id`, `token` |
| `zitadel_organization_domain_validation` | `GenerateOrgDomainValidation` | `token`, `url` |

Ephemeral resources only exist in the plugin-framework, so they are registered on the framework half of the muxed provider (`NewProviderPV6`); no managed resource is migrated. The three `signing_key`s (`action_target`, `email_provider_http`, `sms_provider_http`) are intentionally **out of scope** — ZITADEL exposes no standalone regenerate RPC for them (they rotate only by updating the parent provider resource), so they cannot be modelled as ephemeral resources without a new server API.

### Verification

All eight resources have acceptance tests that drive a real `terraform apply` against a live ZITADEL instance, create the dependency objects, open the ephemeral resource, and assert the produced secret via the `echo` provider. Verified locally against `ghcr.io/zitadel/zitadel:v4.11.0` (8/8 passing) plus a hand-run `terraform apply` confirming the secret never lands in `terraform.tfstate`.

### Follow-ups (justified deviations)

- **Generated docs:** the pinned `tfplugindocs@v0.14.1` predates ephemeral-resource support and removes `docs/ephemeral-resources/` on `generate`, so registry docs are deferred to a follow-up that bumps `tfplugindocs` (≥ v0.19). Examples are included under `examples/ephemeral-resources/`. The existing doc test still passes.
- **Companion deprecation:** marking the managed `client_secret`/`token`/`key_details` attributes `Deprecated` (pointing at these ephemeral resources) is a separate, non-breaking follow-up.

### Definition of Ready

- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] All non-functional requirements are met
- [x] The generic lifecycle acceptance test passes for affected resources.
- [x] Examples are up-to-date and meaningful. The provider version is incremented.
- [ ] Docs are generated.
- [x] Code is generated where possible.
