### PR TITLE
fix: don't treat transient read errors as project role deletion

### DIFF
--- a/zitadel/project_role/funcs.go
+++ b/zitadel/project_role/funcs.go
@@ -118,12 +118,20 @@ func read(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagn
 			}},
 		},
 	})
-	if err != nil || resp.Result == nil || len(resp.Result) == 0 {
+	if err != nil && helper.IgnoreIfNotFoundError(err) == nil {
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return diag.Errorf("failed to get project role: %v", err)
+	}
+
+	if resp.GetResult() == nil || len(resp.GetResult()) == 0 {
 		d.SetId("")
 		return nil
 	}
 
-	if len(resp.Result) == 1 {
+	if len(resp.GetResult()) == 1 {
 		projectRole := resp.GetResult()[0]
 		roleKey := projectRole.GetKey()
 		set := map[string]interface{}{


### PR DESCRIPTION
## Summary

`project_role`'s `read()` treated **any** error from `ListProjectRoles` — not just a genuine not-found — as proof the role had been deleted out-of-band, silently pruning it from state (`d.SetId("")`) and swallowing the actual error. A transient failure (DB unavailability, timeout, auth hiccup) during a plan's refresh pass would therefore get misread as an out-of-band deletion, corrupting state, rather than surfacing as a failed read.

This brings `project_role` in line with the pattern already used by `project` and `org`: only treat a confirmed `codes.NotFound` (via `helper.IgnoreIfNotFoundError`) as "resource is gone"; any other error is returned via `diag.Errorf` so Terraform reports a failed read instead of a false deletion.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./zitadel/project_role/...`
- [x] `gofmt` clean
- [ ] Existing acceptance tests (`TestAccProjectRole`, `TestAccProjectRoleDisplayNameUpdate`) — not run here (requires local Zitadel/Postgres via `docker compose`), but this change doesn't alter the happy-path behavior they exercise