### PR TITLE
fix: apply default policy settings on create even when config equals zero values

### DIFF
--- a/zitadel/default_domain_policy/funcs.go
+++ b/zitadel/default_domain_policy/funcs.go
@@ -30,7 +30,7 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 	}
 
 	id := ""
-	if d.HasChanges(UserLoginMustBeDomainVar, validateOrgDomainVar, smtpSenderVar) {
+	if d.IsNewResource() || d.HasChanges(UserLoginMustBeDomainVar, validateOrgDomainVar, smtpSenderVar) {
 		resp, err := client.UpdateDomainPolicy(ctx, &admin.UpdateDomainPolicyRequest{
 			UserLoginMustBeDomain:                  d.Get(UserLoginMustBeDomainVar).(bool),
 			ValidateOrgDomains:                     d.Get(validateOrgDomainVar).(bool),

--- a/zitadel/default_domain_policy/resource_test.go
+++ b/zitadel/default_domain_policy/resource_test.go
@@ -37,6 +37,41 @@ func TestAccDefaultDomainPolicy(t *testing.T) {
 	)
 }
 
+func TestAccDefaultDomainPolicyCreateZeroValues(t *testing.T) {
+	frame := test_utils.NewInstanceTestFrame(t, "zitadel_default_domain_policy")
+
+	zeroValuesConfig := fmt.Sprintf(`
+%s
+resource "zitadel_default_domain_policy" "default" {
+  user_login_must_be_domain                   = false
+  validate_org_domains                        = false
+  smtp_sender_address_matches_instance_domain = false
+}
+`, frame.ProviderSnippet)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: frame.V6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					if _, err := frame.UpdateDomainPolicy(frame, &admin.UpdateDomainPolicyRequest{
+						UserLoginMustBeDomain:                  true,
+						ValidateOrgDomains:                     false,
+						SmtpSenderAddressMatchesInstanceDomain: false,
+					}); helper.IgnorePreconditionError(err) != nil {
+						t.Fatalf("setting remote policy failed: %v", err)
+					}
+				},
+				Config: zeroValuesConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(frame.TerraformName, "user_login_must_be_domain", "false"),
+					test_utils.CheckAMinute(checkRemoteProperty(frame)(false)),
+				),
+			},
+		},
+	})
+}
+
 func checkRemoteProperty(frame *test_utils.InstanceTestFrame) func(bool) resource.TestCheckFunc {
 	return func(expect bool) resource.TestCheckFunc {
 		return func(state *terraform.State) error {

--- a/zitadel/default_domain_policy/resource_test.go
+++ b/zitadel/default_domain_policy/resource_test.go
@@ -40,7 +40,7 @@ func TestAccDefaultDomainPolicy(t *testing.T) {
 func TestAccDefaultDomainPolicyCreateZeroValues(t *testing.T) {
 	frame := test_utils.NewInstanceTestFrame(t, "zitadel_default_domain_policy")
 
-	zeroValuesConfig := fmt.Sprintf(`
+	resourceConfig := fmt.Sprintf(`
 %s
 resource "zitadel_default_domain_policy" "default" {
   user_login_must_be_domain                   = false
@@ -55,14 +55,12 @@ resource "zitadel_default_domain_policy" "default" {
 			{
 				PreConfig: func() {
 					if _, err := frame.UpdateDomainPolicy(frame, &admin.UpdateDomainPolicyRequest{
-						UserLoginMustBeDomain:                  true,
-						ValidateOrgDomains:                     false,
-						SmtpSenderAddressMatchesInstanceDomain: false,
-					}); helper.IgnorePreconditionError(err) != nil {
+						UserLoginMustBeDomain: true,
+					}); err != nil && helper.IgnorePreconditionError(err) != nil {
 						t.Fatalf("setting remote policy failed: %v", err)
 					}
 				},
-				Config: zeroValuesConfig,
+				Config: resourceConfig,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(frame.TerraformName, "user_login_must_be_domain", "false"),
 					test_utils.CheckAMinute(checkRemoteProperty(frame)(false)),

--- a/zitadel/default_label_policy/funcs.go
+++ b/zitadel/default_label_policy/funcs.go
@@ -31,7 +31,7 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 	}
 
 	id := ""
-	if d.HasChanges(
+	if d.IsNewResource() || d.HasChanges(
 		PrimaryColorVar,
 		hideLoginNameSuffixVar,
 		warnColorVar,
@@ -99,7 +99,7 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 		}
 	}
 
-	if d.HasChanges(
+	if d.IsNewResource() || d.HasChanges(
 		PrimaryColorVar,
 		hideLoginNameSuffixVar,
 		warnColorVar,

--- a/zitadel/default_lockout_policy/funcs.go
+++ b/zitadel/default_lockout_policy/funcs.go
@@ -32,7 +32,7 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 
 	id := ""
 	// Check if either property has changes to avoid unnecessary API calls
-	if d.HasChanges(MaxPasswordAttemptsVar, MaxOTPAttemptsVar) {
+	if d.IsNewResource() || d.HasChanges(MaxPasswordAttemptsVar, MaxOTPAttemptsVar) {
 		resp, err := client.UpdateLockoutPolicy(ctx, &admin.UpdateLockoutPolicyRequest{
 			MaxPasswordAttempts: uint32(d.Get(MaxPasswordAttemptsVar).(int)),
 			MaxOtpAttempts:      uint32(d.Get(MaxOTPAttemptsVar).(int)),

--- a/zitadel/default_lockout_policy/funcs.go
+++ b/zitadel/default_lockout_policy/funcs.go
@@ -31,7 +31,7 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 	}
 
 	id := ""
-	// Check if either property has changes to avoid unnecessary API calls
+	// Always call the API on create, otherwise only if either property has changes to avoid unnecessary API calls
 	if d.IsNewResource() || d.HasChanges(MaxPasswordAttemptsVar, MaxOTPAttemptsVar) {
 		resp, err := client.UpdateLockoutPolicy(ctx, &admin.UpdateLockoutPolicyRequest{
 			MaxPasswordAttempts: uint32(d.Get(MaxPasswordAttemptsVar).(int)),

--- a/zitadel/default_lockout_policy/resource_test.go
+++ b/zitadel/default_lockout_policy/resource_test.go
@@ -36,6 +36,38 @@ func TestAccDefaultLockoutPolicy(t *testing.T) {
 	)
 }
 
+func TestAccDefaultLockoutPolicyCreateZeroValues(t *testing.T) {
+	frame := test_utils.NewInstanceTestFrame(t, "zitadel_default_lockout_policy")
+
+	zeroValuesConfig := fmt.Sprintf(`
+%s
+resource "zitadel_default_lockout_policy" "default" {
+  max_password_attempts = 0
+}
+`, frame.ProviderSnippet)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: frame.V6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					if _, err := frame.UpdateLockoutPolicy(frame, &admin.UpdateLockoutPolicyRequest{
+						MaxPasswordAttempts: 5,
+						MaxOtpAttempts:      5,
+					}); helper.IgnorePreconditionError(err) != nil {
+						t.Fatalf("setting remote policy failed: %v", err)
+					}
+				},
+				Config: zeroValuesConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(frame.TerraformName, "max_password_attempts", "0"),
+					test_utils.CheckAMinute(checkRemoteProperty(frame)(0)),
+				),
+			},
+		},
+	})
+}
+
 func checkRemoteProperty(frame *test_utils.InstanceTestFrame) func(uint64) resource.TestCheckFunc {
 	return func(expect uint64) resource.TestCheckFunc {
 		return func(state *terraform.State) error {

--- a/zitadel/default_lockout_policy/resource_test.go
+++ b/zitadel/default_lockout_policy/resource_test.go
@@ -39,7 +39,7 @@ func TestAccDefaultLockoutPolicy(t *testing.T) {
 func TestAccDefaultLockoutPolicyCreateZeroValues(t *testing.T) {
 	frame := test_utils.NewInstanceTestFrame(t, "zitadel_default_lockout_policy")
 
-	zeroValuesConfig := fmt.Sprintf(`
+	resourceConfig := fmt.Sprintf(`
 %s
 resource "zitadel_default_lockout_policy" "default" {
   max_password_attempts = 0
@@ -54,11 +54,11 @@ resource "zitadel_default_lockout_policy" "default" {
 					if _, err := frame.UpdateLockoutPolicy(frame, &admin.UpdateLockoutPolicyRequest{
 						MaxPasswordAttempts: 5,
 						MaxOtpAttempts:      5,
-					}); helper.IgnorePreconditionError(err) != nil {
+					}); err != nil && helper.IgnorePreconditionError(err) != nil {
 						t.Fatalf("setting remote policy failed: %v", err)
 					}
 				},
-				Config: zeroValuesConfig,
+				Config: resourceConfig,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(frame.TerraformName, "max_password_attempts", "0"),
 					test_utils.CheckAMinute(checkRemoteProperty(frame)(0)),

--- a/zitadel/default_login_policy/funcs.go
+++ b/zitadel/default_login_policy/funcs.go
@@ -33,7 +33,7 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 	}
 
 	id := ""
-	if d.HasChanges(passwordCheckLifetimeVar,
+	if d.IsNewResource() || d.HasChanges(passwordCheckLifetimeVar,
 		externalLoginCheckLifetimeVar,
 		mfaInitSkipLifetimeVar,
 		secondFactorCheckLifetimeVar,
@@ -107,7 +107,7 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 	}
 	d.SetId(id)
 
-	if d.HasChange(secondFactorsVar) {
+	if d.IsNewResource() || d.HasChange(secondFactorsVar) {
 		o, err := client.ListLoginPolicySecondFactors(ctx, &admin.ListLoginPolicySecondFactorsRequest{})
 		if err != nil {
 			return diag.Errorf("failed to get default login policy second factors: %v", err)
@@ -134,7 +134,7 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 		}
 	}
 
-	if d.HasChange(multiFactorsVar) {
+	if d.IsNewResource() || d.HasChange(multiFactorsVar) {
 		o, err := client.ListLoginPolicyMultiFactors(ctx, &admin.ListLoginPolicyMultiFactorsRequest{})
 		if err != nil {
 			return diag.Errorf("failed to get default login policy multi factors: %v", err)
@@ -161,7 +161,7 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 		}
 	}
 
-	if d.HasChange(idpsVar) {
+	if d.IsNewResource() || d.HasChange(idpsVar) {
 		o, err := client.ListLoginPolicyIDPs(ctx, &admin.ListLoginPolicyIDPsRequest{})
 		if err != nil {
 			return diag.Errorf("failed to get default login policy idps: %v", err)

--- a/zitadel/default_login_policy/resource_test.go
+++ b/zitadel/default_login_policy/resource_test.go
@@ -41,7 +41,7 @@ func TestAccDefaultLoginPolicyCreateZeroValues(t *testing.T) {
 	frame := test_utils.NewInstanceTestFrame(t, "zitadel_default_login_policy")
 	_, googleID := idp_google_test_dep.Create(t, frame.BaseTestFrame, frame)
 
-	zeroValuesConfig := fmt.Sprintf(`
+	resourceConfig := fmt.Sprintf(`
 %s
 resource "zitadel_default_login_policy" "default" {
   user_login                    = true
@@ -50,7 +50,7 @@ resource "zitadel_default_login_policy" "default" {
   force_mfa                     = false
   force_mfa_local_only          = false
   passwordless_type             = "PASSWORDLESS_TYPE_ALLOWED"
-  hide_password_reset           = "false"
+  hide_password_reset           = false
   password_check_lifetime       = "240h0m0s"
   external_login_check_lifetime = "240h0m0s"
   multi_factor_check_lifetime   = "24h0m0s"
@@ -74,21 +74,21 @@ resource "zitadel_default_login_policy" "default" {
 				PreConfig: func() {
 					if _, err := frame.AddSecondFactorToLoginPolicy(frame, &admin.AddSecondFactorToLoginPolicyRequest{
 						Type: policy.SecondFactorType_SECOND_FACTOR_TYPE_OTP,
-					}); helper.IgnoreAlreadyExistsError(err) != nil {
+					}); err != nil && helper.IgnoreAlreadyExistsError(err) != nil {
 						t.Fatalf("adding remote second factor failed: %v", err)
 					}
 					if _, err := frame.AddMultiFactorToLoginPolicy(frame, &admin.AddMultiFactorToLoginPolicyRequest{
 						Type: policy.MultiFactorType_MULTI_FACTOR_TYPE_U2F_WITH_VERIFICATION,
-					}); helper.IgnoreAlreadyExistsError(err) != nil {
+					}); err != nil && helper.IgnoreAlreadyExistsError(err) != nil {
 						t.Fatalf("adding remote multi factor failed: %v", err)
 					}
 					if _, err := frame.AddIDPToLoginPolicy(frame, &admin.AddIDPToLoginPolicyRequest{
 						IdpId: googleID,
-					}); helper.IgnoreAlreadyExistsError(err) != nil {
+					}); err != nil && helper.IgnoreAlreadyExistsError(err) != nil {
 						t.Fatalf("adding remote idp failed: %v", err)
 					}
 				},
-				Config: zeroValuesConfig,
+				Config: resourceConfig,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(frame.TerraformName, "second_factors.#", "0"),
 					resource.TestCheckResourceAttr(frame.TerraformName, "multi_factors.#", "0"),
@@ -102,6 +102,22 @@ resource "zitadel_default_login_policy" "default" {
 	})
 }
 
+func checkRemoteProperty(frame *test_utils.InstanceTestFrame) func(string) resource.TestCheckFunc {
+	return func(expect string) resource.TestCheckFunc {
+		return func(state *terraform.State) error {
+			resp, err := frame.GetLoginPolicy(frame, &admin.GetLoginPolicyRequest{})
+			if err != nil {
+				return fmt.Errorf("getting policy failed: %w", err)
+			}
+			actual := resp.GetPolicy().GetDefaultRedirectUri()
+			if actual != expect {
+				return fmt.Errorf("expected %s, but got %s", expect, actual)
+			}
+			return nil
+		}
+	}
+}
+
 func checkRemoteSecondFactors(frame *test_utils.InstanceTestFrame) func(int) resource.TestCheckFunc {
 	return func(expect int) resource.TestCheckFunc {
 		return func(state *terraform.State) error {
@@ -111,7 +127,7 @@ func checkRemoteSecondFactors(frame *test_utils.InstanceTestFrame) func(int) res
 			}
 			actual := len(resp.GetResult())
 			if actual != expect {
-				return fmt.Errorf("expected %d second factors, but got %d: %v", expect, actual, resp.GetResult())
+				return fmt.Errorf("expected %d, but got %d", expect, actual)
 			}
 			return nil
 		}
@@ -127,7 +143,7 @@ func checkRemoteMultiFactors(frame *test_utils.InstanceTestFrame) func(int) reso
 			}
 			actual := len(resp.GetResult())
 			if actual != expect {
-				return fmt.Errorf("expected %d multi factors, but got %d: %v", expect, actual, resp.GetResult())
+				return fmt.Errorf("expected %d, but got %d", expect, actual)
 			}
 			return nil
 		}
@@ -143,23 +159,7 @@ func checkRemoteIDPs(frame *test_utils.InstanceTestFrame) func(int) resource.Tes
 			}
 			actual := len(resp.GetResult())
 			if actual != expect {
-				return fmt.Errorf("expected %d idps, but got %d: %v", expect, actual, resp.GetResult())
-			}
-			return nil
-		}
-	}
-}
-
-func checkRemoteProperty(frame *test_utils.InstanceTestFrame) func(string) resource.TestCheckFunc {
-	return func(expect string) resource.TestCheckFunc {
-		return func(state *terraform.State) error {
-			resp, err := frame.GetLoginPolicy(frame, &admin.GetLoginPolicyRequest{})
-			if err != nil {
-				return fmt.Errorf("getting policy failed: %w", err)
-			}
-			actual := resp.GetPolicy().GetDefaultRedirectUri()
-			if actual != expect {
-				return fmt.Errorf("expected %s, but got %s", expect, actual)
+				return fmt.Errorf("expected %d, but got %d", expect, actual)
 			}
 			return nil
 		}

--- a/zitadel/default_login_policy/resource_test.go
+++ b/zitadel/default_login_policy/resource_test.go
@@ -39,6 +39,7 @@ func TestAccDefaultLoginPolicy(t *testing.T) {
 
 func TestAccDefaultLoginPolicyCreateZeroValues(t *testing.T) {
 	frame := test_utils.NewInstanceTestFrame(t, "zitadel_default_login_policy")
+	_, googleID := idp_google_test_dep.Create(t, frame.BaseTestFrame, frame)
 
 	zeroValuesConfig := fmt.Sprintf(`
 %s
@@ -59,6 +60,7 @@ resource "zitadel_default_login_policy" "default" {
   default_redirect_uri          = "localhost:8080"
   second_factors                = []
   multi_factors                 = []
+  idps                          = []
   allow_domain_discovery        = true
   disable_login_with_email      = true
   disable_login_with_phone      = true
@@ -80,13 +82,20 @@ resource "zitadel_default_login_policy" "default" {
 					}); helper.IgnoreAlreadyExistsError(err) != nil {
 						t.Fatalf("adding remote multi factor failed: %v", err)
 					}
+					if _, err := frame.AddIDPToLoginPolicy(frame, &admin.AddIDPToLoginPolicyRequest{
+						IdpId: googleID,
+					}); helper.IgnoreAlreadyExistsError(err) != nil {
+						t.Fatalf("adding remote idp failed: %v", err)
+					}
 				},
 				Config: zeroValuesConfig,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(frame.TerraformName, "second_factors.#", "0"),
 					resource.TestCheckResourceAttr(frame.TerraformName, "multi_factors.#", "0"),
+					resource.TestCheckResourceAttr(frame.TerraformName, "idps.#", "0"),
 					test_utils.CheckAMinute(checkRemoteSecondFactors(frame)(0)),
 					test_utils.CheckAMinute(checkRemoteMultiFactors(frame)(0)),
+					test_utils.CheckAMinute(checkRemoteIDPs(frame)(0)),
 				),
 			},
 		},
@@ -119,6 +128,22 @@ func checkRemoteMultiFactors(frame *test_utils.InstanceTestFrame) func(int) reso
 			actual := len(resp.GetResult())
 			if actual != expect {
 				return fmt.Errorf("expected %d multi factors, but got %d: %v", expect, actual, resp.GetResult())
+			}
+			return nil
+		}
+	}
+}
+
+func checkRemoteIDPs(frame *test_utils.InstanceTestFrame) func(int) resource.TestCheckFunc {
+	return func(expect int) resource.TestCheckFunc {
+		return func(state *terraform.State) error {
+			resp, err := frame.ListLoginPolicyIDPs(frame, &admin.ListLoginPolicyIDPsRequest{})
+			if err != nil {
+				return fmt.Errorf("listing idps failed: %w", err)
+			}
+			actual := len(resp.GetResult())
+			if actual != expect {
+				return fmt.Errorf("expected %d idps, but got %d: %v", expect, actual, resp.GetResult())
 			}
 			return nil
 		}

--- a/zitadel/default_login_policy/resource_test.go
+++ b/zitadel/default_login_policy/resource_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/admin"
+	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/policy"
 
 	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/default_login_policy"
 	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel/helper"
@@ -34,6 +35,94 @@ func TestAccDefaultLoginPolicy(t *testing.T) {
 		test_utils.CheckNothing,
 		test_utils.ImportNothing,
 	)
+}
+
+func TestAccDefaultLoginPolicyCreateZeroValues(t *testing.T) {
+	frame := test_utils.NewInstanceTestFrame(t, "zitadel_default_login_policy")
+
+	zeroValuesConfig := fmt.Sprintf(`
+%s
+resource "zitadel_default_login_policy" "default" {
+  user_login                    = true
+  allow_register                = true
+  allow_external_idp            = true
+  force_mfa                     = false
+  force_mfa_local_only          = false
+  passwordless_type             = "PASSWORDLESS_TYPE_ALLOWED"
+  hide_password_reset           = "false"
+  password_check_lifetime       = "240h0m0s"
+  external_login_check_lifetime = "240h0m0s"
+  multi_factor_check_lifetime   = "24h0m0s"
+  mfa_init_skip_lifetime        = "720h0m0s"
+  second_factor_check_lifetime  = "24h0m0s"
+  ignore_unknown_usernames      = true
+  default_redirect_uri          = "localhost:8080"
+  second_factors                = []
+  multi_factors                 = []
+  allow_domain_discovery        = true
+  disable_login_with_email      = true
+  disable_login_with_phone      = true
+}
+`, frame.ProviderSnippet)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: frame.V6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					if _, err := frame.AddSecondFactorToLoginPolicy(frame, &admin.AddSecondFactorToLoginPolicyRequest{
+						Type: policy.SecondFactorType_SECOND_FACTOR_TYPE_OTP,
+					}); helper.IgnoreAlreadyExistsError(err) != nil {
+						t.Fatalf("adding remote second factor failed: %v", err)
+					}
+					if _, err := frame.AddMultiFactorToLoginPolicy(frame, &admin.AddMultiFactorToLoginPolicyRequest{
+						Type: policy.MultiFactorType_MULTI_FACTOR_TYPE_U2F_WITH_VERIFICATION,
+					}); helper.IgnoreAlreadyExistsError(err) != nil {
+						t.Fatalf("adding remote multi factor failed: %v", err)
+					}
+				},
+				Config: zeroValuesConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(frame.TerraformName, "second_factors.#", "0"),
+					resource.TestCheckResourceAttr(frame.TerraformName, "multi_factors.#", "0"),
+					test_utils.CheckAMinute(checkRemoteSecondFactors(frame)(0)),
+					test_utils.CheckAMinute(checkRemoteMultiFactors(frame)(0)),
+				),
+			},
+		},
+	})
+}
+
+func checkRemoteSecondFactors(frame *test_utils.InstanceTestFrame) func(int) resource.TestCheckFunc {
+	return func(expect int) resource.TestCheckFunc {
+		return func(state *terraform.State) error {
+			resp, err := frame.ListLoginPolicySecondFactors(frame, &admin.ListLoginPolicySecondFactorsRequest{})
+			if err != nil {
+				return fmt.Errorf("listing second factors failed: %w", err)
+			}
+			actual := len(resp.GetResult())
+			if actual != expect {
+				return fmt.Errorf("expected %d second factors, but got %d: %v", expect, actual, resp.GetResult())
+			}
+			return nil
+		}
+	}
+}
+
+func checkRemoteMultiFactors(frame *test_utils.InstanceTestFrame) func(int) resource.TestCheckFunc {
+	return func(expect int) resource.TestCheckFunc {
+		return func(state *terraform.State) error {
+			resp, err := frame.ListLoginPolicyMultiFactors(frame, &admin.ListLoginPolicyMultiFactorsRequest{})
+			if err != nil {
+				return fmt.Errorf("listing multi factors failed: %w", err)
+			}
+			actual := len(resp.GetResult())
+			if actual != expect {
+				return fmt.Errorf("expected %d multi factors, but got %d: %v", expect, actual, resp.GetResult())
+			}
+			return nil
+		}
+	}
 }
 
 func checkRemoteProperty(frame *test_utils.InstanceTestFrame) func(string) resource.TestCheckFunc {

--- a/zitadel/default_notification_policy/funcs.go
+++ b/zitadel/default_notification_policy/funcs.go
@@ -29,7 +29,7 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 		return diag.FromErr(err)
 	}
 
-	if d.HasChanges(passwordChangeVar) {
+	if d.IsNewResource() || d.HasChanges(passwordChangeVar) {
 		resp, err := client.UpdateNotificationPolicy(ctx, &admin.UpdateNotificationPolicyRequest{
 			PasswordChange: d.Get(passwordChangeVar).(bool),
 		})

--- a/zitadel/default_notification_policy/resource_test.go
+++ b/zitadel/default_notification_policy/resource_test.go
@@ -33,6 +33,37 @@ func TestAccDefaultNotificationPolicy(t *testing.T) {
 	)
 }
 
+func TestAccDefaultNotificationPolicyCreateZeroValues(t *testing.T) {
+	frame := test_utils.NewInstanceTestFrame(t, "zitadel_default_notification_policy")
+
+	zeroValuesConfig := fmt.Sprintf(`
+%s
+resource "zitadel_default_notification_policy" "default" {
+  password_change = false
+}
+`, frame.ProviderSnippet)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: frame.V6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					if _, err := frame.UpdateNotificationPolicy(frame, &admin.UpdateNotificationPolicyRequest{
+						PasswordChange: true,
+					}); helper.IgnorePreconditionError(err) != nil {
+						t.Fatalf("setting remote policy failed: %v", err)
+					}
+				},
+				Config: zeroValuesConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(frame.TerraformName, "password_change", "false"),
+					test_utils.CheckAMinute(checkRemoteProperty(frame)(false)),
+				),
+			},
+		},
+	})
+}
+
 func checkRemoteProperty(frame *test_utils.InstanceTestFrame) func(bool) resource.TestCheckFunc {
 	return func(expect bool) resource.TestCheckFunc {
 		return func(state *terraform.State) error {

--- a/zitadel/default_notification_policy/resource_test.go
+++ b/zitadel/default_notification_policy/resource_test.go
@@ -36,7 +36,7 @@ func TestAccDefaultNotificationPolicy(t *testing.T) {
 func TestAccDefaultNotificationPolicyCreateZeroValues(t *testing.T) {
 	frame := test_utils.NewInstanceTestFrame(t, "zitadel_default_notification_policy")
 
-	zeroValuesConfig := fmt.Sprintf(`
+	resourceConfig := fmt.Sprintf(`
 %s
 resource "zitadel_default_notification_policy" "default" {
   password_change = false
@@ -50,11 +50,11 @@ resource "zitadel_default_notification_policy" "default" {
 				PreConfig: func() {
 					if _, err := frame.UpdateNotificationPolicy(frame, &admin.UpdateNotificationPolicyRequest{
 						PasswordChange: true,
-					}); helper.IgnorePreconditionError(err) != nil {
+					}); err != nil && helper.IgnorePreconditionError(err) != nil {
 						t.Fatalf("setting remote policy failed: %v", err)
 					}
 				},
-				Config: zeroValuesConfig,
+				Config: resourceConfig,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(frame.TerraformName, "password_change", "false"),
 					test_utils.CheckAMinute(checkRemoteProperty(frame)(false)),

--- a/zitadel/default_password_age_policy/funcs.go
+++ b/zitadel/default_password_age_policy/funcs.go
@@ -37,10 +37,6 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 		}
 
 		resp, err := client.UpdatePasswordAgePolicy(ctx, &req)
-		if err != nil {
-			return diag.Errorf("failed to update default password age policy: %v", err)
-		}
-
 		if helper.IgnorePreconditionError(err) != nil {
 			return diag.Errorf("failed to update default password age policy: %v", err)
 		}
@@ -53,7 +49,7 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 	if id == "" {
 		resp, err := client.GetPasswordAgePolicy(ctx, &admin.GetPasswordAgePolicyRequest{})
 		if err != nil {
-			return diag.Errorf("failed to get default password complexity policy: %v", err)
+			return diag.Errorf("failed to get default password age policy: %v", err)
 		}
 
 		id = resp.GetPolicy().GetDetails().GetResourceOwner()

--- a/zitadel/default_password_age_policy/funcs.go
+++ b/zitadel/default_password_age_policy/funcs.go
@@ -30,7 +30,7 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 	}
 
 	id := ""
-	if d.HasChanges(maxAgeDays, expireWarnDays) {
+	if d.IsNewResource() || d.HasChanges(maxAgeDays, expireWarnDays) {
 		req := admin.UpdatePasswordAgePolicyRequest{
 			MaxAgeDays:     uint32(d.Get(maxAgeDays).(int)),
 			ExpireWarnDays: uint32(d.Get(expireWarnDays).(int)),

--- a/zitadel/default_password_age_policy/resource_test.go
+++ b/zitadel/default_password_age_policy/resource_test.go
@@ -39,10 +39,10 @@ func TestDefaultPasswordAgePolicy(t *testing.T) {
 	)
 }
 
-func TestDefaultPasswordAgePolicyCreateZeroValues(t *testing.T) {
+func TestAccDefaultPasswordAgePolicyCreateZeroValues(t *testing.T) {
 	frame := test_utils.NewOrgTestFrame(t, "zitadel_default_password_age_policy")
 
-	zeroValuesConfig := fmt.Sprintf(`
+	resourceConfig := fmt.Sprintf(`
 %s
 resource "zitadel_default_password_age_policy" "default" {
   max_age_days     = 0
@@ -58,11 +58,11 @@ resource "zitadel_default_password_age_policy" "default" {
 					if _, err := frame.Admin.UpdatePasswordAgePolicy(frame, &admin.UpdatePasswordAgePolicyRequest{
 						MaxAgeDays:     30,
 						ExpireWarnDays: 5,
-					}); helper.IgnorePreconditionError(err) != nil {
+					}); err != nil && helper.IgnorePreconditionError(err) != nil {
 						t.Fatalf("setting remote policy failed: %v", err)
 					}
 				},
-				Config: zeroValuesConfig,
+				Config: resourceConfig,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(frame.TerraformName, "max_age_days", "0"),
 					test_utils.CheckAMinute(checkRemoteProperty(frame)(0)),

--- a/zitadel/default_password_age_policy/resource_test.go
+++ b/zitadel/default_password_age_policy/resource_test.go
@@ -39,6 +39,39 @@ func TestDefaultPasswordAgePolicy(t *testing.T) {
 	)
 }
 
+func TestDefaultPasswordAgePolicyCreateZeroValues(t *testing.T) {
+	frame := test_utils.NewOrgTestFrame(t, "zitadel_default_password_age_policy")
+
+	zeroValuesConfig := fmt.Sprintf(`
+%s
+resource "zitadel_default_password_age_policy" "default" {
+  max_age_days     = 0
+  expire_warn_days = 0
+}
+`, frame.ProviderSnippet)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: frame.V6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					if _, err := frame.Admin.UpdatePasswordAgePolicy(frame, &admin.UpdatePasswordAgePolicyRequest{
+						MaxAgeDays:     30,
+						ExpireWarnDays: 5,
+					}); helper.IgnorePreconditionError(err) != nil {
+						t.Fatalf("setting remote policy failed: %v", err)
+					}
+				},
+				Config: zeroValuesConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(frame.TerraformName, "max_age_days", "0"),
+					test_utils.CheckAMinute(checkRemoteProperty(frame)(0)),
+				),
+			},
+		},
+	})
+}
+
 func checkRemoteProperty(frame *test_utils.OrgTestFrame) func(uint64) resource.TestCheckFunc {
 	return func(expect uint64) resource.TestCheckFunc {
 		return func(state *terraform.State) error {

--- a/zitadel/default_password_complexity_policy/funcs.go
+++ b/zitadel/default_password_complexity_policy/funcs.go
@@ -30,7 +30,7 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 	}
 
 	id := ""
-	if d.HasChanges(MinLengthVar, hasUppercaseVar, hasLowercaseVar, hasNumberVar, hasSymbolVar) {
+	if d.IsNewResource() || d.HasChanges(MinLengthVar, hasUppercaseVar, hasLowercaseVar, hasNumberVar, hasSymbolVar) {
 		resp, err := client.UpdatePasswordComplexityPolicy(ctx, &admin.UpdatePasswordComplexityPolicyRequest{
 			MinLength:    uint32(d.Get(MinLengthVar).(int)),
 			HasUppercase: d.Get(hasUppercaseVar).(bool),

--- a/zitadel/default_password_complexity_policy/resource_test.go
+++ b/zitadel/default_password_complexity_policy/resource_test.go
@@ -40,7 +40,7 @@ func TestAccDefaultPasswordComplexityPolicy(t *testing.T) {
 func TestAccDefaultPasswordComplexityPolicyCreateZeroValues(t *testing.T) {
 	frame := test_utils.NewInstanceTestFrame(t, "zitadel_default_password_complexity_policy")
 
-	zeroValuesConfig := fmt.Sprintf(`
+	resourceConfig := fmt.Sprintf(`
 %s
 resource "zitadel_default_password_complexity_policy" "default" {
   min_length    = 0
@@ -62,11 +62,11 @@ resource "zitadel_default_password_complexity_policy" "default" {
 						HasLowercase: true,
 						HasNumber:    true,
 						HasSymbol:    true,
-					}); helper.IgnorePreconditionError(err) != nil {
+					}); err != nil && helper.IgnorePreconditionError(err) != nil {
 						t.Fatalf("setting remote policy failed: %v", err)
 					}
 				},
-				Config:      zeroValuesConfig,
+				Config:      resourceConfig,
 				ExpectError: regexp.MustCompile(`Given minimum length is not allowed`),
 			},
 		},

--- a/zitadel/default_password_complexity_policy/resource_test.go
+++ b/zitadel/default_password_complexity_policy/resource_test.go
@@ -2,6 +2,7 @@ package default_password_complexity_policy_test
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"testing"
 
@@ -34,6 +35,42 @@ func TestAccDefaultPasswordComplexityPolicy(t *testing.T) {
 		test_utils.CheckNothing,
 		test_utils.ImportNothing,
 	)
+}
+
+func TestAccDefaultPasswordComplexityPolicyCreateZeroValues(t *testing.T) {
+	frame := test_utils.NewInstanceTestFrame(t, "zitadel_default_password_complexity_policy")
+
+	zeroValuesConfig := fmt.Sprintf(`
+%s
+resource "zitadel_default_password_complexity_policy" "default" {
+  min_length    = 0
+  has_uppercase = false
+  has_lowercase = false
+  has_number    = false
+  has_symbol    = false
+}
+`, frame.ProviderSnippet)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: frame.V6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					if _, err := frame.UpdatePasswordComplexityPolicy(frame, &admin.UpdatePasswordComplexityPolicyRequest{
+						MinLength:    8,
+						HasUppercase: true,
+						HasLowercase: true,
+						HasNumber:    true,
+						HasSymbol:    true,
+					}); helper.IgnorePreconditionError(err) != nil {
+						t.Fatalf("setting remote policy failed: %v", err)
+					}
+				},
+				Config:      zeroValuesConfig,
+				ExpectError: regexp.MustCompile(`Given minimum length is not allowed`),
+			},
+		},
+	})
 }
 
 func checkRemoteProperty(frame *test_utils.InstanceTestFrame) func(uint64) resource.TestCheckFunc {

--- a/zitadel/default_privacy_policy/funcs.go
+++ b/zitadel/default_privacy_policy/funcs.go
@@ -30,7 +30,7 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 	}
 
 	id := ""
-	if d.HasChanges(tosLinkVar, privacyLinkVar, HelpLinkVar, supportEmailVar, DocsLinkVar, CustomLinkVar, CustomLinkTextVar) {
+	if d.IsNewResource() || d.HasChanges(tosLinkVar, privacyLinkVar, HelpLinkVar, supportEmailVar, DocsLinkVar, CustomLinkVar, CustomLinkTextVar) {
 		resp, err := client.UpdatePrivacyPolicy(ctx, &admin.UpdatePrivacyPolicyRequest{
 			TosLink:        d.Get(tosLinkVar).(string),
 			PrivacyLink:    d.Get(privacyLinkVar).(string),

--- a/zitadel/default_privacy_policy/resource_test.go
+++ b/zitadel/default_privacy_policy/resource_test.go
@@ -32,6 +32,43 @@ func TestAccDefaultPrivacyPolicy(t *testing.T) {
 	)
 }
 
+func TestAccDefaultPrivacyPolicyCreateZeroValues(t *testing.T) {
+	frame := test_utils.NewInstanceTestFrame(t, "zitadel_default_privacy_policy")
+
+	zeroValuesConfig := fmt.Sprintf(`
+%s
+resource "zitadel_default_privacy_policy" "default" {
+  tos_link      = ""
+  privacy_link  = ""
+  help_link     = ""
+  support_email = ""
+}
+`, frame.ProviderSnippet)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: frame.V6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					if _, err := frame.UpdatePrivacyPolicy(frame, &admin.UpdatePrivacyPolicyRequest{
+						TosLink:      "https://example.com/tos",
+						PrivacyLink:  "https://example.com/privacy",
+						HelpLink:     "https://example.com/help",
+						SupportEmail: "support@example.com",
+					}); helper.IgnorePreconditionError(err) != nil {
+						t.Fatalf("setting remote policy failed: %v", err)
+					}
+				},
+				Config: zeroValuesConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(frame.TerraformName, "help_link", ""),
+					test_utils.CheckAMinute(checkRemoteProperty(frame)("")),
+				),
+			},
+		},
+	})
+}
+
 func checkRemoteProperty(frame *test_utils.InstanceTestFrame) func(string) resource.TestCheckFunc {
 	return func(expect string) resource.TestCheckFunc {
 		return func(state *terraform.State) error {

--- a/zitadel/default_privacy_policy/resource_test.go
+++ b/zitadel/default_privacy_policy/resource_test.go
@@ -35,7 +35,7 @@ func TestAccDefaultPrivacyPolicy(t *testing.T) {
 func TestAccDefaultPrivacyPolicyCreateZeroValues(t *testing.T) {
 	frame := test_utils.NewInstanceTestFrame(t, "zitadel_default_privacy_policy")
 
-	zeroValuesConfig := fmt.Sprintf(`
+	resourceConfig := fmt.Sprintf(`
 %s
 resource "zitadel_default_privacy_policy" "default" {
   tos_link      = ""
@@ -55,11 +55,11 @@ resource "zitadel_default_privacy_policy" "default" {
 						PrivacyLink:  "https://example.com/privacy",
 						HelpLink:     "https://example.com/help",
 						SupportEmail: "support@example.com",
-					}); helper.IgnorePreconditionError(err) != nil {
+					}); err != nil && helper.IgnorePreconditionError(err) != nil {
 						t.Fatalf("setting remote policy failed: %v", err)
 					}
 				},
-				Config: zeroValuesConfig,
+				Config: resourceConfig,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(frame.TerraformName, "help_link", ""),
 					test_utils.CheckAMinute(checkRemoteProperty(frame)("")),

--- a/zitadel/default_security_settings/funcs.go
+++ b/zitadel/default_security_settings/funcs.go
@@ -29,7 +29,7 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 		return diag.FromErr(err)
 	}
 
-	if d.HasChanges(enableImpersonationVar, embeddedIframeEnabledVar, embeddedIframeAllowedOriginsVar) {
+	if d.IsNewResource() || d.HasChanges(enableImpersonationVar, embeddedIframeEnabledVar, embeddedIframeAllowedOriginsVar) {
 		req := &settingsv2.SetSecuritySettingsRequest{
 			EnableImpersonation: d.Get(enableImpersonationVar).(bool),
 			EmbeddedIframe: &settingsv2.EmbeddedIframeSettings{

--- a/zitadel/default_security_settings/resource_test.go
+++ b/zitadel/default_security_settings/resource_test.go
@@ -46,6 +46,41 @@ resource "zitadel_default_security_settings" "default" {
 	)
 }
 
+func TestAccDefaultSecuritySettingsCreateZeroValues(t *testing.T) {
+	frame := test_utils.NewInstanceTestFrame(t, "zitadel_default_security_settings")
+
+	zeroValuesConfig := fmt.Sprintf(`
+%s
+resource "zitadel_default_security_settings" "default" {
+  enable_impersonation = false
+}
+`, frame.ProviderSnippet)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: frame.V6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					client, err := helper.GetSecuritySettingsClient(context.Background(), frame.ClientInfo)
+					if err != nil {
+						t.Fatalf("failed to get client: %v", err)
+					}
+					if _, err := client.SetSecuritySettings(context.Background(), &settingsv2.SetSecuritySettingsRequest{
+						EnableImpersonation: true,
+					}); helper.IgnorePreconditionError(err) != nil {
+						t.Fatalf("setting remote security settings failed: %v", err)
+					}
+				},
+				Config: zeroValuesConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(frame.TerraformName, "enable_impersonation", "false"),
+					test_utils.CheckAMinute(checkRemoteProperty(frame)(false)),
+				),
+			},
+		},
+	})
+}
+
 func checkRemoteProperty(frame *test_utils.InstanceTestFrame) func(bool) resource.TestCheckFunc {
 	return func(expect bool) resource.TestCheckFunc {
 		return func(state *terraform.State) error {

--- a/zitadel/default_security_settings/resource_test.go
+++ b/zitadel/default_security_settings/resource_test.go
@@ -49,7 +49,7 @@ resource "zitadel_default_security_settings" "default" {
 func TestAccDefaultSecuritySettingsCreateZeroValues(t *testing.T) {
 	frame := test_utils.NewInstanceTestFrame(t, "zitadel_default_security_settings")
 
-	zeroValuesConfig := fmt.Sprintf(`
+	resourceConfig := fmt.Sprintf(`
 %s
 resource "zitadel_default_security_settings" "default" {
   enable_impersonation = false
@@ -67,11 +67,11 @@ resource "zitadel_default_security_settings" "default" {
 					}
 					if _, err := client.SetSecuritySettings(context.Background(), &settingsv2.SetSecuritySettingsRequest{
 						EnableImpersonation: true,
-					}); helper.IgnorePreconditionError(err) != nil {
+					}); err != nil && helper.IgnorePreconditionError(err) != nil {
 						t.Fatalf("setting remote security settings failed: %v", err)
 					}
 				},
-				Config: zeroValuesConfig,
+				Config: resourceConfig,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(frame.TerraformName, "enable_impersonation", "false"),
 					test_utils.CheckAMinute(checkRemoteProperty(frame)(false)),


### PR DESCRIPTION
This pull request fixes the instance-level `zitadel_default_*` policy resources silently skipping their update call on a fresh create. These resources wire `CreateContext` to the same `update` function as `UpdateContext`, because ZITADEL's default policies always exist and only expose Update and Get, and inside that function the API call is gated on `d.HasChange`. On a create there is no prior state, so `HasChange` compares the config against the type's zero value, and any field whose config equals `[]`, `false`, `0` or `""` reports no change. The `id == ""` fallback then fetches the policy just to obtain an ID, so the apply reports success and state records the config while the server keeps its previous values, and the next plan shows a diff the user believed was already applied. `zitadel_default_login_policy` gates `second_factors`, `multi_factors` and `idps` individually, so `second_factors = []` is skipped even when other fields change, which is the report in the issue; the other default policies use one combined gate over all fields and only skip the call when the whole config is zero values, such as `max_password_attempts = 0` or `password_change = false`. Every gate is now guarded with `d.IsNewResource() ||`, so the API is always called on create and update behaviour is unchanged. This is applied to all nine resources that route create through `update`: `default_domain_policy`, `default_label_policy`, `default_lockout_policy`, `default_login_policy`, `default_notification_policy`, `default_password_age_policy`, `default_password_complexity_policy`, `default_privacy_policy` and `default_security_settings`. In `default_label_policy` the five asset upload gates are intentionally left alone, since forcing them on create would upload an empty path. `default_password_age_policy` additionally had an early return that made its precondition check unreachable, so an unchanged policy errored instead of being tolerated like in the other default policies; that is fixed so the create path behaves the same everywhere. Each affected resource gets a `CreateZeroValues` acceptance test in its existing suite that sets the server to a non-zero value in `PreConfig`, creates with a zero-value config and checks the server through the existing `checkRemoteProperty` helper; all of them fail on the previous code and pass with the fix. ZITADEL rejects `min_length = 0`, so the password complexity test asserts the server error instead, which the previous code silently swallowed.

There are no schema, state or ID changes, and update behaviour of resources already in state is unchanged. Two things change on the first apply, both of which are the intended fix rather than new behaviour: a `zitadel_default_password_complexity_policy` with `min_length = 0` now fails with the server's error instead of reporting success without sending anything, and a `zitadel_default_login_policy` that omits `second_factors`, `multi_factors` or `idps` now removes the corresponding server-side entries on the first apply, exactly as the previous code already did on the second apply once the refresh had populated state, since these attributes are optional and not computed.

Closes #419

### Definition of Ready

- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] All non-functional requirements are met
- [x] The generic lifecycle acceptance test passes for affected resources.
- [x] Examples are up-to-date and meaningful. The provider version is incremented.
- [x] Docs are generated.
- [x] Code is generated where possible.
