### PR TITLE
fix: fail the apply when ZITADEL rejects instance restrictions or key activation

### DIFF
--- a/zitadel/action_target_public_key/funcs.go
+++ b/zitadel/action_target_public_key/funcs.go
@@ -52,7 +52,8 @@ func delete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 	targetID := d.Get(targetIDVar).(string)
 	keyID := d.Id()
 
-	// ZITADEL requires deactivating a key before it can be removed.
+	// ZITADEL requires deactivating a key before it can be removed. A missing key
+	// or target fails this with FailedPrecondition, which means the delete is done.
 	_, err = client.DeactivatePublicKey(ctx, &actionv2.DeactivatePublicKeyRequest{
 		TargetId: targetID,
 		KeyId:    keyID,
@@ -111,8 +112,8 @@ func create(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 	// An unset active leaves the key in ZITADEL's default (inactive) state to preserve
 	// pre-existing behavior for configs that don't set the field.
 	// d.SetId above ensures the key is tracked in state even if activation fails;
-	// the next apply will retry via the Update path rather than orphan or duplicate it.
-	// FailedPrecondition (key already active) is treated as idempotent success.
+	// it is then replaced on the next apply rather than orphaned or duplicated.
+	// Activating an already active key succeeds, so every error is returned.
 	//
 	// Inspect the raw config (not d.Get/d.GetOkExists, which blend state and
 	// config) so this stays correct on Optional+Computed attributes where state
@@ -134,7 +135,7 @@ func create(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 		if _, err := client.ActivatePublicKey(ctx, &actionv2.ActivatePublicKeyRequest{
 			TargetId: req.TargetId,
 			KeyId:    resp.GetKeyId(),
-		}); err != nil && helper.IgnorePreconditionError(err) != nil {
+		}); err != nil {
 			return diag.Errorf("failed to activate public key: %v", err)
 		}
 		if err := d.Set(activeVar, true); err != nil {
@@ -180,18 +181,20 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 	targetID := d.Get(targetIDVar).(string)
 	keyID := d.Id()
 
+	// Both calls succeed when the key already is in the requested state, so every
+	// error is returned.
 	if wantActive {
 		if _, err := client.ActivatePublicKey(ctx, &actionv2.ActivatePublicKeyRequest{
 			TargetId: targetID,
 			KeyId:    keyID,
-		}); err != nil && helper.IgnorePreconditionError(err) != nil {
+		}); err != nil {
 			return diag.Errorf("failed to activate public key: %v", err)
 		}
 	} else {
 		if _, err := client.DeactivatePublicKey(ctx, &actionv2.DeactivatePublicKeyRequest{
 			TargetId: targetID,
 			KeyId:    keyID,
-		}); err != nil && helper.IgnorePreconditionError(err) != nil {
+		}); err != nil {
 			return diag.Errorf("failed to deactivate public key: %v", err)
 		}
 	}

--- a/zitadel/action_target_public_key/resource_test.go
+++ b/zitadel/action_target_public_key/resource_test.go
@@ -3,7 +3,9 @@ package action_target_public_key_test
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -205,7 +207,7 @@ EOT
 //     deactivated when terraform applies a config that omits the `active` field.
 //   - Removing `active` from config must NOT change the remote activation state.
 //   - Adding `active = true` to config when the server is already active must be a
-//     plan/apply no-op (FailedPrecondition idempotency).
+//     plan/apply no-op.
 func TestAccActionTargetPublicKeyNoAccidentalToggle(t *testing.T) {
 	frame := test_utils.NewInstanceTestFrame(t, "zitadel_action_target_public_key")
 
@@ -263,7 +265,7 @@ EOT
 		if _, err := client.ActivatePublicKey(context.Background(), &actionv2.ActivatePublicKeyRequest{
 			TargetId: captured.targetID,
 			KeyId:    captured.keyID,
-		}); err != nil && helper.IgnorePreconditionError(err) != nil {
+		}); err != nil {
 			t.Fatalf("external activation failed: %v", err)
 		}
 	}
@@ -303,7 +305,7 @@ EOT
 				PlanOnly: true,
 			},
 			// Adding `active = true` to config when the server already matches must be a
