### PR TITLE
fix: stop perpetual diff on login_texts when ZITADEL returns empty screen-text blocks

### DIFF
--- a/gen/github.com/zitadel/zitadel/pkg/grpc/text/text_terraform.go
+++ b/gen/github.com/zitadel/zitadel/pkg/grpc/text/text_terraform.go
@@ -228,6 +228,22 @@ func copyToTerraform(ctx context.Context, obj proto.Message, tf *types.Object, a
 		return diags
 	}
 
+	// ZITADEL returns every nested text message, even ones that were never
+	// customised, with all fields set to empty strings. Keep such a block null
+	// unless the prior state holds it, so a config that omits the block does not
+	// diff against state while a config that sets it to {} is preserved.
+	prior := tf.Attributes()
+	for name, value := range values {
+		obj, ok := value.(types.Object)
+		if !ok || obj.IsNull() || !allNull(obj.Attributes()) {
+			continue
+		}
+		if priorObj, ok := prior[name].(types.Object); ok && !priorObj.IsNull() && !priorObj.IsUnknown() {
+			continue
+		}
+		values[name] = types.ObjectNull(obj.AttributeTypes(ctx))
+	}
+
 	newObj, objDiags := types.ObjectValue(targetAttrTypes, values)
 	diags.Append(objDiags...)
 	if diags.HasError() {
@@ -319,4 +335,13 @@ func mapToAttrValues(ctx context.Context, data map[string]any, attrTypes map[str
 	}
 
 	return values, diags
+}
+
+func allNull(values map[string]attr.Value) bool {
+	for _, v := range values {
+		if !v.IsNull() {
+			return false
+		}
+	}
+	return true
 }

--- a/gen/github.com/zitadel/zitadel/pkg/grpc/text/text_terraform_test.go
+++ b/gen/github.com/zitadel/zitadel/pkg/grpc/text/text_terraform_test.go
@@ -1,0 +1,99 @@
+package text
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	textpb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/text"
+)
+
+// TestCopyLoginCustomTextToTerraform verifies how nested screen-text blocks are
+// written into state. ZITADEL returns every screen-text message on
+// GetCustomLoginTexts, even for screens that were never customised, as a
+// present message with all fields empty. Such a block must stay null when the
+// prior state does not hold it, otherwise a config that omits it diffs against
+// state on every plan. A block the prior state does hold, such as one
+// configured as {}, must be kept so the opposite diff does not appear either.
+func TestCopyLoginCustomTextToTerraform(t *testing.T) {
+	const attribute = "password_change_done_text"
+	attrTypes := loginAttrTypes[attribute].(types.ObjectType).AttrTypes
+	tests := []struct {
+		name      string
+		prior     attr.Value
+		obj       *textpb.LoginCustomText
+		wantNull  bool
+		wantTitle string
+	}{
+		{
+			name:     "absent message stays null",
+			prior:    types.ObjectNull(attrTypes),
+			obj:      &textpb.LoginCustomText{},
+			wantNull: true,
+		},
+		{
+			name:  "empty message stays null",
+			prior: types.ObjectNull(attrTypes),
+			obj: &textpb.LoginCustomText{
+				PasswordChangeDoneText: &textpb.PasswordChangeDoneScreenText{},
+			},
+			wantNull: true,
+		},
+		{
+			name: "empty message keeps explicitly empty block",
+			prior: types.ObjectValueMust(attrTypes, map[string]attr.Value{
+				"title":            types.StringNull(),
+				"description":      types.StringNull(),
+				"next_button_text": types.StringNull(),
+			}),
+			obj: &textpb.LoginCustomText{
+				PasswordChangeDoneText: &textpb.PasswordChangeDoneScreenText{},
+			},
+			wantNull: false,
+		},
+		{
+			name:  "populated message is copied",
+			prior: types.ObjectNull(attrTypes),
+			obj: &textpb.LoginCustomText{
+				PasswordChangeDoneText: &textpb.PasswordChangeDoneScreenText{Title: "Password changed"},
+			},
+			wantTitle: "Password changed",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := loginState(t, attribute, tt.prior)
+			if diags := CopyLoginCustomTextToTerraform(context.Background(), tt.obj, &state); diags.HasError() {
+				t.Fatalf("unexpected diagnostics: %v", diags)
+			}
+			got := state.Attributes()[attribute].(types.Object)
+			if got.IsNull() != tt.wantNull {
+				t.Fatalf("%s null = %v, want %v", attribute, got.IsNull(), tt.wantNull)
+			}
+			if tt.wantNull {
+				return
+			}
+			if title := got.Attributes()["title"].(types.String); title.ValueString() != tt.wantTitle {
+				t.Errorf("%s.title = %q, want %q", attribute, title.ValueString(), tt.wantTitle)
+			}
+		})
+	}
+}
+
+// loginState returns a login texts object with every attribute null except the
+// given one, which is set to value.
+func loginState(t *testing.T, name string, value attr.Value) types.Object {
+	t.Helper()
+	values := make(map[string]attr.Value, len(loginAttrTypes))
+	for attrName, typ := range loginAttrTypes {
+		switch typ := typ.(type) {
+		case types.ObjectType:
+			values[attrName] = types.ObjectNull(typ.AttrTypes)
+		default:
+			values[attrName] = types.StringNull()
+		}
+	}
+	values[name] = value
+	return types.ObjectValueMust(loginAttrTypes, values)
+}

--- a/zitadel/default_login_texts/resource_test.go
+++ b/zitadel/default_login_texts/resource_test.go
@@ -34,6 +34,53 @@ func TestAccDefaultLoginTexts(t *testing.T) {
 	)
 }
 
