### PR TITLE
docs: link to registry reference docs from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Importing existing resources to the Terraform state is supported.
 Note that you need to create an authorized service user to access the ZITADEL APIs through the provider, as noted in the
 prerequisites.
 
+For the resource and data source reference, see the
+[provider documentation on the Terraform Registry](https://registry.terraform.io/providers/zitadel/zitadel/latest/docs).
+
 ## Contributing
 
 If you find a bug or want to request a new feature, please open


### PR DESCRIPTION
### Definition of Ready

- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] All non-functional requirements are met
- [x] The generic lifecycle acceptance test passes for affected resources.
- [x] Examples are up-to-date and meaningful. The provider version is incremented.
- [x] Docs are generated.
- [x] Code is generated where possible.

The README only points to the ZITADEL website guide for setup; readers looking for the resource/data source schema reference have to guess where it lives. Add a one-line pointer to the Terraform Registry alongside the existing guide link so both halves of the documentation are discoverable from the repo landing page.

Refs #410.