-			// no-op (idempotent activate; FailedPrecondition is swallowed).
+			// no-op.
 			{
 				Config: configActiveTrue,
 				Check: resource.ComposeTestCheckFunc(
@@ -318,6 +320,87 @@ EOT
 				Check: resource.ComposeTestCheckFunc(
 					test_utils.CheckAMinute(checkRemoteProperty(frame, true)),
 				),
+			},
+		},
+	})
+}
+
+// TestAccActionTargetPublicKeyActivateExpired verifies that activating a key
+// ZITADEL refuses because it is expired fails the apply with the server's error
+// and leaves the key inactive on the server.
+func TestAccActionTargetPublicKeyActivateExpired(t *testing.T) {
+	frame := test_utils.NewInstanceTestFrame(t, "zitadel_action_target_public_key")
+
+	// Terraform takes the expiry right before it adds the key, so a slow setup
+	// cannot push the creation past it, and ignores the recomputed timestamp
+	// afterwards so it does not force a replacement.
+	config := func(active bool) string {
+		activeAttribute := ""
+		if active {
+			activeAttribute = "  active          = true\n"
+		}
+		return fmt.Sprintf(`
+%s
+resource "zitadel_action_target" "default" {
+  name               = "%s"
+  endpoint           = "https://example.com/test"
+  target_type        = "REST_ASYNC"
+  timeout            = "10s"
+  interrupt_on_error = false
+  payload_type       = "PAYLOAD_TYPE_JWE"
+}
+
+resource "zitadel_action_target_public_key" "default" {
+  target_id       = zitadel_action_target.default.id
+  expiration_date = timeadd(timestamp(), "20s")
+%s  public_key      = <<-EOT
+%s
+EOT
+
+  lifecycle {
+    ignore_changes = [expiration_date]
+  }
+}
+`, frame.ProviderSnippet, frame.UniqueResourcesID, activeAttribute, testPublicKey)
+	}
+
+	// The expiry the server stored, taken from state after the create.
+	var expiry time.Time
+	captureExpiry := func(state *terraform.State) error {
+		rs, ok := state.RootModule().Resources[frame.TerraformName]
+		if !ok {
+			return fmt.Errorf("not found: %s", frame.TerraformName)
+		}
+		parsed, err := time.Parse(time.RFC3339, rs.Primary.Attributes["expiration_date"])
+		if err != nil {
+			return fmt.Errorf("parsing expiration_date failed: %w", err)
+		}
+		expiry = parsed
+		return nil
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: frame.V6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: config(false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(frame.TerraformName, "active", "false"),
+					captureExpiry,
+					test_utils.CheckAMinute(checkRemoteProperty(frame, false)),
+				),
+			},
+			{
+				PreConfig: func() {
+					time.Sleep(time.Until(expiry) + 5*time.Second)
+				},
+				Config:      config(true),
+				ExpectError: regexp.MustCompile(`Target public key is expired`),
+			},
+			{
+				// The rejected activation must not have changed the server.
+				Config: config(false),
+				Check:  test_utils.CheckAMinute(checkRemoteProperty(frame, false)),
 			},
 		},
 	})

--- a/zitadel/helper/client.go
+++ b/zitadel/helper/client.go
@@ -533,6 +533,10 @@ func IgnoreIfNotFoundError(err error) error {
 	return err
 }
 
+// IgnorePreconditionError treats a FailedPrecondition status as success. ZITADEL
+// returns that code when an update changed nothing, which the zitadel_default_*
+// policy resources rely on, but also to reject a request, and the client cannot
+// tell the two apart. Only use it on calls that never reject with that code.
 func IgnorePreconditionError(err error) error {
 	if code := status.Code(err); code == codes.FailedPrecondition {
 		return nil

--- a/zitadel/instance_restrictions/funcs.go
+++ b/zitadel/instance_restrictions/funcs.go
@@ -51,8 +51,10 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 			}
 		}
 