+// TestAccDefaultLoginTextsPartialConfig verifies that a config which only sets
+// some of the screen-text blocks converges. ZITADEL returns all the other blocks
+// with empty fields, which must not show up as a diff, while a block that is
+// explicitly configured as {} must be kept.
+func TestAccDefaultLoginTextsPartialConfig(t *testing.T) {
+	frame := test_utils.NewInstanceTestFrame(t, "zitadel_default_login_texts")
+	exampleLanguage := "en"
+
+	resourceConfig := fmt.Sprintf(`
+%s
+resource "zitadel_default_login_texts" "default" {
+  language = "%s"
+
+  email_verification_done_text = {
+    title       = "partial"
+    description = "Your email has been verified."
+  }
+
+  login_text = {
+    title = "Welcome"
+  }
+
+  password_change_done_text = {}
+}
+`, frame.ProviderSnippet, exampleLanguage)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: frame.V6ProviderFactories(),
+		CheckDestroy:             test_utils.CheckAMinute(checkRemoteProperty(frame, exampleLanguage)("")),
+		Steps: []resource.TestStep{
+			{
+				Config: resourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(frame.TerraformName, "email_verification_done_text.title", "partial"),
+					resource.TestCheckResourceAttr(frame.TerraformName, "login_text.title", "Welcome"),
+					resource.TestCheckNoResourceAttr(frame.TerraformName, "logout_text.title"),
+					test_utils.CheckAMinute(checkRemoteProperty(frame, exampleLanguage)("partial")),
+				),
+			},
+			{
+				Config:   resourceConfig,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func checkRemoteProperty(frame *test_utils.InstanceTestFrame, lang string) func(string) resource.TestCheckFunc {
 	return func(expect string) resource.TestCheckFunc {
 		return func(state *terraform.State) error {

--- a/zitadel/login_texts/resource_test.go
+++ b/zitadel/login_texts/resource_test.go
@@ -34,6 +34,55 @@ func TestAccLoginTexts(t *testing.T) {
 	)
 }
 
+// TestAccLoginTextsPartialConfig verifies that a config which only sets some of
+// the screen-text blocks converges. ZITADEL returns all the other blocks with
+// empty fields, which must not show up as a diff, while a block that is
+// explicitly configured as {} must be kept.
+func TestAccLoginTextsPartialConfig(t *testing.T) {
+	frame := test_utils.NewOrgTestFrame(t, "zitadel_login_texts")
+	exampleLanguage := "en"
+
+	resourceConfig := fmt.Sprintf(`
+%s
+%s
+resource "zitadel_login_texts" "default" {
+  org_id   = data.zitadel_org.default.id
+  language = "%s"
+
+  email_verification_done_text = {
+    title       = "partial"
+    description = "Your email has been verified."
+  }
+
+  login_text = {
+    title = "Welcome"
+  }
+
+  password_change_done_text = {}
+}
+`, frame.ProviderSnippet, frame.AsOrgDefaultDependency, exampleLanguage)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: frame.V6ProviderFactories(),
+		CheckDestroy:             test_utils.CheckAMinute(checkRemoteProperty(frame, exampleLanguage)("")),
+		Steps: []resource.TestStep{
+			{
+				Config: resourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(frame.TerraformName, "email_verification_done_text.title", "partial"),
+					resource.TestCheckResourceAttr(frame.TerraformName, "login_text.title", "Welcome"),
+					resource.TestCheckNoResourceAttr(frame.TerraformName, "logout_text.title"),
+					test_utils.CheckAMinute(checkRemoteProperty(frame, exampleLanguage)("partial")),
+				),
+			},
+			{
+				Config:   resourceConfig,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func checkRemoteProperty(frame *test_utils.OrgTestFrame, lang string) func(string) resource.TestCheckFunc {
 	return func(expect string) resource.TestCheckFunc {
 		return func(state *terraform.State) error {


### PR DESCRIPTION
`terraform plan` on `zitadel_login_texts` (and `zitadel_default_login_texts`) showed an in-place update on every run even right after a clean `apply`, listing every screen-text block that was not in the config as `{} -> null` (32 of them for a config that sets two blocks). Applying the update "succeeded" and the next plan showed the same diff again, so the resource could never converge. Root cause: ZITADEL always returns every nested screen-text message on `GetCustomLoginTexts`, even ones that were never customised, as a present message with all fields set to empty strings. The shared read converter in `gen/.../text_terraform.go` turned each of those into a known object whose attributes were all null instead of a null object, so Terraform diffed it against the absent block in the config. The flat `*_message_text` resources listed in the issue are not affected: they have no nested blocks and planned clean throughout the reproduction.

Read now keeps a nested block null when the server returned it with every field empty and the prior state does not hold the block. A block the prior state does hold, such as one configured as `{}`, is kept as is, so that config does not diff in the other direction. Added a table-driven unit test for the absent, empty, explicitly empty and populated cases (the empty case failed before the fix), and a `PartialConfig` acceptance test on both `zitadel_login_texts` and `zitadel_default_login_texts` that applies a config setting two blocks plus one explicit `{}` block and asserts an empty plan afterwards. Both acceptance tests pass against the acceptance stack on ZITADEL v4.17.0 and fail on `main` with the `{} -> null` diff. Also verified end to end with a dev-override provider: create then plan is clean, editing a configured value converges, removing a configured block converges, and an explicit `{}` block converges.
Closes #429

### Definition of Ready

- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] All non-functional requirements are met
- [x] The generic lifecycle acceptance test passes for affected resources.
- [x] Examples are up-to-date and meaningful. The provider version is incremented.
- [x] Docs are generated.
- [x] Code is generated where possible.
