### PR TITLE
fix: scope human and machine users data sources by org_id

### DIFF
--- a/zitadel/human_user/datasource_test.go
+++ b/zitadel/human_user/datasource_test.go
@@ -255,6 +255,52 @@ data "zitadel_human_users" "default" {
 	)
 }
 
+func TestAccHumanUsersDatasource_ScopedByOrg(t *testing.T) {
+	frame := test_utils.NewOrgTestFrame(t, "zitadel_human_users")
+	otherFrame := frame.AnotherOrg(t, "human-users-scope-b-"+frame.UniqueResourcesID)
+
+	userName := "scopetest_" + frame.UniqueResourcesID
+
+	userA := fmt.Sprintf(`
+resource "zitadel_human_user" "user_a" {
+  org_id            = "%s"
+  user_name         = "a_%s@example.com"
+  first_name        = "Test"
+  last_name         = "User"
+  email             = "a_%s@example.com"
+  is_email_verified = true
+}`, frame.OrgID, userName, userName)
+
+	userB := fmt.Sprintf(`
+resource "zitadel_human_user" "user_b" {
+  org_id            = "%s"
+  user_name         = "b_%s@example.com"
+  first_name        = "Test"
+  last_name         = "User"
+  email             = "b_%s@example.com"
+  is_email_verified = true
+}`, otherFrame.OrgID, userName, userName)
+
+	config := fmt.Sprintf(`
+data "zitadel_human_users" "default" {
+  org_id           = "%s"
+  user_name        = "%s"
+  user_name_method = "TEXT_QUERY_METHOD_CONTAINS"
+  depends_on       = [zitadel_human_user.user_a, zitadel_human_user.user_b]
+}`, frame.OrgID, userName)
+
+	test_utils.RunDatasourceTest(
+		t,
+		frame.BaseTestFrame,
+		config,
+		[]string{userA, userB},
+		nil,
+		map[string]string{
+			"user_ids.#": "1",
+		},
+	)
+}
+
 func checkUserExists(frame *test_utils.OrgTestFrame, expectedUsername string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 		resp, err := frame.ListUsers(frame, &management.ListUsersRequest{})

--- a/zitadel/human_user/funcs.go
+++ b/zitadel/human_user/funcs.go
@@ -421,6 +421,16 @@ func list(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagn
 		},
 	})
 
+	if orgID, ok := d.GetOk(helper.OrgIDVar); ok {
+		queries = append(queries, &userv2.SearchQuery{
+			Query: &userv2.SearchQuery_OrganizationIdQuery{
+				OrganizationIdQuery: &userv2.OrganizationIdQuery{
+					OrganizationId: orgID.(string),
+				},
+			},
+		})
+	}
+
 	if userName, ok := d.GetOk(UserNameVar); ok {
 		userNameMethod := d.Get(userNameMethodVar).(string)
 		queries = append(queries, &userv2.SearchQuery{

--- a/zitadel/machine_user/datasource_test.go
+++ b/zitadel/machine_user/datasource_test.go
@@ -170,6 +170,46 @@ data "zitadel_machine_users" "default" {
 	)
 }
 
+func TestAccMachineUsersDatasource_ScopedByOrg(t *testing.T) {
+	frame := test_utils.NewOrgTestFrame(t, "zitadel_machine_users")
+	otherFrame := frame.AnotherOrg(t, "machine-users-scope-b-"+frame.UniqueResourcesID)
+
+	userName := "scopetest_" + frame.UniqueResourcesID
+
+	userA := fmt.Sprintf(`
+resource "zitadel_machine_user" "user_a" {
+  org_id    = "%s"
+  user_name = "a_%s@example.com"
+  name      = "Test Machine"
+}`, frame.OrgID, userName)
+
+	userB := fmt.Sprintf(`
+resource "zitadel_machine_user" "user_b" {
+  org_id    = "%s"
+  user_name = "b_%s@example.com"
+  name      = "Test Machine"
+}`, otherFrame.OrgID, userName)
+
+	config := fmt.Sprintf(`
+data "zitadel_machine_users" "default" {
+  org_id           = "%s"
+  user_name        = "%s"
+  user_name_method = "TEXT_QUERY_METHOD_CONTAINS"
+  depends_on       = [zitadel_machine_user.user_a, zitadel_machine_user.user_b]
+}`, frame.OrgID, userName)
+
+	test_utils.RunDatasourceTest(
+		t,
+		frame.BaseTestFrame,
+		config,
+		[]string{userA, userB},
+		nil,
+		map[string]string{
+			"user_ids.#": "1",
+		},
+	)
+}
+
 func checkUserExists(frame *test_utils.OrgTestFrame, expectedUsername string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 		resp, err := frame.ListUsers(frame, &management.ListUsersRequest{})

--- a/zitadel/machine_user/funcs.go
+++ b/zitadel/machine_user/funcs.go
@@ -311,6 +311,16 @@ func list(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagn
 		},
 	})
 
+	if orgID, ok := d.GetOk(helper.OrgIDVar); ok {
+		queries = append(queries, &userv2.SearchQuery{
+			Query: &userv2.SearchQuery_OrganizationIdQuery{
+				OrganizationIdQuery: &userv2.OrganizationIdQuery{
+					OrganizationId: orgID.(string),
+				},
+			},
+		})
+	}
+
 	if userName, ok := d.GetOk(UserNameVar); ok {
 		userNameMethod := d.Get(userNameMethodVar).(string)
 		queries = append(queries, &userv2.SearchQuery{


### PR DESCRIPTION
`zitadel_human_users` and `zitadel_machine_users` ignored `org_id`. With an instance-scoped token (e.g. IAM_OWNER), they returned users from all orgs in the instance.

Add a `SearchQuery_OrganizationIdQuery` to the request when `org_id` is set, matching how `zitadel_projects_v2` scopes results. Behavior is unchanged when `org_id` is omitted.


### Definition of Ready

- [x] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] All non-functional requirements are met
- [x] The generic lifecycle acceptance test passes for affected resources.
- [x] Examples are up-to-date and meaningful. The provider version is incremented.
- [x] Docs are generated.
- [x] Code is generated where possible.
