### PR TITLE
fix: wait for eventually consistent v2 reads after writes

### DIFF
--- a/zitadel/action_execution_base/base_funcs.go
+++ b/zitadel/action_execution_base/base_funcs.go
@@ -2,6 +2,7 @@ package action_execution_base
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -29,31 +30,38 @@ func ReadExecutionBase(
 		return nil, diag.FromErr(err)
 	}
 
-	resp, err := client.ListExecutions(ctx, &action.ListExecutionsRequest{})
-	if err != nil {
-		return nil, diag.Errorf("failed to list executions: %v", err)
-	}
-
-	for _, execution := range resp.GetExecutions() {
-		idPtr, err := idFromCondition(execution.GetCondition())
+	id := helper.GetID(d, IDVar)
+	var found *action.Execution
+	// An execution set moments ago may not be listed by the query API yet, so wait for it to appear.
+	_, err = helper.RetryUntilFound(ctx, func() (bool, error) {
+		resp, err := client.ListExecutions(ctx, &action.ListExecutionsRequest{})
 		if err != nil {
-			return nil, diag.FromErr(err)
+			return false, fmt.Errorf("failed to list executions: %w", err)
 		}
-		if idPtr == nil {
-			// different execution type → skip
-			continue
-		}
-
-		if *idPtr == helper.GetID(d, IDVar) {
-			if len(execution.GetTargets()) == 0 {
-				d.SetId("")
-				return nil, nil
+		for _, execution := range resp.GetExecutions() {
+			idPtr, err := idFromCondition(execution.GetCondition())
+			if err != nil {
+				return false, err
 			}
-			d.SetId(*idPtr)
-			return execution, nil
+			if idPtr == nil {
+				// different execution type → skip
+				continue
+			}
+			if *idPtr == id {
+				found = execution
+				return true, nil
+			}
 		}
+		return false, nil
+	})
+	if err != nil {
+		return nil, diag.FromErr(err)
 	}
 
-	d.SetId("")
-	return nil, nil
+	if found == nil || len(found.GetTargets()) == 0 {
+		d.SetId("")
+		return nil, nil
+	}
+	d.SetId(id)
+	return found, nil
 }

--- a/zitadel/action_execution_base/funcs.go
+++ b/zitadel/action_execution_base/funcs.go
@@ -43,11 +43,21 @@ func NewSetExecution(buildCondition BuildConditionFunc, idFromCondition IdFromCo
 			}
 		}
 
-		// Validate all targets exist
+		// Validate all targets exist. A target created moments ago may not be
+		// visible to the query API yet, so wait for it to appear.
 		for _, targetID := range targetIDs {
-			_, err := client.GetTarget(ctx, &action.GetTargetRequest{Id: targetID})
+			found, err := helper.RetryUntilFound(ctx, func() (bool, error) {
+				_, err := client.GetTarget(ctx, &action.GetTargetRequest{Id: targetID})
+				if err != nil && helper.IgnoreIfNotFoundError(err) == nil {
+					return false, nil
+				}
+				return err == nil, err
+			})
 			if err != nil {
 				return diag.Errorf("target %s does not exist: %v", targetID, err)
+			}
+			if !found {
+				return diag.Errorf("target %s does not exist", targetID)
 			}
 		}
 

--- a/zitadel/action_target/funcs.go
+++ b/zitadel/action_target/funcs.go
@@ -189,16 +189,24 @@ func read(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagn
 		return diag.FromErr(err)
 	}
 
-	resp, err := client.GetTarget(ctx, &actionv2.GetTargetRequest{
-		Id: helper.GetID(d, TargetIDVar),
+	var resp *actionv2.GetTargetResponse
+	// A target created moments ago may not be visible to the query API yet, so wait for it to appear.
+	found, err := helper.RetryUntilFound(ctx, func() (bool, error) {
+		var err error
+		resp, err = client.GetTarget(ctx, &actionv2.GetTargetRequest{
+			Id: helper.GetID(d, TargetIDVar),
+		})
+		if err != nil && helper.IgnoreIfNotFoundError(err) == nil {
+			return false, nil
+		}
+		return err == nil, err
 	})
-
-	if err != nil && helper.IgnoreIfNotFoundError(err) == nil {
-		d.SetId("")
-		return nil
-	}
 	if err != nil {
 		return diag.Errorf("failed to get target: %v", err)
+	}
+	if !found {
+		d.SetId("")
+		return nil
 	}
 
 	target := resp.GetTarget()

--- a/zitadel/helper/consistency.go
+++ b/zitadel/helper/consistency.go
@@ -1,0 +1,37 @@
+package helper
+
+import (
+	"context"
+	"time"
+)
+
+const (
+	// eventualConsistencyTimeout bounds how long a read waits for ZITADEL's
+	// eventually consistent v2 query APIs to reflect a preceding write.
+	eventualConsistencyTimeout = 15 * time.Second
+	// eventualConsistencyInterval is the pause between two lookups.
+	eventualConsistencyInterval = 500 * time.Millisecond
+)
+
+// RetryUntilFound calls lookup until it reports the object as found, returns an
+// error, or the consistency timeout elapses. ZITADEL's v2 query APIs are served
+// from projections that can lag behind a write for a short moment, so an object
+// created by a preceding resource may not be visible immediately. Callers keep
+// their not-found semantics: when the timeout elapses, found is false and err is nil.
+func RetryUntilFound(ctx context.Context, lookup func() (found bool, err error)) (bool, error) {
+	deadline := time.Now().Add(eventualConsistencyTimeout)
+	for {
+		found, err := lookup()
+		if err != nil || found {
+			return found, err
+		}
+		if time.Now().After(deadline) {
+			return false, nil
+		}
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		case <-time.After(eventualConsistencyInterval):
+		}
+	}
+}

--- a/zitadel/helper/consistency_test.go
+++ b/zitadel/helper/consistency_test.go
@@ -1,0 +1,56 @@
+package helper
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestRetryUntilFound_ReturnsOnceFound(t *testing.T) {
+	calls := 0
+	found, err := RetryUntilFound(context.Background(), func() (bool, error) {
+		calls++
+		return calls == 3, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected found")
+	}
+	if calls != 3 {
+		t.Fatalf("expected 3 lookups, got %d", calls)
+	}
+}
+
+func TestRetryUntilFound_PropagatesError(t *testing.T) {
+	want := errors.New("boom")
+	calls := 0
+	found, err := RetryUntilFound(context.Background(), func() (bool, error) {
+		calls++
+		return false, want
+	})
+	if !errors.Is(err, want) {
+		t.Fatalf("expected %v, got %v", want, err)
+	}
+	if found {
+		t.Fatal("expected not found")
+	}
+	if calls != 1 {
+		t.Fatalf("expected a single lookup, got %d", calls)
+	}
+}
+
+func TestRetryUntilFound_StopsWhenContextIsCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	found, err := RetryUntilFound(ctx, func() (bool, error) {
+		return false, nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if found {
+		t.Fatal("expected not found")
+	}
+}

--- a/zitadel/organization/funcs.go
+++ b/zitadel/organization/funcs.go
@@ -118,33 +118,41 @@ func get(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagno
 	}
 	orgID := helper.GetID(d, OrgIDVar)
 	tflog.Info(ctx, fmt.Sprintf("Reading org ID: %s", orgID))
-	resp, err := client.ListOrganizations(ctx, &org.ListOrganizationsRequest{
-		Queries: []*org.SearchQuery{
-			{
-				Query: &org.SearchQuery_IdQuery{
-					IdQuery: &org.OrganizationIDQuery{
-						Id: orgID,
+	var remoteOrg *org.Organization
+	// An organization created moments ago may not be visible to the query API yet, so wait for it to appear.
+	found, err := helper.RetryUntilFound(ctx, func() (bool, error) {
+		resp, err := client.ListOrganizations(ctx, &org.ListOrganizationsRequest{
+			Queries: []*org.SearchQuery{
+				{
+					Query: &org.SearchQuery_IdQuery{
+						IdQuery: &org.OrganizationIDQuery{
+							Id: orgID,
+						},
 					},
 				},
 			},
-		},
+		})
+		if err != nil && helper.IgnoreIfNotFoundError(err) == nil {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		if len(resp.Result) == 0 {
+			return false, nil
+		}
+		remoteOrg = resp.Result[0]
+		return true, nil
 	})
-	if err != nil && helper.IgnoreIfNotFoundError(err) == nil {
-		tflog.Info(ctx, "Org not found, clearing from state")
-		d.SetId("")
-		return nil
-	}
 	if err != nil {
 		tflog.Error(ctx, fmt.Sprintf("Error getting org: %v", err))
 		return diag.Errorf("error while getting org by id %s: %v", orgID, err)
 	}
-
-	if len(resp.Result) == 0 {
-		tflog.Info(ctx, "Org not found in list, clearing from state")
+	if !found {
+		tflog.Info(ctx, "Org not found, clearing from state")
 		d.SetId("")
 		return nil
 	}
-	remoteOrg := resp.Result[0]
 
 	tflog.Info(ctx, "Org found, updating state")
 	d.SetId(remoteOrg.Id)


### PR DESCRIPTION
This pull request fixes the acceptance test flakiness that has been failing the `Test Provider` workflow on every recent pull request. ZITADEL's v2 query APIs (`GetTarget`, `ListExecutions`, `ListOrganizations`) are served from projections that can lag a write by a moment. When a Terraform configuration creates an action target, execution or organization and reads it in the same apply, the read intermittently returned not found: the data sources then cleared their ID and the plugin SDK test harness failed with `no "id" found in attributes`, and execution creation failed with `target ... does not exist`. Which tests failed varied from run to run, and all of them pass locally where the projection catches up faster.

The fix adds a small `helper.RetryUntilFound` that polls a lookup every 500ms for up to 15s until the object is visible, and applies it to the action target read, the shared execution read, the target validation when setting an execution, and the organization read. Callers keep their not-found semantics, so a genuinely missing object is still reported as absent once the window elapses. No schema or documentation changes.

Verified locally against `ghcr.io/zitadel/zitadel:v4.17.0`: the `action_execution_event`, `action_execution_function`, `action_execution_request`, `action_execution_response`, `action_target` and `organization` packages all pass, and the helper has unit tests.

### Definition of Ready

- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] All non-functional requirements are met
- [x] The generic lifecycle acceptance test passes for affected resources.
- [x] Examples are up-to-date and meaningful. The provider version is incremented.
- [x] Docs are generated.
- [x] Code is generated where possible.