+		// Unlike the default policy updates, SetRestrictions uses FailedPrecondition
+		// to reject a request, not to report that nothing changed.
 		_, err := client.SetRestrictions(ctx, req)
-		if helper.IgnorePreconditionError(err) != nil {
+		if err != nil {
 			return diag.Errorf("failed to update instance restrictions: %v", err)
 		}
 	}

--- a/zitadel/instance_restrictions/resource_test.go
+++ b/zitadel/instance_restrictions/resource_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"slices"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -44,6 +45,132 @@ resource "zitadel_instance_restrictions" "default" {
 		test_utils.CheckNothing,
 		test_utils.ImportNothing,
 	)
+}
+
+// TestAccInstanceRestrictionsRejectedByServer covers the report in issue 444:
+// ZITADEL refuses allowed_languages that do not contain the instance default
+// language with FailedPrecondition. The apply has to fail with that error and
+// nothing may be persisted on the server.
+func TestAccInstanceRestrictionsRejectedByServer(t *testing.T) {
+	frame := test_utils.NewInstanceTestFrame(t, "zitadel_instance_restrictions")
+	rejectedConfig := frame.ProviderSnippet + `
+resource "zitadel_instance_restrictions" "default" {
+  allowed_languages                = ["de"]
+  disallow_public_org_registration = true
+}
+`
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: frame.V6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config:      rejectedConfig,
+				ExpectError: regexp.MustCompile(`The default language must be allowed`),
+			},
+			{
+				Config: frame.ProviderSnippet,
+				Check:  test_utils.CheckAMinute(checkRemoteAllowedLanguages(frame, nil)),
+			},
+		},
+	})
+}
+
+// TestAccInstanceRestrictionsUpdateRejectedByServer covers the same rejection
+// on the update path of a resource that is already in state.
+func TestAccInstanceRestrictionsUpdateRejectedByServer(t *testing.T) {
+	frame := test_utils.NewInstanceTestFrame(t, "zitadel_instance_restrictions")
+	config := func(disallow bool) string {
+		return fmt.Sprintf(`
+%s
+resource "zitadel_instance_restrictions" "default" {
+  disallow_public_org_registration = %t
+}
+`, frame.ProviderSnippet, disallow)
+	}
+	rejectedConfig := frame.ProviderSnippet + `
+resource "zitadel_instance_restrictions" "default" {
+  allowed_languages                = ["de"]
+  disallow_public_org_registration = true
+}
+`
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: frame.V6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: config(true),
+				Check:  test_utils.CheckAMinute(checkRemoteProperty(frame)(true)),
+			},
+			{
+				Config:      rejectedConfig,
+				ExpectError: regexp.MustCompile(`The default language must be allowed`),
+			},
+			{
+				Config: config(false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					test_utils.CheckAMinute(checkRemoteProperty(frame)(false)),
+					test_utils.CheckAMinute(checkRemoteAllowedLanguages(frame, nil)),
+				),
+			},
+		},
+	})
+}
+
+// TestAccInstanceRestrictionsCreateUnchanged creates the resource with a config
+// that already matches the server. SetRestrictions answers that with success,
+// so the create must not need to tolerate any error.
+func TestAccInstanceRestrictionsCreateUnchanged(t *testing.T) {
+	frame := test_utils.NewInstanceTestFrame(t, "zitadel_instance_restrictions")
+	config := func(disallow bool) string {
+		return fmt.Sprintf(`
+%s
+resource "zitadel_instance_restrictions" "default" {
+  disallow_public_org_registration = %t
+}
+`, frame.ProviderSnippet, disallow)
+	}
+	setRemoteProperty := func(value bool) func() {
+		return func() {
+			client, err := helper.GetAdminClient(context.Background(), frame.ClientInfo)
+			if err != nil {
+				t.Fatalf("failed to get client: %v", err)
+			}
+			if _, err := client.SetRestrictions(context.Background(), &admin.SetRestrictionsRequest{
+				DisallowPublicOrgRegistration: &value,
+			}); err != nil {
+				t.Fatalf("setting instance restrictions failed: %v", err)
+			}
+		}
+	}
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: frame.V6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				PreConfig: setRemoteProperty(true),
+				Config:    config(true),
+				Check:     test_utils.CheckAMinute(checkRemoteProperty(frame)(true)),
+			},
+			{
+				Config: config(false),
+				Check:  test_utils.CheckAMinute(checkRemoteProperty(frame)(false)),
+			},
+		},
+	})
+}
+
+func checkRemoteAllowedLanguages(frame *test_utils.InstanceTestFrame, expect []string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		client, err := helper.GetAdminClient(context.Background(), frame.ClientInfo)
+		if err != nil {
+			return fmt.Errorf("failed to get client: %w", err)
+		}
+		resp, err := client.GetRestrictions(context.Background(), &admin.GetRestrictionsRequest{})
+		if err != nil {
+			return fmt.Errorf("getting instance restrictions failed: %w", err)
+		}
+		if actual := resp.GetAllowedLanguages(); !slices.Equal(actual, expect) {
+			return fmt.Errorf("expected allowed languages %v, but got %v", expect, actual)
+		}
+		return nil
+	}
 }
 
 func checkRemoteProperty(frame *test_utils.InstanceTestFrame) func(bool) resource.TestCheckFunc {


### PR DESCRIPTION
`zitadel_instance_restrictions` reported `Apply complete` and wrote the resource to state when ZITADEL rejected `SetRestrictions`, so a config whose `allowed_languages` did not contain the instance default language showed the same diff on every following plan while nothing was persisted. Root cause: the resource passed the call's error through `helper.IgnorePreconditionError`, which maps every gRPC `FailedPrecondition` to success. ZITADEL uses that code for the `NotChanged` answer of the default policy updates, which is what the helper exists for, but also to reject a request, and the client cannot tell the two apart because the message is localized by the server and the error ID is unique to the throw site. `SetRestrictions` never returns `NotChanged`; it answers an unchanged request with success and uses `FailedPrecondition` only to reject, so the tolerance was a plain bug. `zitadel_action_target_public_key` had the same on `ActivatePublicKey` and `DeactivatePublicKey`, whose comment claimed the tolerance covered an already active key while the server answers that with success and uses the code for an expired or missing key, so activating an expired key recorded `active = true` in state while the key stayed inactive. Both resources now return those errors. The delete of the public key resource keeps tolerating the deactivation error, since the only precondition there is a missing key or target, which means the delete is done. The eleven `zitadel_default_*` policy resources and `zitadel_instance_secret_generator` were checked against the ZITADEL command layer and are left unchanged: the update RPC behind each of them uses `FailedPrecondition` only for `NotChanged` or `NoChangesFound`, which their create path relies on. The helper gets a doc comment stating that rule. There are no schema, state or ID changes; the only behaviour change is that an apply ZITADEL rejected now fails with the server's error. Acceptance tests cover the rejected create and update of the restrictions, a create whose config already matches the server, and activating an expired key; the rejection tests fail on `main` with the perpetual `plan was not empty` diff from the issue and pass with the fix, alongside the full suite against ZITADEL v4.17.0. Verified end to end with a dev-override build: `main` prints `Apply complete! Resources: 1 added` and re-plans the change, this branch fails with `code = FailedPrecondition desc = The default language must be allowed (COMMAND-L0m2u)`.

Closes #444

### Definition of Ready

- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] All non-functional requirements are met
- [x] The generic lifecycle acceptance test passes for affected resources.
- [x] Examples are up-to-date and meaningful. The provider version is incremented.
- [x] Docs are generated.
- [x] Code is generated where possible.
