### PR TITLE
fix: don't treat transient project role read errors as an out-of-band deletion

### DIFF
--- a/zitadel/project_role/funcs.go
+++ b/zitadel/project_role/funcs.go
@@ -118,7 +118,15 @@ func read(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagn
 			}},
 		},
 	})
-	if err != nil || resp.Result == nil || len(resp.Result) == 0 {
+	if err != nil && helper.IgnoreIfNotFoundError(err) == nil {
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return diag.Errorf("failed to get project role: %v", err)
+	}
+
+	if len(resp.Result) == 0 {
 		d.SetId("")
 		return nil
 	}


### PR DESCRIPTION
`zitadel_project_role`'s `read()` treated every error from `ListProjectRoles` as proof the role had been deleted out of band, so a transient failure during a plan's refresh pass silently pruned the resource from state and swallowed the error instead of surfacing it. The condition was `if err != nil || resp.Result == nil || len(resp.Result) == 0`, which collapses three distinct outcomes into one: a genuine deletion, an empty result set, and an arbitrary RPC failure such as a DB outage, a timeout, an auth hiccup or an eventstore write conflict. The user then sees a plan that wants to recreate a role that still exists, and on apply gets a duplicate-key error from the server, with the original error never printed. This is the same defect class as #277, which was fixed for `zitadel_org` in #299 by adding the missing `helper.IgnoreIfNotFoundError` check; `project_role` was passed over by that sweep precisely because it already caught errors, just by discarding all of them, so it ended up on the wrong side of the same bug. Every other read in the provider was audited for this: of the 95 functions that call `d.SetId("")`, 86 are resource reads, 6 are datasource-style `get()` functions and 3 are deletes clearing the ID after a successful call, and `project_role` was the only one where an `err != nil` path reached `d.SetId("")` without first confirming a not-found, so this is the last remaining instance rather than one of many.

Read now splits the three cases: a confirmed `codes.NotFound` via `helper.IgnoreIfNotFoundError` still clears the ID, any other error returns `diag.Errorf` so Terraform reports a failed read, and an empty result set still clears the ID. Worth recording for reviewers is that the not-found branch is defensive rather than load-bearing, because `ListProjectRoles` never returns `NotFound`. That was verified against a live ZITADEL v4.17.0 instance with a probe over five cases: an existing project with an existing role returns one result, an existing project with a missing role returns `OK` with zero results, a nonexistent project ID returns `OK` with zero results, a malformed project ID returns `OK` with zero results, and a project deleted out of band returns `OK` with zero results. Out-of-band deletion is therefore signalled by the empty result set, which the third branch still handles, so drift detection is unchanged. It also makes the fix stronger than it first appears: since the server never signals deletion through an error on this call, every error reaching this code is genuine and failing the read is unconditionally correct. The not-found branch is kept anyway so the resource reads like `project`, `org`, `user_grant`, `organization_domain` and the rest.

Two deliberate deviations from the original patch in #430, both to match the surrounding code rather than change behaviour: the redundant `resp.Result == nil` check is dropped, since `len(nil)` is `0` in Go and every sibling resource writes the bare `len(...) == 0`; and the existing `resp.Result` field accesses are left alone rather than switched to `resp.GetResult()`, since no other resource uses the getter in its length check and the churn would make this resource the odd one out again. There are no schema, state or ID changes, and the only behaviour change is that a read ZITADEL failed now fails the plan with the server's error instead of reporting the resource as deleted.

No new acceptance test accompanies this. The regression needs `ListProjectRoles` to return a transient non-`NotFound` error, and the acceptance harness runs against a real ZITADEL instance with no way to inject one, so a test would only restate the happy path the suite already covers. The existing `TestAccProjectRole`, `TestAccProjectRoleDisplayNameUpdate` and the four `TestAccProjectRolesDatasource_*` tests pass against the acceptance stack on ZITADEL v4.17.0, alongside the `project` package, and `go build ./...`, `go vet` and `gofmt` are clean. The full suite was also run: 100 packages pass and 24 fail, all of them pre-existing and unrelated, caused by the local Terraform being v1.10.5 while write-only attributes need 1.11 or newer; that was confirmed by re-running `human_user`, `idp_google` and `organization` with this change reverted and reproducing the identical failures.

The commit is the original from #430 by @timbgn, preserved with authorship intact, with the two adjustments above amended in. Supersedes #430. Related to #292, whose eventstore write conflicts on concurrent role creation are exactly the kind of transient error the old code would have misread as a deletion, though the underlying server-side conflict there is a separate issue and is not fixed here.

### Definition of Ready

- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] All non-functional requirements are met
- [ ] The generic lifecycle acceptance test passes for affected resources. — existing project_role suite passes; no new test, see above
- [x] Examples are up-to-date and meaningful. The provider version is incremented.
- [x] Docs are generated.
- [x] Code is generated where possible.
